### PR TITLE
ci: fix publish retry logic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,14 +45,10 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-    - name: Publish distribution to PyPI
-      uses: nick-fields/retry@v3
-      with:
-        timeout_minutes: 5
-        max_attempts: 3
-        retry_wait_seconds: 15
-        command: >-
-          python3 -m pip install pypa/gh-action-pypi-publish@release/v1 &&
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          python3 -m pypa.gh-action-pypi-publish
-          --packages-dir dist/
+    - name: Publish distribution to PyPI (Attempt 1)
+      id: publish-1
+      uses: pypa/gh-action-pypi-publish@release/v1
+      continue-on-error: true
+    - name: Publish distribution to PyPI (Attempt 2)
+      if: steps.publish-1.outcome == 'failure'
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Replaces the broken command-line retry with a native GitHub Actions double-step pattern. This provides a second attempt for the OIDC handshake in case of transient network timeouts.