### PR TITLE
fix(adapters): use OpenCode `run` subcommand with positional prompt

### DIFF
--- a/crates/ralph-cli/presets/minimal/opencode.yml
+++ b/crates/ralph-cli/presets/minimal/opencode.yml
@@ -1,0 +1,27 @@
+# Ralph Orchestrator Configuration - OpenCode
+# v2 nested format
+#
+# Requires:
+# - `opencode` CLI installed (https://github.com/opencode-ai/opencode)
+# - Configured provider credentials (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
+
+# Event loop settings
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400           # 4 hours
+  idle_timeout_secs: 1800
+
+# CLI backend settings
+cli:
+  backend: "opencode"
+  prompt_mode: "arg"                   # Positional argument after `run` subcommand
+
+# Core behaviors (always injected into prompts)
+core:
+  scratchpad: ".agent/scratchpad.md"
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - scratchpad is memory"
+    - "Don't assume 'not implemented' - search first"
+    - "Backpressure is law - tests/typecheck/lint must pass"

--- a/presets/minimal/opencode.yml
+++ b/presets/minimal/opencode.yml
@@ -1,0 +1,27 @@
+# Ralph Orchestrator Configuration - OpenCode
+# v2 nested format
+#
+# Requires:
+# - `opencode` CLI installed (https://github.com/opencode-ai/opencode)
+# - Configured provider credentials (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
+
+# Event loop settings
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400           # 4 hours
+  idle_timeout_secs: 1800
+
+# CLI backend settings
+cli:
+  backend: "opencode"
+  prompt_mode: "arg"                   # Positional argument after `run` subcommand
+
+# Core behaviors (always injected into prompts)
+core:
+  scratchpad: ".agent/scratchpad.md"
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - scratchpad is memory"
+    - "Don't assume 'not implemented' - search first"
+    - "Backpressure is law - tests/typecheck/lint must pass"


### PR DESCRIPTION
## Summary

- Updates OpenCode CLI backend to use `opencode run "prompt"` syntax instead of the deprecated `opencode -p "prompt"` flag approach
- Removes the `--dangerously-skip-permissions` flag which is no longer part of the OpenCode CLI interface
- All three OpenCode backend variants (headless, TUI, interactive) now consistently use the `run` subcommand

## Test plan

- [x] Existing unit tests updated and passing
- [x] Manual verification with OpenCode CLI (if available)