### PR TITLE
feat: codex-acp support, agent priority, and ralph.yml auto-load

### DIFF
--- a/ralph.codex-acp.yml
+++ b/ralph.codex-acp.yml
@@ -1,0 +1,33 @@
+# Ralph Orchestrator Configuration (Codex via ACP)
+#
+# Requires:
+# - `codex` installed (you already have it)
+# - `codex-acp` installed (e.g. `npm i -g @zed-industries/codex-acp`)
+# - Auth for Codex (either `codex login` or `OPENAI_API_KEY`/`CODEX_API_KEY`)
+
+agent: acp
+# Prefer Codex first, then fall back to Claude, then Gemini.
+agent_priority:
+  - acp
+  - claude
+  - gemini
+prompt_file: PROMPT.md
+max_iterations: 100
+max_runtime: 14400
+
+adapters:
+  q:
+    enabled: false
+  acp:
+    enabled: true
+    timeout: 300
+    tool_permissions:
+      agent_command: codex-acp
+      # Prefer configuring Codex here so you can run `ralph run` with no flags.
+      agent_args:
+        - -c
+        - model="gpt-5.2"
+        - -c
+        - model_reasoning_effort="high"
+      permission_mode: auto_approve
+      permission_allowlist: []

--- a/ralph.yml
+++ b/ralph.yml
@@ -2,7 +2,14 @@
 # This file configures Ralph and its AI agent adapters
 
 # Core orchestrator settings
-agent: auto                    # Which agent to use: claude, q, gemini, auto
+agent: auto                    # Which agent to use: claude, q, gemini, acp, auto
+# Agent selection + fallback ordering (used when agent=auto, and for fallback order)
+# Valid values: acp, claude, gemini, qchat (aliases: codex->acp, q->qchat)
+agent_priority:                # Priority order (first available wins)
+  - claude
+  - gemini
+  - qchat
+  - acp
 prompt_file: PROMPT.md         # Path to prompt file
 max_iterations: 100            # Maximum iterations before stopping
 max_runtime: 14400             # Maximum runtime in seconds (4 hours)
@@ -52,3 +59,17 @@ adapters:
     max_retries: 3
     args: []
     env: {}
+
+  # Agent Client Protocol (ACP) adapter
+  # Works with any ACP-compliant agent, e.g. `codex-acp` (Codex), `gemini`, etc.
+  acp:
+    enabled: true
+    timeout: 300
+    max_retries: 3
+    args: []
+    env: {}
+    tool_permissions:
+      agent_command: codex-acp          # ACP agent command to run
+      agent_args: []                   # Args passed to the ACP agent
+      permission_mode: interactive      # auto_approve | deny_all | allowlist | interactive
+      permission_allowlist: []         # Used when permission_mode=allowlist

--- a/src/ralph_orchestrator/main.py
+++ b/src/ralph_orchestrator/main.py
@@ -202,6 +202,9 @@ class RalphConfig:
 
     # Core configuration fields
     agent: AgentType = AgentType.AUTO
+    # Agent selection and fallback priority (used when agent=auto, and for fallback ordering)
+    # Valid values: "acp", "claude", "gemini", "qchat" (also accepts aliases: "codex"->"acp", "q"->"qchat")
+    agent_priority: List[str] = field(default_factory=lambda: ["claude", "qchat", "gemini", "acp"])
     prompt_file: str = DEFAULT_PROMPT_FILE
     prompt_text: Optional[str] = None  # Direct prompt text (overrides prompt_file)
     max_iterations: int = DEFAULT_MAX_ITERATIONS

--- a/tests/test_acp_cli.py
+++ b/tests/test_acp_cli.py
@@ -192,10 +192,10 @@ class TestOrchestratorACPAdapter:
             )
 
             # Verify ACPAdapter was called with correct parameters
-            mock_acp.assert_called_once_with(
-                agent_command="claude-code-acp",
-                permission_mode="auto_approve"
-            )
+            mock_acp.assert_called_once()
+            kwargs = mock_acp.call_args.kwargs
+            assert kwargs["agent_command"] == "claude-code-acp"
+            assert kwargs["permission_mode"] == "auto_approve"
 
 
 class TestACPAutoDetection:

--- a/tests/test_agent_priority.py
+++ b/tests/test_agent_priority.py
@@ -1,0 +1,100 @@
+# ABOUTME: Tests for agent_priority-driven adapter ordering and auto selection
+# ABOUTME: Ensures auto mode can prefer ACP/Codex and control fallback ordering
+
+import pytest
+
+from ralph_orchestrator.main import RalphConfig, AgentType, AdapterConfig
+from ralph_orchestrator.orchestrator import RalphOrchestrator
+
+
+class _DummyClaudeAdapter:
+    def __init__(self, verbose: bool = False) -> None:
+        self.name = "claude"
+        self.available = True
+
+
+class _DummyGeminiAdapter:
+    def __init__(self) -> None:
+        self.name = "gemini"
+        self.available = True
+
+
+class _DummyQChatAdapter:
+    def __init__(self) -> None:
+        self.name = "qchat"
+        self.available = True
+
+
+class _DummyACPAdapter:
+    def __init__(
+        self,
+        agent_command: str = "gemini",
+        agent_args: list[str] | None = None,
+        timeout: int = 300,
+        permission_mode: str = "auto_approve",
+        permission_allowlist: list[str] | None = None,
+        verbose: bool = False,
+    ) -> None:
+        self.name = "acp"
+        self.available = True
+        self.agent_command = agent_command
+        self.agent_args = agent_args or []
+        self.timeout = timeout
+        self.permission_mode = permission_mode
+        self.permission_allowlist = permission_allowlist or []
+        self.verbose = verbose
+
+
+def test_agent_priority_orders_adapters_and_auto_selects_first(tmp_path, monkeypatch):
+    # Patch adapters so this test is deterministic and does not depend on installed CLIs.
+    import ralph_orchestrator.orchestrator as orch_mod
+
+    monkeypatch.setattr(orch_mod, "ClaudeAdapter", _DummyClaudeAdapter)
+    monkeypatch.setattr(orch_mod, "GeminiAdapter", _DummyGeminiAdapter)
+    monkeypatch.setattr(orch_mod, "QChatAdapter", _DummyQChatAdapter)
+    monkeypatch.setattr(orch_mod, "ACPAdapter", _DummyACPAdapter)
+
+    prompt_file = tmp_path / "PROMPT.md"
+    prompt_file.write_text("# Task: Test\n\nDo nothing.\n", encoding="utf-8")
+
+    config = RalphConfig(
+        agent=AgentType.AUTO,
+        prompt_file=str(prompt_file),
+        agent_priority=["acp", "claude", "gemini"],
+        adapters={
+            "q": AdapterConfig(enabled=False),
+            "acp": AdapterConfig(
+                enabled=True,
+                tool_permissions={
+                    "agent_command": "codex-acp",
+                    "agent_args": [
+                        "-c",
+                        'model="gpt-5.2"',
+                        "-c",
+                        'model_reasoning_effort="high"',
+                    ],
+                    "permission_mode": "auto_approve",
+                    "permission_allowlist": [],
+                },
+            ),
+        },
+    )
+
+    orchestrator = RalphOrchestrator(prompt_file_or_config=config)
+
+    # Auto mode should pick the first available adapter in the priority list.
+    assert orchestrator.current_adapter is orchestrator.adapters["acp"]
+
+    # Adapter dict insertion order drives fallback order.
+    assert list(orchestrator.adapters.keys()) == ["acp", "claude", "gemini"]
+
+    # ACP adapter should be configured from config.tool_permissions.
+    acp = orchestrator.adapters["acp"]
+    assert acp.agent_command == "codex-acp"
+    assert acp.permission_mode == "auto_approve"
+    assert acp.agent_args == [
+        "-c",
+        'model="gpt-5.2"',
+        "-c",
+        'model_reasoning_effort="high"',
+    ]

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -1,0 +1,81 @@
+# ABOUTME: Tests for --codex CLI shortcut behavior
+# ABOUTME: Ensures codex convenience flag maps to ACP settings
+
+import argparse
+
+import pytest
+
+from ralph_orchestrator.__main__ import _apply_codex_shortcut
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    # Provide defaults used by _apply_codex_shortcut
+    defaults = dict(
+        codex=False,
+        agent="auto",
+        acp_agent=None,
+        acp_permission_mode=None,
+        codex_permission_mode=None,
+        codex_model=None,
+        codex_reasoning_effort=None,
+        agent_args=[],
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_codex_sets_acp_defaults():
+    parser = argparse.ArgumentParser()
+    args = _ns(codex=True)
+
+    _apply_codex_shortcut(args, parser)
+
+    assert args.agent == "acp"
+    assert args.acp_agent == "codex-acp"
+    assert args.acp_permission_mode == "interactive"
+    assert args.agent_args == []
+
+
+def test_codex_respects_explicit_acp_overrides():
+    parser = argparse.ArgumentParser()
+    args = _ns(
+        codex=True,
+        acp_agent="custom-acp-agent",
+        acp_permission_mode="deny_all",
+        codex_permission_mode="interactive",
+    )
+
+    _apply_codex_shortcut(args, parser)
+
+    assert args.agent == "acp"
+    assert args.acp_agent == "custom-acp-agent"
+    assert args.acp_permission_mode == "deny_all"
+
+
+def test_codex_conflicts_with_non_acp_agent():
+    parser = argparse.ArgumentParser()
+    args = _ns(codex=True, agent="claude")
+
+    with pytest.raises(SystemExit):
+        _apply_codex_shortcut(args, parser)
+
+
+def test_codex_model_and_reasoning_append_agent_args():
+    parser = argparse.ArgumentParser()
+    args = _ns(
+        codex=True,
+        codex_model="gpt-5.2",
+        codex_reasoning_effort="xhigh",
+    )
+
+    _apply_codex_shortcut(args, parser)
+
+    assert args.agent == "acp"
+    assert args.acp_agent == "codex-acp"
+    assert args.acp_permission_mode == "interactive"
+    assert args.agent_args == [
+        "-c",
+        "model=\"gpt-5.2\"",
+        "-c",
+        "model_reasoning_effort=\"xhigh\"",
+    ]


### PR DESCRIPTION
## Why
I’m using Ralph locally on Apple Silicon and wanted Codex CLI to be a first-class agent option via the Agent Client Protocol (ACP). In practice that also surfaced two recurring usability issues:

1) Running `ralph run ...` without `-c ralph.yml` silently ignores project settings (timeouts/iterations), leading to unexpected 5-minute ACP timeouts and fallbacks.
2) `codex-acp` (and some ACP agents) can emit large single-line JSON-RPC frames; asyncio’s default per-line read limit (~64KiB) can crash the ACP read loop.

This PR makes Codex-over-ACP easier to use, configurable, and more robust.

## What changed
- Add Codex convenience flags:
  - `ralph run --codex` (equivalent to `--agent acp --acp-agent codex-acp`)
  - `--codex-permission-mode {auto_approve,deny_all,allowlist,interactive}`
  - `--codex-model <model>` (passed to `codex-acp` as `-c model=...`)
  - `--codex-reasoning-effort {low,medium,high,xhigh}` (passed as `-c model_reasoning_effort=...`)
- Add `agent_priority` config field so `agent: auto` can prefer Codex/ACP first (and control fallback ordering).
- Auto-load `./ralph.yml` when present (so project defaults apply even if `-c ralph.yml` is omitted).
- Increase ACP subprocess stream read limit (default 8MiB) to prevent `LimitOverrunError: Separator is found, but chunk is longer than limit`.
  - Optional override via `RALPH_ACP_STREAM_LIMIT`.
- Add sample config preset `ralph.codex-acp.yml`.
- Add/adjust tests covering Codex shortcut flags and agent priority ordering.

## Files / highlights
- `src/ralph_orchestrator/__main__.py`
  - Adds `--codex*` flags and the shortcut mapping.
  - Auto-loads `ralph.yml` when present.
- `src/ralph_orchestrator/orchestrator.py`
  - Implements `agent_priority` ordering and auto selection.
  - Initializes adapters in priority order for deterministic fallback behavior.
- `src/ralph_orchestrator/adapters/acp_client.py`
  - Raises asyncio stream read limit for ACP agent subprocesses.
- `ralph.codex-acp.yml`
  - Example to run Codex via ACP with reasoning effort + permissions.

## How to use
- Use Codex directly:
  - `ralph run --codex --codex-model gpt-5.2 --codex-reasoning-effort xhigh`
- Prefer Codex first in auto mode (project config):
  - `agent: auto`
  - `agent_priority: [acp, claude, gemini]`

## Tests
- New: `tests/test_codex_cli.py`, `tests/test_agent_priority.py`
- Updated: `tests/test_acp_cli.py`
