### PR TITLE
feat(tasks): add native task provider for Claude Code backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,31 @@ When enabled (default):
 - Tasks replace scratchpad for completion verification
 - Loop terminates when no open tasks + consecutive LOOP_COMPLETE
 
-To disable (legacy scratchpad mode):
+#### Task Provider Configuration
+
+When running with Claude Code as the backend, Ralph can use Claude Code's native task tools (`TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`) instead of the `ralph tools task` CLI commands:
+
+```yaml
+tasks:
+  enabled: true
+  provider: "auto"  # "native" | "local" | "auto" (default)
+```
+
+- `"native"`: Use Claude Code's native task tools
+- `"local"`: Use `ralph tools task` commands and `.agent/tasks.jsonl`
+- `"auto"`: Auto-detect based on backend (Claude → native, others → local)
+
+**When to use native mode:**
+- Running Ralph with Claude Code backend
+- Better integration with Claude Code's task tracking UI
+- Reduces CLI overhead in prompts
+
+**When to use local mode:**
+- Running Ralph with non-Claude backends (Kiro, Gemini, etc.)
+- Need explicit task file for external tooling/analysis
+- Consistent behavior across all backends
+
+To disable tasks and memories (legacy scratchpad mode):
 ```yaml
 memories:
   enabled: false

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -28,6 +28,7 @@ mod session_recorder;
 mod summary_writer;
 pub mod task;
 pub mod task_definition;
+pub mod task_provider;
 pub mod task_store;
 pub mod testing;
 mod text;
@@ -37,7 +38,7 @@ pub mod workspace;
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
     CliConfig, CoreConfig, EventLoopConfig, EventMetadata, HatBackend, HatConfig, InjectMode,
-    MemoriesConfig, MemoriesFilter, RalphConfig,
+    MemoriesConfig, MemoriesFilter, RalphConfig, TasksConfig,
 };
 pub use diagnostics::DiagnosticsCollector;
 pub use event_logger::{EventHistory, EventLogger, EventRecord};
@@ -58,6 +59,7 @@ pub use task::{Task, TaskStatus};
 pub use task_definition::{
     TaskDefinition, TaskDefinitionError, TaskSetup, TaskSuite, Verification,
 };
+pub use task_provider::{TaskProvider, resolve_task_provider};
 pub use task_store::TaskStore;
 pub use text::truncate_with_ellipsis;
 pub use workspace::{

--- a/crates/ralph-core/src/task_provider.rs
+++ b/crates/ralph-core/src/task_provider.rs
@@ -1,0 +1,211 @@
+//! Task provider resolution for native vs local task tracking.
+//!
+//! This module determines which task provider to use based on configuration
+//! and the backend being used. When running with Claude Code, the native
+//! task tools (TaskCreate, TaskUpdate, etc.) can be used instead of the
+//! custom `ralph tools task` CLI commands.
+
+use crate::config::TasksConfig;
+use tracing::{debug, warn};
+
+/// The resolved task provider for a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskProvider {
+    /// Use Claude Code's native task tools (TaskCreate, TaskUpdate, etc.)
+    Native,
+    /// Use `ralph tools task` commands and `.agent/tasks.jsonl`
+    Local,
+    /// Tasks are disabled
+    Disabled,
+}
+
+impl TaskProvider {
+    /// Returns true if this provider trusts the agent for completion verification.
+    ///
+    /// Native mode trusts the agent to verify all tasks are complete before
+    /// signaling LOOP_COMPLETE. Local mode checks `.agent/tasks.jsonl`.
+    pub fn trusts_agent(&self) -> bool {
+        matches!(self, TaskProvider::Native)
+    }
+}
+
+/// Resolves which task provider to use based on config and backend.
+///
+/// # Arguments
+/// * `tasks_config` - The tasks configuration from ralph config
+/// * `backend_name` - The name of the backend being used (e.g., "claude", "kiro")
+///
+/// # Returns
+/// The resolved `TaskProvider` to use for this session.
+///
+/// # Examples
+/// ```
+/// use ralph_core::{TasksConfig, resolve_task_provider, TaskProvider};
+///
+/// // Auto mode with Claude backend → Native
+/// let config = TasksConfig { enabled: true, provider: "auto".to_string() };
+/// assert_eq!(resolve_task_provider(&config, "claude"), TaskProvider::Native);
+///
+/// // Auto mode with Kiro backend → Local
+/// let config = TasksConfig { enabled: true, provider: "auto".to_string() };
+/// assert_eq!(resolve_task_provider(&config, "kiro"), TaskProvider::Local);
+/// ```
+pub fn resolve_task_provider(tasks_config: &TasksConfig, backend_name: &str) -> TaskProvider {
+    if !tasks_config.enabled {
+        debug!("Tasks disabled in config");
+        return TaskProvider::Disabled;
+    }
+
+    match tasks_config.provider.as_str() {
+        "native" => {
+            if is_claude_backend(backend_name) {
+                debug!(provider = "native", "Using Claude Code native task tools");
+                TaskProvider::Native
+            } else {
+                warn!(
+                    provider = "native",
+                    backend = backend_name,
+                    "Native task tools not available for backend '{}'. Using local task tracking.",
+                    backend_name
+                );
+                TaskProvider::Local
+            }
+        }
+        "local" => {
+            debug!(
+                provider = "local",
+                "Using local task tracking (.agent/tasks.jsonl)"
+            );
+            TaskProvider::Local
+        }
+        _ => {
+            // Default to auto-detection behavior
+            if is_claude_backend(backend_name) {
+                debug!(
+                    provider = "auto",
+                    backend = backend_name,
+                    "Auto-detected Claude backend, using native task tools"
+                );
+                TaskProvider::Native
+            } else {
+                debug!(
+                    provider = "auto",
+                    backend = backend_name,
+                    "Auto-detected non-Claude backend, using local task tracking"
+                );
+                TaskProvider::Local
+            }
+        }
+    }
+}
+
+/// Checks if the backend supports Claude Code's native task tools.
+fn is_claude_backend(backend_name: &str) -> bool {
+    backend_name == "claude"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(enabled: bool, provider: &str) -> TasksConfig {
+        TasksConfig {
+            enabled,
+            provider: provider.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_disabled_tasks() {
+        assert_eq!(
+            resolve_task_provider(&config(false, "auto"), "claude"),
+            TaskProvider::Disabled
+        );
+        assert_eq!(
+            resolve_task_provider(&config(false, "native"), "claude"),
+            TaskProvider::Disabled
+        );
+    }
+
+    #[test]
+    fn test_native_with_claude() {
+        assert_eq!(
+            resolve_task_provider(&config(true, "native"), "claude"),
+            TaskProvider::Native
+        );
+    }
+
+    #[test]
+    fn test_native_with_kiro_falls_back() {
+        // Native requested but Kiro doesn't support it → falls back to Local
+        assert_eq!(
+            resolve_task_provider(&config(true, "native"), "kiro"),
+            TaskProvider::Local
+        );
+    }
+
+    #[test]
+    fn test_native_with_gemini_falls_back() {
+        assert_eq!(
+            resolve_task_provider(&config(true, "native"), "gemini"),
+            TaskProvider::Local
+        );
+    }
+
+    #[test]
+    fn test_local_always_local() {
+        // Local mode always uses local, regardless of backend
+        assert_eq!(
+            resolve_task_provider(&config(true, "local"), "claude"),
+            TaskProvider::Local
+        );
+        assert_eq!(
+            resolve_task_provider(&config(true, "local"), "kiro"),
+            TaskProvider::Local
+        );
+    }
+
+    #[test]
+    fn test_auto_with_claude() {
+        assert_eq!(
+            resolve_task_provider(&config(true, "auto"), "claude"),
+            TaskProvider::Native
+        );
+    }
+
+    #[test]
+    fn test_auto_with_kiro() {
+        assert_eq!(
+            resolve_task_provider(&config(true, "auto"), "kiro"),
+            TaskProvider::Local
+        );
+    }
+
+    #[test]
+    fn test_auto_with_gemini() {
+        assert_eq!(
+            resolve_task_provider(&config(true, "auto"), "gemini"),
+            TaskProvider::Local
+        );
+    }
+
+    #[test]
+    fn test_unknown_provider_defaults_to_auto() {
+        // Unknown provider value falls through to auto behavior
+        assert_eq!(
+            resolve_task_provider(&config(true, "unknown"), "claude"),
+            TaskProvider::Native
+        );
+        assert_eq!(
+            resolve_task_provider(&config(true, "unknown"), "kiro"),
+            TaskProvider::Local
+        );
+    }
+
+    #[test]
+    fn test_trusts_agent() {
+        assert!(TaskProvider::Native.trusts_agent());
+        assert!(!TaskProvider::Local.trusts_agent());
+        assert!(!TaskProvider::Disabled.trusts_agent());
+    }
+}

--- a/crates/ralph-core/tests/event_loop_ralph.rs
+++ b/crates/ralph-core/tests/event_loop_ralph.rs
@@ -217,6 +217,7 @@ event_loop:
 #[test]
 fn test_solo_mode_memories_task_verification_requirements() {
     // Test that solo mode with memories/tasks enabled includes task verification requirements
+    // Explicitly use local provider to test CLI-based instructions
     let yaml = r#"
 core:
   scratchpad: ".agent/scratchpad.md"
@@ -227,6 +228,7 @@ memories:
   enabled: true
 tasks:
   enabled: true
+  provider: local
 "#;
 
     let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();

--- a/docs/concepts/memories-and-tasks.md
+++ b/docs/concepts/memories-and-tasks.md
@@ -89,6 +89,42 @@ memories:
 
 Tasks track runtime work items during orchestration.
 
+### Task Provider
+
+Ralph supports two task providers that determine how tasks are managed:
+
+```yaml
+tasks:
+  enabled: true
+  provider: "auto"  # "native" | "local" | "auto" (default)
+```
+
+| Provider | Description |
+|----------|-------------|
+| `native` | Use Claude Code's built-in task tools (`TaskCreate`, `TaskUpdate`, `TaskList`) |
+| `local` | Use `ralph tools task` CLI commands and `.agent/tasks.jsonl` |
+| `auto` | Auto-detect: Claude backend → native, others → local |
+
+**When to use native mode:**
+- Running Ralph with Claude Code as the backend
+- Better integration with Claude Code's task tracking UI
+- Reduces CLI overhead in prompts
+
+**When to use local mode:**
+- Running Ralph with non-Claude backends (Kiro, Gemini, etc.)
+- Need explicit task file for external tooling/analysis
+- Consistent behavior across all backends
+
+### Multi-Session Task Sharing
+
+When using native mode with Claude Code, you can share tasks across sessions:
+
+```bash
+CLAUDE_CODE_TASK_LIST_ID=my-project ralph run -p "your prompt"
+```
+
+This allows multiple Ralph sessions to coordinate on the same task list.
+
 ### Creating Tasks
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds configurable task provider (`native`, `local`, or `auto`) for flexible task management
- When using Claude Code backend with native mode, Ralph uses Claude Code's built-in task tools (TaskCreate, TaskUpdate, TaskList, TaskGet) instead of `ralph tools task` CLI commands
- Auto mode (default) detects the backend and chooses the appropriate provider

## Changes

- New `task_provider` module with `TaskProvider` enum and `resolve_task_provider()` function
- Extended `TasksConfig` with `provider` field (default: `"auto"`)
- Updated `HatlessRalph` to generate appropriate task instructions based on provider
- Updated `EventLoop` to trust agent for task completion verification in native mode
- Documentation updates in AGENTS.md and docs/concepts/memories-and-tasks.md

## Configuration

```yaml
tasks:
  enabled: true
  provider: "auto"  # "native" | "local" | "auto" (default)
```

## Test plan

- [x] Unit tests for task_provider module (13 tests)
- [x] Config parsing tests for new provider field (4 tests)
- [x] HatlessRalph tests for task provider integration (3 tests)
- [x] Pre-commit hooks pass (fmt + clippy)