### PR TITLE
fix(tui): require stdin to be terminal for TUI enablement

### DIFF
--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -33,7 +33,7 @@ use ralph_core::{
 use ralph_proto::{Event, HatId};
 use ralph_tui::Tui;
 use std::fs::{self, File};
-use std::io::{BufWriter, IsTerminal, Write, stdout};
+use std::io::{BufWriter, IsTerminal, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -1763,8 +1763,9 @@ async fn run_loop_impl(
 
     // Wire TUI with termination signal and shared state
     // TUI is observation-only - works in both interactive and autonomous modes
-    // Only requirement: stdout must be a terminal for TUI to render
-    let enable_tui = enable_tui && stdout().is_terminal();
+    // Requirements: both stdin and stdout must be terminals for TUI
+    // (Crossterm requires stdin for keyboard input, stdout for rendering)
+    let enable_tui = enable_tui && stdin().is_terminal() && stdout().is_terminal();
     let (mut tui_handle, tui_state) = if enable_tui {
         // Build hat map for dynamic topic-to-hat resolution
         // This allows TUI to display custom hats (e.g., "🔒 Security Reviewer")


### PR DESCRIPTION
## Summary
- Adds `stdin().is_terminal()` check to TUI enablement condition
- TUI now requires both stdin AND stdout to be terminals
- Prevents TUI from enabling when running through Claude Code (where stdin fd/0 is a socket)

## Problem
When running ralph through Claude Code or similar tools that pipe stdin, the TUI would enable but crossterm's EventStream would fail to receive keyboard input, making the TUI unresponsive.

## Solution
Check both `stdin().is_terminal()` and `stdout().is_terminal()` before enabling TUI. This defensive check ensures TUI only activates in truly interactive terminal contexts.

## Test plan
- [x] `cargo test --package ralph-tui` - 29 tests pass
- [x] `cargo build` - compiles successfully
- [x] Verified logic: TUI auto-disables when stdin is not a TTY

🤖 Generated with [Claude Code](https://claude.ai/code)