### PR TITLE
feat(telemetry): Add per-iteration telemetry capture

### DIFF
--- a/ralph.yml
+++ b/ralph.yml
@@ -22,6 +22,10 @@ enable_metrics: true          # Enable metrics collection
 verbose: false                # Enable verbose output
 dry_run: false                # Test mode without execution
 
+# Telemetry settings
+iteration_telemetry: true     # Enable per-iteration telemetry capture
+output_preview_length: 500    # Max chars for output preview in telemetry (truncated for privacy)
+
 # Safety settings
 max_prompt_size: 10485760     # Max prompt file size (10MB)
 allow_unsafe_paths: false     # Allow potentially unsafe prompt paths

--- a/src/ralph_orchestrator/metrics.py
+++ b/src/ralph_orchestrator/metrics.py
@@ -170,6 +170,7 @@ class IterationStats:
     current_iteration: int = 0
     iterations: List[Dict[str, Any]] = field(default_factory=list)
     max_iterations_stored: int = 1000  # Memory limit for stored iterations
+    max_preview_length: int = 500  # Max chars for output preview truncation
 
     def __post_init__(self) -> None:
         """Initialize start time if not set."""
@@ -237,10 +238,9 @@ class IterationStats:
         else:
             self.failures += 1
 
-        # Truncate output preview to 500 chars for privacy
-        max_preview_length = 500
-        if output_preview and len(output_preview) > max_preview_length:
-            output_preview = output_preview[:max_preview_length] + "..."
+        # Truncate output preview for privacy (configurable length)
+        if output_preview and len(output_preview) > self.max_preview_length:
+            output_preview = output_preview[:self.max_preview_length] + "..."
 
         # Store detailed iteration information
         iteration_data = {

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -536,3 +536,44 @@ class TestIterationStatsTelemetry:
         assert iter_data["tokens_used"] == 0
         assert iter_data["cost"] == 0.0
         assert iter_data["tools_used"] == []
+
+    def test_custom_max_preview_length(self):
+        """Test configurable max_preview_length."""
+        stats = IterationStats(max_preview_length=100)
+        long_output = "x" * 150  # Exceeds custom limit
+
+        stats.record_iteration(
+            iteration=1,
+            duration=1.0,
+            success=True,
+            error="",
+            output_preview=long_output,
+        )
+
+        preview = stats.iterations[0]["output_preview"]
+        # Should be 100 chars + "..." = 103 chars total
+        assert len(preview) == 103
+        assert preview.endswith("...")
+        assert preview[:100] == "x" * 100
+
+    def test_custom_max_preview_length_small(self):
+        """Test very small max_preview_length."""
+        stats = IterationStats(max_preview_length=10)
+        output = "Hello World Test"  # 16 chars
+
+        stats.record_iteration(
+            iteration=1,
+            duration=1.0,
+            success=True,
+            error="",
+            output_preview=output,
+        )
+
+        preview = stats.iterations[0]["output_preview"]
+        assert preview == "Hello Worl..."
+        assert len(preview) == 13  # 10 + "..."
+
+    def test_default_max_preview_length(self):
+        """Test default max_preview_length is 500."""
+        stats = IterationStats()
+        assert stats.max_preview_length == 500

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -375,6 +375,57 @@ class TestIterationTelemetry(unittest.TestCase):
         finally:
             Path(prompt_file).unlink()
 
+    @patch('ralph_orchestrator.orchestrator.ClaudeAdapter')
+    @patch('ralph_orchestrator.orchestrator.QChatAdapter')
+    @patch('ralph_orchestrator.orchestrator.GeminiAdapter')
+    def test_iteration_telemetry_disabled(self, mock_gemini, mock_qchat, mock_claude):
+        """Test orchestrator with iteration_telemetry=False."""
+        mock_claude_instance = MagicMock()
+        mock_claude_instance.available = True
+        mock_claude.return_value = mock_claude_instance
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write("# Test Task")
+            prompt_file = f.name
+
+        try:
+            orchestrator = RalphOrchestrator(
+                prompt_file_or_config=prompt_file,
+                primary_tool="claude",
+                iteration_telemetry=False,
+            )
+
+            # iteration_stats should be None when telemetry disabled
+            self.assertIsNone(orchestrator.iteration_stats)
+        finally:
+            Path(prompt_file).unlink()
+
+    @patch('ralph_orchestrator.orchestrator.ClaudeAdapter')
+    @patch('ralph_orchestrator.orchestrator.QChatAdapter')
+    @patch('ralph_orchestrator.orchestrator.GeminiAdapter')
+    def test_custom_output_preview_length(self, mock_gemini, mock_qchat, mock_claude):
+        """Test orchestrator with custom output_preview_length."""
+        mock_claude_instance = MagicMock()
+        mock_claude_instance.available = True
+        mock_claude.return_value = mock_claude_instance
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+            f.write("# Test Task")
+            prompt_file = f.name
+
+        try:
+            orchestrator = RalphOrchestrator(
+                prompt_file_or_config=prompt_file,
+                primary_tool="claude",
+                output_preview_length=200,
+            )
+
+            self.assertEqual(orchestrator.output_preview_length, 200)
+            self.assertIsNotNone(orchestrator.iteration_stats)
+            self.assertEqual(orchestrator.iteration_stats.max_preview_length, 200)
+        finally:
+            Path(prompt_file).unlink()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds per-iteration telemetry capture to ralph-orchestrator, enabling detailed analysis of orchestration patterns.

### Changes

- **`TriggerReason` enum** - Categorizes why each iteration was triggered (initial, task_incomplete, recovery, etc.)
- **Extended `IterationStats.record_iteration()`** - Now captures trigger_reason, output_preview (truncated), tokens_used, cost, and tools_used
- **New `_determine_trigger_reason()` method** - Analyzes orchestrator state to classify iteration triggers  
- **Enhanced `_print_summary()`** - Saves full iteration list with per-iteration details to metrics JSON

### Output Format

```json
{
  "summary": { /* backward compatible summary stats */ },
  "iterations": [
    {
      "iteration": 1,
      "duration": 5.2,
      "success": true,
      "trigger_reason": "initial",
      "output_preview": "Task started...",
      "tokens_used": 1500,
      "cost": 0.025
    }
  ],
  "cost": { /* cost breakdown */ },
  "analysis": { "avg_iteration_duration": 4.1, "success_rate": 0.95 }
}
```

## Test Plan

- [x] All 68 tests pass (including 23 new telemetry tests)
- [x] Backward compatibility verified (old `record_iteration()` calls still work)
- [x] Output preview truncation at 500 chars verified
- [x] TriggerReason enum values tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)