### PR TITLE
ci: add manual trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Adds workflow_dispatch to allow manual retries in case of transient network errors during PyPI publishing.