### PR TITLE
refactor(adapters): Move scratchpad instructions to base adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Based on the Ralph Wiggum technique by [Geoffrey Huntley](https://ghuntley.com/r
 - 🔒 **Security Features**: Automatic masking of API keys et sensitive data in logs
 - ⚡ **Async-First Design**: Non-blocking I/O throughout (logging, git operations)
 - 📝 **Inline Prompts**: Run with `-p "your task"` without needing a file
-- 🧠 **Agent Scratchpad**: ACP agents persist context across iterations via `.agent/scratchpad.md`
+- 🧠 **Agent Scratchpad**: All agents persist context across iterations via `.agent/scratchpad.md`
 
 ## Installation
 
@@ -288,7 +288,7 @@ adapters:
 
 ### Agent Scratchpad
 
-ACP agents maintain context across iterations via `.agent/scratchpad.md`. This file persists:
+All agents maintain context across iterations via `.agent/scratchpad.md`. This file persists:
 - Progress from previous iterations
 - Decisions and context
 - Current blockers or issues

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -511,7 +511,7 @@ adapters:
 ```
 
 **Agent Scratchpad:**
-ACP agents maintain context across iterations via `.agent/scratchpad.md`:
+All agents maintain context across iterations via `.agent/scratchpad.md`:
 - Persists progress from previous iterations
 - Records decisions and context
 - Tracks current blockers or issues

--- a/src/ralph_orchestrator/adapters/acp.py
+++ b/src/ralph_orchestrator/adapters/acp.py
@@ -680,51 +680,6 @@ class ACPAdapter(ToolAdapter):
                 error=str(e),
             )
 
-    def _enhance_prompt_with_instructions(self, prompt: str) -> str:
-        """Enhance prompt with ACP-specific orchestration and scratchpad instructions.
-
-        Adds scratchpad persistence mechanism to base orchestration instructions.
-
-        Args:
-            prompt: The original prompt
-
-        Returns:
-            Enhanced prompt with orchestration and scratchpad instructions
-        """
-        # Get base orchestration instructions
-        enhanced_prompt = super()._enhance_prompt_with_instructions(prompt)
-
-        # Check if scratchpad instructions already exist
-        if "Agent Scratchpad" in enhanced_prompt:
-            return enhanced_prompt
-
-        # Add scratchpad instructions before the "ORIGINAL PROMPT:" marker
-        scratchpad_instructions = """
-## Agent Scratchpad
-Before starting your work, check if .agent/scratchpad.md exists in the current working directory.
-If it does, read it to understand what was accomplished in previous iterations and continue from there.
-
-At the end of your iteration, update .agent/scratchpad.md with:
-- What you accomplished this iteration
-- What remains to be done
-- Any important context or decisions made
-- Current blockers or issues (if any)
-
-Do NOT restart from scratch if the scratchpad shows previous progress. Continue where the previous iteration left off.
-
-Create the .agent/ directory if it doesn't exist.
-
----
-"""
-
-        # Insert scratchpad instructions before "ORIGINAL PROMPT:"
-        if "ORIGINAL PROMPT:" in enhanced_prompt:
-            parts = enhanced_prompt.split("ORIGINAL PROMPT:")
-            return parts[0] + scratchpad_instructions + "ORIGINAL PROMPT:" + parts[1]
-        else:
-            # Fallback: append if marker not found
-            return enhanced_prompt + "\n" + scratchpad_instructions
-
     def estimate_cost(self, prompt: str) -> float:
         """Estimate execution cost.
 

--- a/src/ralph_orchestrator/adapters/base.py
+++ b/src/ralph_orchestrator/adapters/base.py
@@ -137,6 +137,21 @@ IMPORTANT INSTRUCTIONS:
 4. When you complete a subtask, document it in the prompt file so the next iteration knows what's done.
 5. For maximum efficiency, whenever you need to perform multiple independent operations, invoke all relevant tools simultaneously rather than sequentially.
 6. If you create any temporary new files, scripts, or helper files for iteration, clean up these files by removing them at the end of the task.
+
+## Agent Scratchpad
+Before starting your work, check if .agent/scratchpad.md exists in the current working directory.
+If it does, read it to understand what was accomplished in previous iterations and continue from there.
+
+At the end of your iteration, update .agent/scratchpad.md with:
+- What you accomplished this iteration
+- What remains to be done
+- Any important context or decisions made
+- Current blockers or issues (if any)
+
+Do NOT restart from scratch if the scratchpad shows previous progress. Continue where the previous iteration left off.
+
+Create the .agent/ directory if it doesn't exist.
+
 ---
 ORIGINAL PROMPT:
 


### PR DESCRIPTION
Move agent scratchpad mechanism from ACP adapter to base ToolAdapter class, making it available to all agents (Claude, Kiro, Q, Gemini, ACP).

This enables consistent context persistence across iterations for all agent types.

## Changes
- Removed `_enhance_prompt_with_instructions` override from ACP adapter
- Added scratchpad instructions to base ToolAdapter class
- Updated documentation to reflect scratchpad availability for all agents

## Benefits
- All agents now benefit from context persistence
- Reduces code duplication
- Consistent behavior across all agent types