### PR TITLE
Fix UTF-8 truncation panics in events outputFor origin

### DIFF
--- a/crates/ralph-e2e/src/scenarios/capabilities.rs
+++ b/crates/ralph-e2e/src/scenarios/capabilities.rs
@@ -396,8 +396,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;

--- a/crates/ralph-e2e/src/scenarios/connectivity.rs
+++ b/crates/ralph-e2e/src/scenarios/connectivity.rs
@@ -184,8 +184,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;

--- a/crates/ralph-e2e/src/scenarios/errors.rs
+++ b/crates/ralph-e2e/src/scenarios/errors.rs
@@ -789,8 +789,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;

--- a/crates/ralph-e2e/src/scenarios/events.rs
+++ b/crates/ralph-e2e/src/scenarios/events.rs
@@ -374,8 +374,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;

--- a/crates/ralph-e2e/src/scenarios/hats.rs
+++ b/crates/ralph-e2e/src/scenarios/hats.rs
@@ -1099,8 +1099,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;

--- a/crates/ralph-e2e/src/scenarios/memory.rs
+++ b/crates/ralph-e2e/src/scenarios/memory.rs
@@ -908,8 +908,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;

--- a/crates/ralph-e2e/src/scenarios/mod.rs
+++ b/crates/ralph-e2e/src/scenarios/mod.rs
@@ -362,8 +362,9 @@ fn truncate(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        // 这里的 `max_len` 是按“字节”计数的上限。
-        // 必须回退到合法的 UTF-8 字符边界，否则当输出包含中文/emoji 时会因为 `&s[..N]` 触发 panic。
+        // Note: `max_len` is a byte-count upper bound.
+        // We must back off to a valid UTF-8 character boundary; otherwise slicing `&s[..N]` can
+        // panic when the output contains multi-byte characters (e.g. CJK, emoji).
         let mut boundary = max_len.min(s.len());
         while boundary > 0 && !s.is_char_boundary(boundary) {
             boundary -= 1;


### PR DESCRIPTION
It turns out that when Chinese characters appear in files like PROMPT.md, it will panic.