### PR TITLE
Update preset configurations for better termination and pragmatic reviews

### DIFF
--- a/presets/api-design.yml
+++ b/presets/api-design.yml
@@ -72,8 +72,14 @@ hats:
       - [ ] Are there unnecessary concepts to learn?
       - [ ] Can it be misused easily?
 
-      If issues found: publish api.refined with specific feedback
-      If solid: publish api.approved
+      IMPORTANT: Be pragmatic. Only request refinement for critical issues
+      that would make the API unusable or dangerous. Minor improvements
+      can be noted but approved with comments.
+
+      After 1 refinement cycle, approve with notes rather than rejecting again.
+
+      If critical issues found: publish api.refined with specific feedback
+      If solid (or already refined once): publish api.approved
 
   implementer:
     name: "🔧 Implementer"

--- a/presets/code-archaeology.yml
+++ b/presets/code-archaeology.yml
@@ -90,4 +90,8 @@ hats:
       5. Verify nothing broke (run full test suite)
       6. Document any new artifacts you discovered
 
-      LOOP_COMPLETE when done.
+      When the task is complete: output LOOP_COMPLETE
+
+      If the task was just to document/understand (no code changes needed):
+      - Write findings to the specified output file
+      - Output LOOP_COMPLETE

--- a/presets/documentation-first.yml
+++ b/presets/documentation-first.yml
@@ -60,8 +60,14 @@ hats:
       - [ ] Are limitations called out?
       - [ ] Is there anything ambiguous?
 
-      If issues: publish docs.rejected with specific feedback
-      If solid: publish docs.approved
+      IMPORTANT: Be pragmatic. Only reject for fundamental issues that
+      would make implementation impossible. Minor gaps can be approved
+      with notes for the implementer to clarify.
+
+      After 1 rejection, approve with notes rather than rejecting again.
+
+      If critical issues: publish docs.rejected with specific feedback
+      If solid (or already revised once): publish docs.approved
 
   implementer:
     name: "⚙️ Implementer"

--- a/presets/mob-programming.yml
+++ b/presets/mob-programming.yml
@@ -13,7 +13,7 @@ hats:
     name: "🧭 Navigator"
     description: "Thinks strategically, gives clear instructions to driver."
     triggers: ["mob.start", "observation.noted"]
-    publishes: ["direction.set", "mob.complete"]
+    publishes: ["direction.set"]
     instructions: |
       You are the navigator. Think strategically.
 
@@ -29,7 +29,13 @@ hats:
 
       Do NOT write code yourself—describe what to write.
 
-      If task is complete: publish mob.complete → LOOP_COMPLETE
+      **Completion criteria** - task is complete when:
+      - All required functionality is implemented
+      - Tests pass (if applicable)
+      - Observer has no major concerns
+      - The code is ready for use
+
+      If task is complete: output LOOP_COMPLETE
       Otherwise: publish direction.set with your instructions
 
   driver:

--- a/presets/socratic-learning.yml
+++ b/presets/socratic-learning.yml
@@ -31,7 +31,7 @@ hats:
     name: "❓ Socratic Questioner"
     description: "Challenges understanding with probing questions."
     triggers: ["understanding.claimed"]
-    publishes: ["question.asked", "understanding.verified"]
+    publishes: ["question.asked"]
     instructions: |
       Challenge the Explorer's understanding with probing questions.
 
@@ -48,7 +48,10 @@ hats:
       - "How does this handle...?"
       - "What are the implications of...?"
 
-      If understanding is solid and complete: publish understanding.verified
+      If understanding is solid and complete after 2-3 rounds of questioning:
+      - Document the final understanding to the output file
+      - Output LOOP_COMPLETE
+
       Otherwise: publish question.asked with your challenge
 
   answerer:
@@ -66,5 +69,3 @@ hats:
       5. Publish answer.provided
 
       If you can't find the answer, say so honestly and explain what you tried.
-
-      When understanding.verified is published, output LOOP_COMPLETE.

--- a/presets/spec-driven.yml
+++ b/presets/spec-driven.yml
@@ -46,8 +46,15 @@ hats:
       - [ ] Are there ambiguous terms that need definition?
       - [ ] Are there missing scenarios?
 
+      NOTE: Be pragmatic. Don't reject specs for minor issues that
+      can be clarified during implementation. Only reject for:
+      - Fundamental ambiguity that would lead to wrong implementation
+      - Missing critical requirements
+
+      After 1 rejection, approve with notes rather than rejecting again.
+
       If issues found: publish spec.rejected with specific feedback
-      If solid: publish spec.approved
+      If solid (or already revised once): publish spec.approved
 
   implementer:
     name: "⚙️ Implementer"

--- a/tools/preset-test-tasks.yml
+++ b/tools/preset-test-tasks.yml
@@ -87,15 +87,17 @@ test_tasks:
     Use the expand-contract pattern. Document the plan in `.eval-sandbox/migration/plan.md`.
 
 # Complexity ratings for time budgeting
+# NOTE: Ratings based on actual iteration counts and per-iteration times observed
+# Multi-hat presets with exploration tend to run longer (~75-90s/iteration)
 complexity:
   hatless-baseline: medium
   tdd-red-green: simple
   adversarial-review: medium
-  socratic-learning: simple
+  socratic-learning: medium     # Up to 9 iterations with exploration - was incorrectly simple
   spec-driven: medium
-  mob-programming: simple
+  mob-programming: medium       # Multi-role preset runs longer - was incorrectly simple
   scientific-method: medium
-  code-archaeology: medium
+  code-archaeology: complex     # Git history exploration runs slow - was incorrectly medium
   performance-optimization: complex
   api-design: medium
   documentation-first: medium
@@ -119,11 +121,15 @@ expected_iterations:
   migration-safety: [4, 5]
 
 # Timeout per preset (seconds)
-# Based on ~45-60s per iteration:
-#   simple (3-6 iters): 6 × 60s = 360s → use 300s
-#   medium (4-8 iters): 8 × 60s = 480s → use 600s
-#   complex (4-8 iters): 8 × 75s = 600s → use 900s
+# Based on observed per-iteration times:
+#   - Simple presets: ~45-60s/iteration
+#   - Multi-hat presets: ~75-90s/iteration (context loading, exploration)
+#   - Complex presets: ~90-120s/iteration (git history, profiling)
+# Adding 50% buffer for API latency variance
+#   simple (3-6 iters): 6 × 75s = 450s → use 450s
+#   medium (4-9 iters): 9 × 90s = 810s → use 900s
+#   complex (4-8 iters): 8 × 120s = 960s → use 1200s
 timeouts:
-  simple: 300
-  medium: 600
-  complex: 900
+  simple: 450
+  medium: 900
+  complex: 1200


### PR DESCRIPTION
## Summary

- Add pragmatic review guidance to prevent infinite rejection loops in reviewer hats (api-design, documentation-first, spec-driven)
- Fix termination conditions in mob-programming and socratic-learning presets to use `LOOP_COMPLETE` correctly
- Update complexity ratings based on observed iteration counts (socratic-learning, mob-programming, code-archaeology)
- Increase timeouts to account for multi-hat presets with exploration (~75-90s/iteration)

## Test plan

- [ ] Run `cargo test` to verify no regressions
- [ ] Test affected presets with sample tasks to verify proper termination