### PR TITLE
fix: correct agent validation in _apply_codex_shortcut

### DIFF
--- a/src/ralph_orchestrator/__main__.py
+++ b/src/ralph_orchestrator/__main__.py
@@ -42,7 +42,11 @@ def _apply_codex_shortcut(args: argparse.Namespace, parser: argparse.ArgumentPar
         return
 
     # --codex implies ACP mode; reject conflicting explicit agent selection.
-    if getattr(args, "agent", "auto") not in ("auto", "acp"):
+    # Note: We must check for None explicitly because getattr returns the actual
+    # attribute value (None) when the attribute exists, not the default value.
+    # The --agent argument defaults to None in argparse, so we treat None as "auto".
+    agent_value = getattr(args, "agent", None)
+    if agent_value is not None and agent_value not in ("auto", "acp"):
         parser.error("--codex requires --agent auto or acp (or omit -a/--agent)")
 
     args.agent = "acp"


### PR DESCRIPTION
## Summary

This PR fixes a bug in the `_apply_codex_shortcut` function where the `--codex` flag fails to work correctly when used with the `run` subcommand.

## Problem

When running `ralph run --codex`, users encounter the following error:

```
ralph: error: --codex requires --agent auto or acp (or omit -a/--agent)
```

This happens even though no explicit `--agent` argument was provided.

## Root Cause

The issue is in line 45 of `__main__.py`:

```python
if getattr(args, "agent", "auto") not in ("auto", "acp"):
```

The problem is that `getattr(obj, name, default)` only returns the `default` value when the attribute **does not exist**. However, when the attribute exists but has a value of `None`, `getattr` returns `None`, not the default value.

Since the `--agent` argument is defined with `default=None` in argparse:

```python
p.add_argument(
    "-a", "--agent",
    choices=["claude", "q", "gemini", "kiro", "acp", "auto"],
    default=None,  # <-- This is the issue
    help="AI agent to use (default: auto)"
)
```

When a user runs `ralph run --codex` without specifying `--agent`:
- `args.agent` exists and equals `None`
- `getattr(args, "agent", "auto")` returns `None` (not `"auto"`)
- `None not in ("auto", "acp")` evaluates to `True`
- The error is triggered incorrectly

## Solution

Replace the problematic `getattr` check with an explicit `None` check:

```python
# Before (buggy)
if getattr(args, "agent", "auto") not in ("auto", "acp"):
    parser.error(...)

# After (fixed)
agent_value = getattr(args, "agent", None)
if agent_value is not None and agent_value not in ("auto", "acp"):
    parser.error(...)
```

This correctly treats `None` (no explicit agent specified) as equivalent to `"auto"`.

## Test Cases

| Command | Expected | Result |
|---------|----------|--------|
| `ralph run --codex` | Use ACP with codex-acp | ✅ Works |
| `ralph run --codex -a auto` | Use ACP with codex-acp | ✅ Works |
| `ralph run --codex -a acp` | Use ACP with codex-acp | ✅ Works |
| `ralph run --codex -a claude` | Error (conflicting) | ✅ Error |

## Additional Notes

There is also a related UX issue: the `--codex` flag must be placed **after** the `run` subcommand:

```bash
# Works:
ralph run --codex

# Does NOT work:
ralph --codex run
```

This is due to argparse subparser behavior and may warrant documentation updates in a future PR.
