### PR TITLE
docs: Add uv tool installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Based on the Ralph Wiggum technique by [Geoffrey Huntley](https://ghuntley.com/r
 
 ## Installation
 
+### For Users (Recommended)
+
+```bash
+# Install with uv tool (easiest way to run Ralph globally)
+uv tool install ralph-orchestrator
+
+# Or install with pip
+pip install ralph-orchestrator
+```
+
+### For Developers
+
 ```bash
 # Clone the repository
 git clone https://github.com/mikeyobrien/ralph-orchestrator.git

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,10 +50,25 @@ cd ralph-orchestrator-1.0.0
 chmod +x ralph_orchestrator.py
 ```
 
-### Method 3: pip Install (Coming Soon)
+### Method 3: uv tool (Recommended for Users)
+
+If you just want to run Ralph without setting up a development environment:
 
 ```bash
-# Future installation via pip
+# Install uv if you haven't already
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install Ralph globally
+uv tool install ralph-orchestrator
+
+# Verify installation
+ralph --help
+```
+
+### Method 4: pip Install
+
+```bash
+# Install via pip
 pip install ralph-orchestrator
 ```
 

--- a/uv.lock
+++ b/uv.lock
@@ -1028,7 +1028,7 @@ wheels = [
 
 [[package]]
 name = "ralph-orchestrator"
-version = "1.2.0"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Updates installation documentation to include instructions for installing via `uv tool install ralph-orchestrator`, which is now the recommended method for end users. Also fixes `uv.lock` version to 1.2.2.