### PR TITLE
feat: multi-loop concurrency via git worktrees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "crossterm 0.28.1",
+ "nix 0.29.0",
  "ralph-proto",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ colored = "3"
 
 # PTY support
 portable-pty = "0.9"
-nix = { version = "0.29", features = ["signal", "term"] }
+nix = { version = "0.29", features = ["signal", "term", "fs"] }
 vt100 = "0.15"
 scopeguard = "1"
 strip-ansi-escapes = "0.2"

--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,141 @@ ralph loops discard <id> -y        # Skip confirmation
 ralph loops prune
 ```
 
+### Auto-Merge Workflow
+
+When a worktree loop completes, it queues itself for merge. The primary loop processes this queue when it finishes:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Worktree Loop                         Primary Loop                  │
+│  ─────────────                         ─────────────                 │
+│  LOOP_COMPLETE                                                       │
+│       ↓                                                              │
+│  Queue for merge ─────────────────────→ [continues working]         │
+│       ↓                                       ↓                      │
+│  Exit cleanly                          LOOP_COMPLETE                 │
+│                                              ↓                       │
+│                                        Process merge queue           │
+│                                              ↓                       │
+│                                        Spawn merge-ralph             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The merge-ralph process uses a **hat collection** with specialized roles:
+
+| Hat | Trigger | Purpose |
+|-----|---------|---------|
+| `merger` | `merge.start` | Performs `git merge`, runs tests |
+| `resolver` | `conflict.detected` | Resolves merge conflicts by understanding intent |
+| `tester` | `conflict.resolved` | Verifies tests pass after conflict resolution |
+| `cleaner` | `merge.done` | Removes worktree and branch |
+| `failure_handler` | `*failed`, `unresolvable` | Marks loop for manual review |
+
+The workflow handles conflicts intelligently:
+1. **No conflicts**: Merge → Run tests → Clean up → Done
+2. **With conflicts**: Detect → AI resolves → Run tests → Clean up → Done
+3. **Unresolvable**: Abort → Mark for review → Keep worktree for manual fix
+
+### Conflict Resolution
+
+When merge conflicts occur, the AI resolver:
+
+1. Examines conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
+2. Understands the **intent** of both sides (not just the code)
+3. Resolves by preserving both intents when possible
+4. Prefers the loop's changes when directly contradictory (newer work)
+
+**Conflicts marked `needs-review`:**
+- Major architectural changes on both sides
+- Complex refactoring that can't be automatically reconciled
+- Business logic contradictions requiring human judgment
+
+To manually resolve:
+```bash
+# Enter the worktree
+ralph loops attach <loop-id>
+
+# Fix the issue, commit
+git add . && git commit -m "Manual conflict resolution"
+
+# Retry the merge
+ralph loops retry <loop-id>
+
+# Or discard if unneeded
+ralph loops discard <loop-id>
+```
+
+### Best Practices
+
+**When to use parallel loops:**
+- ✅ Independent features with minimal file overlap
+- ✅ Bug fixes while feature work continues
+- ✅ Documentation updates parallel to code changes
+- ✅ Test additions that don't conflict with active development
+
+**When to use `--exclusive` (sequential):**
+- ⚠️ Large refactoring touching many files
+- ⚠️ Database migrations or schema changes
+- ⚠️ Tasks that modify shared configuration files
+- ⚠️ Work that depends on changes from another in-progress loop
+
+**Tips for reducing conflicts:**
+- Keep loops focused on distinct areas of the codebase
+- Use separate files when adding new features
+- Avoid modifying the same functions in parallel loops
+- Let one loop complete before starting conflicting work
+
+### Troubleshooting
+
+**Loop stuck in `queued` state:**
+```bash
+# Check if primary loop is still running
+ralph loops
+
+# If primary finished but merge didn't start, manually trigger
+ralph loops retry <loop-id>
+```
+
+**Merge keeps failing:**
+```bash
+# View merge-ralph logs
+ralph loops logs <loop-id>
+
+# Check what changes conflict
+ralph loops diff <loop-id>
+
+# Manually resolve in worktree
+ralph loops attach <loop-id>
+```
+
+**Orphaned worktrees:**
+```bash
+# List and clean up orphans
+ralph loops prune
+
+# Force cleanup of specific worktree
+git worktree remove .worktrees/<loop-id> --force
+git branch -D ralph/<loop-id>
+```
+
+**Lock file issues:**
+```bash
+# Check who holds the lock
+cat .ralph/loop.lock
+
+# If process is dead, remove stale lock
+rm .ralph/loop.lock
+```
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `RALPH_MERGE_LOOP_ID` | Set by auto-merge to identify which loop to merge |
+| `RALPH_DIAGNOSTICS=1` | Enable detailed diagnostic logging |
+| `RALPH_VERBOSE=1` | Verbose output mode |
+| `RALPH_DEBUG_LOG=1` | Write debug logs to `.agent/ralph.log` |
+
 ## CLI Reference
 
 ### Commands

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ v1.0.0 was ralphed into existence with little oversight and guidance. v2.0.0 is 
 - [Presets](#presets)
 - [Key Concepts](#key-concepts)
 - [Orchestration and Coordination Patterns](#orchestration-and-coordination-patterns)
+- [Multi-Loop Concurrency](#multi-loop-concurrency)
 - [CLI Reference](#cli-reference)
 - [Architecture](#architecture)
 - [Building & Testing](#building--testing)
@@ -76,6 +77,7 @@ See [AGENTS.md](AGENTS.md) for the full philosophy.
 - **Interactive TUI** — Real-time terminal UI for monitoring Ralph's activity (enabled by default)
 - **Memories** — Persistent learning across sessions stored in `.agent/memories.md`
 - **Tasks** — Runtime work tracking stored in `.agent/tasks.jsonl`
+- **Multi-Loop Concurrency** — Run parallel loops in git worktrees with automatic merge workflow
 - **Session Recording** — Record and replay sessions for debugging and testing (experimental)
 
 ## Installation
@@ -924,6 +926,124 @@ Ralph enforces quality gates through backpressure. When a builder publishes `bui
 tests: pass, lint: pass, typecheck: pass
 ```
 
+## Multi-Loop Concurrency
+
+Ralph supports running multiple orchestration loops in parallel using git worktrees for filesystem isolation. This enables working on multiple tasks simultaneously without conflicts.
+
+### How It Works
+
+When you start a Ralph loop:
+
+1. **First loop** acquires `.ralph/loop.lock` and runs in-place (the primary loop)
+2. **Additional loops** automatically spawn into `.worktrees/<loop-id>/`
+3. **Each loop** has isolated events, tasks, and scratchpad
+4. **Memories are shared** — symlinked back to the main repo's `.agent/memories.md`
+5. **On completion**, worktree loops automatically spawn a merge-ralph to integrate changes
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Terminal 1                    │  Terminal 2                       │
+│  ralph run -p "Add auth"       │  ralph run -p "Add logging"       │
+│  [acquires lock, runs in-place]│  [spawns to worktree]             │
+│           ↓                    │           ↓                       │
+│     Primary loop               │  .worktrees/ralph-20250124-a3f2/  │
+│           ↓                    │           ↓                       │
+│     LOOP_COMPLETE              │     LOOP_COMPLETE → auto-merge    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Usage
+
+```bash
+# First loop acquires lock, runs in-place
+ralph run -p "Add authentication"
+
+# In another terminal — automatically spawns to worktree
+ralph run -p "Add logging"
+
+# Check running loops
+ralph loops
+
+# View logs from a specific loop
+ralph loops logs <loop-id>
+ralph loops logs <loop-id> --follow  # Real-time streaming
+
+# Force sequential execution (wait for lock)
+ralph run --exclusive -p "Task that needs main workspace"
+
+# Skip auto-merge (keep worktree for manual handling)
+ralph run --no-auto-merge -p "Experimental feature"
+```
+
+### Loop States
+
+| State | Description |
+|-------|-------------|
+| `running` | Loop is actively executing |
+| `queued` | Completed, waiting for merge |
+| `merging` | Merge operation in progress |
+| `merged` | Successfully merged to main |
+| `needs-review` | Merge failed, requires manual resolution |
+| `crashed` | Process died unexpectedly |
+| `orphan` | Worktree exists but not tracked |
+| `discarded` | Explicitly abandoned by user |
+
+### File Structure
+
+```
+project/
+├── .ralph/
+│   ├── loop.lock          # Primary loop indicator
+│   ├── loops.json         # Loop registry
+│   ├── merge-queue.jsonl  # Merge event log
+│   └── events.jsonl       # Primary loop events
+├── .agent/
+│   └── memories.md        # Shared across all loops
+└── .worktrees/
+    └── ralph-20250124-a3f2/
+        ├── .ralph/events.jsonl    # Loop-isolated
+        ├── .agent/
+        │   ├── memories.md → ../../.agent/memories.md  # Symlink
+        │   └── scratchpad.md      # Loop-isolated
+        └── [project files]
+```
+
+### Managing Loops
+
+```bash
+# List all loops with status
+ralph loops list
+
+# View loop output
+ralph loops logs <id>              # Full output
+ralph loops logs <id> --follow     # Stream real-time
+
+# View event history
+ralph loops history <id>           # Formatted table
+ralph loops history <id> --json    # Raw JSONL
+
+# Show changes from merge-base
+ralph loops diff <id>              # Full diff
+ralph loops diff <id> --stat       # Summary only
+
+# Open shell in worktree
+ralph loops attach <id>
+
+# Re-run merge for failed loop
+ralph loops retry <id>
+
+# Stop a running loop
+ralph loops stop <id>              # SIGTERM
+ralph loops stop <id> --force      # SIGKILL
+
+# Abandon loop and cleanup
+ralph loops discard <id>           # With confirmation
+ralph loops discard <id> -y        # Skip confirmation
+
+# Clean up stale loops (crashed processes)
+ralph loops prune
+```
+
 ## CLI Reference
 
 ### Commands
@@ -939,6 +1059,7 @@ tests: pass, lint: pass, typecheck: pass
 | `ralph clean` | Clean up `.agent/` directory |
 | `ralph emit` | Emit an event to the event log |
 | `ralph tools` | Runtime tools for memories and tasks (agent-facing) |
+| `ralph loops` | Manage parallel loops (list, logs, stop, merge) |
 
 ### Global Options
 
@@ -963,6 +1084,8 @@ tests: pass, lint: pass, typecheck: pass
 | `--record-session <FILE>` | Record session to JSONL |
 | `-q, --quiet` | Suppress output (for CI) |
 | `--continue` | Resume from existing scratchpad |
+| `--exclusive` | Wait for primary loop slot instead of spawning worktree |
+| `--no-auto-merge` | Skip automatic merge after worktree loop completes |
 
 ### `ralph init` Options
 
@@ -1006,6 +1129,22 @@ ralph tools task list                           # All tasks
 ralph tools task ready                          # Unblocked tasks only
 ralph tools task close <id>                     # Mark complete
 ```
+
+### `ralph loops` Subcommands
+
+Manage parallel loops running in git worktrees:
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | Show all loops with status (default) |
+| `logs <ID>` | View loop output (`--follow` for real-time) |
+| `history <ID>` | Show event history (`--json` for raw JSONL) |
+| `retry <ID>` | Re-run merge for `needs-review` loop |
+| `discard <ID>` | Abandon loop and cleanup worktree (`-y` to skip confirm) |
+| `stop <ID>` | Terminate running loop (`--force` for SIGKILL) |
+| `prune` | Clean up stale loops (crashed processes) |
+| `attach <ID>` | Open shell in loop's worktree |
+| `diff <ID>` | Show changes from merge-base (`--stat` for summary) |
 
 ## Architecture
 

--- a/crates/ralph-cli/presets/merge-loop.yml
+++ b/crates/ralph-cli/presets/merge-loop.yml
@@ -1,0 +1,315 @@
+# Merge Loop Preset
+#
+# Merges completed parallel loop from worktree back to main branch.
+# Designed to run automatically after worktree loops complete, resolving
+# conflicts via AI and verifying with tests.
+#
+# This preset reads the RALPH_MERGE_LOOP_ID environment variable to
+# identify which loop to merge. If not set, reads from the prompt.
+#
+# Usage (automatic, via auto-merge):
+#   After a worktree loop completes, Ralph spawns:
+#   RALPH_MERGE_LOOP_ID=a3f2 ralph run --preset builtin:merge-loop
+#
+# Usage (manual):
+#   ralph run --preset builtin:merge-loop -p "Merge loop ralph-20250124-a3f2"
+
+event_loop:
+  prompt: |
+    Merge the completed Ralph loop back to the main branch.
+
+    ## Context
+    - Check RALPH_MERGE_LOOP_ID environment variable for loop ID
+    - Or extract loop ID from this prompt if provided
+    - Loop branch format: ralph/{loop_id}
+    - Worktree location: .worktrees/{loop_id}
+
+    ## Your Task
+    Safely merge the loop's changes into the main branch, ensuring all tests pass.
+  completion_promise: "MERGE_COMPLETE"
+  max_iterations: 15
+  max_runtime_seconds: 1800
+  starting_event: "merge.start"
+
+cli:
+  backend: "auto"
+
+core:
+  specs_dir: "./specs/"
+
+hats:
+  merger:
+    name: "Branch Merger"
+    description: "Performs git merge with conflict resolution and test verification."
+    triggers: ["merge.start", "conflict.resolved", "tests.passed"]
+    publishes: ["merge.done", "conflict.detected", "merge.failed"]
+    default_publishes: "merge.done"
+    instructions: |
+      ## BRANCH MERGER MODE
+
+      Merge the completed Ralph loop branch into main.
+
+      ### Step 1: Identify the Loop
+
+      Check the RALPH_MERGE_LOOP_ID environment variable:
+      ```bash
+      echo $RALPH_MERGE_LOOP_ID
+      ```
+
+      If not set, extract the loop ID from the prompt (format: ralph-YYYYMMDD-HHMMSS-XXXX).
+
+      The branch to merge is: `ralph/{loop_id}`
+
+      ### Step 2: Review Changes
+
+      Before merging, understand what the loop accomplished:
+      ```bash
+      git diff main...ralph/{loop_id} --stat
+      git log main..ralph/{loop_id} --oneline
+      ```
+
+      ### Step 3: Attempt Merge
+
+      ```bash
+      git checkout main
+      git merge ralph/{loop_id} --no-edit
+      ```
+
+      ### If Merge Succeeds (No Conflicts)
+
+      1. Run the test suite:
+         ```bash
+         cargo test
+         ```
+
+      2. If tests pass, publish `merge.done` with the merge commit SHA
+
+      3. If tests fail, investigate and fix:
+         - The issue may be a subtle incompatibility
+         - Make minimal changes to fix
+         - Re-run tests until passing
+         - Commit the fix
+         - Then publish `merge.done`
+
+      ### If Conflicts Detected
+
+      Publish `conflict.detected` with:
+      - List of conflicted files
+      - Brief description of the conflict type (e.g., "both modified same function")
+
+      ### DON'T
+      - Don't merge if you can't identify the loop branch
+      - Don't skip running tests after merge
+      - Don't make unrelated changes
+      - Don't force push or rewrite history
+
+      ### DONE
+      When merge is complete and tests pass, output: MERGE_COMPLETE
+
+  resolver:
+    name: "Conflict Resolver"
+    description: "Resolves merge conflicts by understanding intent of both sides."
+    triggers: ["conflict.detected"]
+    publishes: ["conflict.resolved", "conflict.unresolvable"]
+    instructions: |
+      ## CONFLICT RESOLVER MODE
+
+      Resolve merge conflicts by understanding the intent of both sides.
+
+      ### Process
+
+      1. **List conflicted files:**
+         ```bash
+         git status --short | grep "^UU"
+         ```
+
+      2. **For each conflict:**
+
+         a. Read the file to understand the conflict markers:
+            - `<<<<<<< HEAD` — Main branch version
+            - `=======` — Separator
+            - `>>>>>>> ralph/{id}` — Loop branch version
+
+         b. Understand what each side intended:
+            - Main: What was the goal of these changes?
+            - Loop: What was the goal of these changes?
+
+         c. Resolve by preserving intent from BOTH sides:
+            - If features are independent, include both
+            - If features overlap, merge logic carefully
+            - If directly contradictory, prefer the loop's intent (it's newer)
+
+      3. **Mark resolved:**
+         ```bash
+         git add <file>
+         ```
+
+      4. **After all conflicts resolved:**
+         ```bash
+         git commit --no-edit
+         ```
+
+      5. **Publish `conflict.resolved`** to trigger test verification
+
+      ### If Unresolvable
+
+      Some conflicts can't be auto-resolved:
+      - Major architectural changes on both sides
+      - Complex refactoring conflicts
+      - Business logic contradictions requiring human decision
+
+      In these cases, publish `conflict.unresolvable` with:
+      - Detailed explanation of why
+      - What decision needs to be made
+      - Which files are affected
+
+      ### DON'T
+      - Don't delete code without understanding its purpose
+      - Don't resolve conflicts by just picking one side blindly
+      - Don't leave conflict markers in the code
+
+  tester:
+    name: "Test Verifier"
+    description: "Runs test suite to verify merge didn't break anything."
+    triggers: ["conflict.resolved"]
+    publishes: ["tests.passed", "tests.failed"]
+    instructions: |
+      ## TEST VERIFIER MODE
+
+      Verify the merge by running the complete test suite.
+
+      ### Process
+
+      1. **Run the test suite:**
+         ```bash
+         cargo test
+         ```
+
+      2. **If all tests pass:**
+         Publish `tests.passed`
+
+      3. **If tests fail:**
+         Publish `tests.failed` with:
+         - Which tests failed
+         - Brief analysis of why
+         - Suggested fix approach
+
+      ### Build Verification
+
+      Also verify the build is clean:
+      ```bash
+      cargo build
+      cargo clippy -- -D warnings
+      ```
+
+      ### DON'T
+      - Don't skip any test suites
+      - Don't ignore warnings if clippy fails
+      - Don't publish tests.passed if anything fails
+
+  cleaner:
+    name: "Worktree Cleaner"
+    description: "Cleans up worktree and branch after successful merge."
+    triggers: ["merge.done"]
+    publishes: ["cleanup.done", "cleanup.failed"]
+    instructions: |
+      ## WORKTREE CLEANER MODE
+
+      Clean up the worktree and branch after successful merge.
+
+      ### Step 1: Get Loop ID
+
+      Read from RALPH_MERGE_LOOP_ID or extract from context.
+
+      ### Step 2: Remove Worktree
+
+      ```bash
+      git worktree remove .worktrees/{loop_id} --force
+      ```
+
+      ### Step 3: Delete Branch
+
+      ```bash
+      git branch -D ralph/{loop_id}
+      ```
+
+      ### Step 4: Prune Refs
+
+      ```bash
+      git worktree prune
+      ```
+
+      ### Step 5: Update Merge Queue
+
+      Use ralph tools to mark the loop as merged:
+      ```bash
+      ralph emit "merge.complete" --json '{"loop_id": "{loop_id}", "status": "merged"}'
+      ```
+
+      ### Step 6: Publish Result
+
+      Publish `cleanup.done` to signal completion.
+
+      If any step fails, publish `cleanup.failed` with the error details.
+
+      ### DON'T
+      - Don't force-remove if there are uncommitted changes (investigate first)
+      - Don't delete wrong branches (always verify the ralph/ prefix)
+
+  failure_handler:
+    name: "Failure Handler"
+    description: "Handles unresolvable conflicts and marks loop for review."
+    triggers: ["conflict.unresolvable", "tests.failed", "merge.failed", "cleanup.failed"]
+    publishes: []
+    instructions: |
+      ## FAILURE HANDLER MODE
+
+      Handle merge failures by marking the loop for manual review.
+
+      ### Step 1: Assess the Failure
+
+      Understand what failed:
+      - `conflict.unresolvable` — Conflicts need human decision
+      - `tests.failed` — Merge broke something
+      - `merge.failed` — Merge operation itself failed
+      - `cleanup.failed` — Cleanup failed (merge may have succeeded)
+
+      ### Step 2: Abort Merge (if in progress)
+
+      If there's a merge in progress:
+      ```bash
+      git merge --abort
+      ```
+
+      ### Step 3: Update Merge Queue
+
+      Mark the loop as needing review:
+      ```bash
+      ralph emit "merge.needs_review" --json '{"loop_id": "{loop_id}", "reason": "{failure_reason}"}'
+      ```
+
+      ### Step 4: Provide Instructions
+
+      Output clear instructions for manual resolution:
+
+      ```
+      ## Manual Resolution Required
+
+      Loop {loop_id} could not be automatically merged.
+
+      **Reason:** {detailed explanation}
+
+      **To resolve:**
+      1. cd .worktrees/{loop_id}
+      2. Investigate the issue
+      3. Make necessary changes
+      4. Run: ralph loops retry {loop_id}
+
+      **To discard:**
+      Run: ralph loops discard {loop_id}
+      ```
+
+      ### DON'T
+      - Don't keep retrying indefinitely
+      - Don't leave merge in conflicted state
+      - Don't delete the worktree (user may need it)

--- a/crates/ralph-cli/presets/merge-loop.yml
+++ b/crates/ralph-cli/presets/merge-loop.yml
@@ -41,7 +41,7 @@ hats:
   merger:
     name: "Branch Merger"
     description: "Performs git merge with conflict resolution and test verification."
-    triggers: ["merge.start", "conflict.resolved", "tests.passed"]
+    triggers: ["merge.start", "tests.passed"]
     publishes: ["merge.done", "conflict.detected", "merge.failed"]
     default_publishes: "merge.done"
     instructions: |

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -10,8 +10,9 @@ use ralph_adapters::{
     PrettyStreamHandler, PtyConfig, PtyExecutor, QuietStreamHandler, TuiStreamHandler,
 };
 use ralph_core::{
-    EventLogger, EventLoop, EventParser, EventRecord, RalphConfig, Record, SessionRecorder,
-    SummaryWriter, TerminationReason,
+    CompletionAction, EventLogger, EventLoop, EventParser, EventRecord, LoopCompletionHandler,
+    LoopContext, LoopHistory, LoopRegistry, RalphConfig, Record, SessionRecorder, SummaryWriter,
+    TerminationReason,
 };
 use ralph_proto::{Event, HatId};
 use ralph_tui::Tui;
@@ -47,6 +48,7 @@ pub async fn run_loop_impl(
     enable_tui: bool,
     verbosity: Verbosity,
     record_session: Option<PathBuf>,
+    loop_context: Option<LoopContext>,
 ) -> Result<TerminationReason> {
     // Set up process group leadership per spec
     // "The orchestrator must run as a process group leader"
@@ -272,10 +274,29 @@ pub async fn run_loop_impl(
     let mut consecutive_fallbacks: u32 = 0;
     const MAX_FALLBACK_ATTEMPTS: u32 = 3;
 
-    // Helper closure to handle termination (writes summary, prints status)
+    // Initialize loop history if we have a loop context
+    let loop_history = loop_context
+        .as_ref()
+        .map(|ctx| LoopHistory::from_context(ctx));
+
+    // Record loop start in history
+    if let Some(ref history) = loop_history
+        && let Err(e) = history.record_started(&prompt_content)
+    {
+        warn!("Failed to record loop start in history: {}", e);
+    }
+
+    // Auto-merge setting (default: true; can be overridden by config later)
+    let auto_merge = true;
+
+    // Helper closure to handle termination (writes summary, prints status, records history)
     let handle_termination = |reason: &TerminationReason,
                               state: &ralph_core::LoopState,
-                              scratchpad: &str| {
+                              scratchpad: &str,
+                              history: &Option<LoopHistory>,
+                              context: &Option<LoopContext>,
+                              auto_merge: bool,
+                              prompt: &str| {
         // Per spec: Write summary file on termination
         let summary_writer = SummaryWriter::default();
         let scratchpad_path = std::path::Path::new(scratchpad);
@@ -291,6 +312,73 @@ pub async fn run_loop_impl(
         if let Err(e) = summary_writer.write(reason, state, scratchpad_opt, final_commit.as_deref())
         {
             warn!("Failed to write summary file: {}", e);
+        }
+
+        // Record termination in history
+        if let Some(hist) = history {
+            let reason_str = match reason {
+                TerminationReason::CompletionPromise => "completion_promise",
+                TerminationReason::MaxIterations => "max_iterations",
+                TerminationReason::MaxRuntime => "max_runtime",
+                TerminationReason::MaxCost => "max_cost",
+                TerminationReason::ConsecutiveFailures => "consecutive_failures",
+                TerminationReason::LoopThrashing => "loop_thrashing",
+                TerminationReason::ValidationFailure => "validation_failure",
+                TerminationReason::Stopped => "stopped",
+                TerminationReason::Interrupted => "interrupted",
+            };
+
+            if matches!(reason, TerminationReason::Interrupted) {
+                if let Err(e) = hist.record_terminated("SIGTERM") {
+                    warn!("Failed to record termination in history: {}", e);
+                }
+            } else if let Err(e) = hist.record_completed(reason_str) {
+                warn!("Failed to record completion in history: {}", e);
+            }
+        }
+
+        // Handle completion for worktree loops (auto-merge or manual)
+        if let Some(ctx) = context {
+            if !ctx.is_primary() && matches!(reason, TerminationReason::CompletionPromise) {
+                let handler = LoopCompletionHandler::new(auto_merge);
+                match handler.handle_completion(ctx, prompt) {
+                    Ok(CompletionAction::None) => {
+                        debug!("Primary loop completed, no action needed");
+                    }
+                    Ok(CompletionAction::Enqueued { loop_id }) => {
+                        info!(loop_id = %loop_id, "Loop queued for auto-merge");
+                        if let Some(hist) = history {
+                            let _ = hist.record_merge_queued();
+                        }
+                    }
+                    Ok(CompletionAction::ManualMerge {
+                        loop_id,
+                        worktree_path,
+                    }) => {
+                        info!(
+                            loop_id = %loop_id,
+                            "Loop completed. To merge manually: cd {} && git merge",
+                            worktree_path
+                        );
+                    }
+                    Err(e) => {
+                        warn!("Completion handler failed: {}", e);
+                    }
+                }
+            }
+
+            // Deregister from registry if terminated (not completed normally)
+            if matches!(
+                reason,
+                TerminationReason::Interrupted | TerminationReason::Stopped
+            ) {
+                let registry = LoopRegistry::new(ctx.repo_root());
+                if let Some(loop_id) = ctx.loop_id()
+                    && let Err(e) = registry.deregister(loop_id)
+                {
+                    warn!("Failed to deregister loop from registry: {}", e);
+                }
+            }
         }
 
         // Print termination info to console (skip in TUI mode - TUI handles display)
@@ -324,7 +412,15 @@ pub async fn run_loop_impl(
                 event_loop.state().iteration,
                 &terminate_event,
             );
-            handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+            handle_termination(
+                &reason,
+                event_loop.state(),
+                &config.core.scratchpad,
+                &loop_history,
+                &loop_context,
+                auto_merge,
+                &prompt_content,
+            );
             // Signal TUI to exit immediately on interrupt
             let _ = terminated_tx.send(true);
             return Ok(reason);
@@ -339,7 +435,15 @@ pub async fn run_loop_impl(
                 event_loop.state().iteration,
                 &terminate_event,
             );
-            handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+            handle_termination(
+                &reason,
+                event_loop.state(),
+                &config.core.scratchpad,
+                &loop_history,
+                &loop_context,
+                auto_merge,
+                &prompt_content,
+            );
             // Wait for user to exit TUI (press 'q') on natural completion
             if let Some(handle) = tui_handle.take() {
                 let _ = handle.await;
@@ -372,7 +476,15 @@ pub async fn run_loop_impl(
                         event_loop.state().iteration,
                         &terminate_event,
                     );
-                    handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+                    handle_termination(
+                        &reason,
+                        event_loop.state(),
+                        &config.core.scratchpad,
+                        &loop_history,
+                        &loop_context,
+                        auto_merge,
+                        &prompt_content,
+                    );
                     // Wait for user to exit TUI (press 'q') on natural completion
                     if let Some(handle) = tui_handle.take() {
                         let _ = handle.await;
@@ -399,7 +511,15 @@ pub async fn run_loop_impl(
                     event_loop.state().iteration,
                     &terminate_event,
                 );
-                handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+                handle_termination(
+                    &reason,
+                    event_loop.state(),
+                    &config.core.scratchpad,
+                    &loop_history,
+                    &loop_context,
+                    auto_merge,
+                    &prompt_content,
+                );
                 // Wait for user to exit TUI (press 'q') on natural completion
                 if let Some(handle) = tui_handle.take() {
                     let _ = handle.await;
@@ -540,7 +660,7 @@ pub async fn run_loop_impl(
                 let reason = TerminationReason::Interrupted;
                 let terminate_event = event_loop.publish_terminate_event(&reason);
                 log_terminate_event(&mut event_logger, event_loop.state().iteration, &terminate_event);
-                handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+                handle_termination(&reason, event_loop.state(), &config.core.scratchpad, &loop_history, &loop_context, auto_merge, &prompt_content);
                 // Signal TUI to exit immediately on interrupt
                 let _ = terminated_tx.send(true);
                 return Ok(reason);
@@ -554,7 +674,15 @@ pub async fn run_loop_impl(
                 event_loop.state().iteration,
                 &terminate_event,
             );
-            handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+            handle_termination(
+                &reason,
+                event_loop.state(),
+                &config.core.scratchpad,
+                &loop_history,
+                &loop_context,
+                auto_merge,
+                &prompt_content,
+            );
             // Wait for user to exit TUI (press 'q') on natural completion
             if let Some(handle) = tui_handle.take() {
                 let _ = handle.await;
@@ -593,7 +721,15 @@ pub async fn run_loop_impl(
                 event_loop.state().iteration,
                 &terminate_event,
             );
-            handle_termination(&reason, event_loop.state(), &config.core.scratchpad);
+            handle_termination(
+                &reason,
+                event_loop.state(),
+                &config.core.scratchpad,
+                &loop_history,
+                &loop_context,
+                auto_merge,
+                &prompt_content,
+            );
             // Wait for user to exit TUI (press 'q') on natural completion
             if let Some(handle) = tui_handle.take() {
                 let _ = handle.await;

--- a/crates/ralph-cli/src/loops.rs
+++ b/crates/ralph-cli/src/loops.rs
@@ -1,0 +1,666 @@
+//! CLI commands for the `ralph loops` namespace.
+//!
+//! Manage parallel Ralph loops running in git worktrees.
+//!
+//! Subcommands:
+//! - `list`: Show all loops (active, merging, merged, needs-review)
+//! - `logs`: View loop output
+//! - `history`: Show event history
+//! - `retry`: Re-run merge for failed loop
+//! - `discard`: Abandon loop and cleanup
+//! - `stop`: Terminate running loop
+//! - `prune`: Clean up stale loops
+//! - `attach`: Open shell in worktree
+//! - `diff`: Show changes from merge-base
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use clap::{Parser, Subcommand};
+
+use ralph_core::worktree::{list_ralph_worktrees, remove_worktree};
+use ralph_core::{LoopRegistry, MergeQueue, MergeState};
+
+/// Manage parallel loops.
+#[derive(Parser, Debug)]
+pub struct LoopsArgs {
+    #[command(subcommand)]
+    pub command: Option<LoopsCommands>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum LoopsCommands {
+    /// List all loops (default if no subcommand)
+    List,
+
+    /// View loop output/logs
+    Logs(LogsArgs),
+
+    /// Show event history for a loop
+    History(HistoryArgs),
+
+    /// Re-run merge for a failed loop
+    Retry(RetryArgs),
+
+    /// Abandon loop and clean up worktree
+    Discard(DiscardArgs),
+
+    /// Stop a running loop
+    Stop(StopArgs),
+
+    /// Clean up stale loops (crashed processes)
+    Prune,
+
+    /// Open shell in loop's worktree
+    Attach(AttachArgs),
+
+    /// Show diff of loop's changes from merge-base
+    Diff(DiffArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct LogsArgs {
+    /// Loop ID (e.g., ralph-20250124-a3f2 or just a3f2)
+    pub loop_id: String,
+
+    /// Follow output in real-time
+    #[arg(short, long)]
+    pub follow: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct HistoryArgs {
+    /// Loop ID
+    pub loop_id: String,
+
+    /// Output raw JSONL instead of formatted table
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct RetryArgs {
+    /// Loop ID
+    pub loop_id: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct DiscardArgs {
+    /// Loop ID
+    pub loop_id: String,
+
+    /// Skip confirmation prompt
+    #[arg(short = 'y', long)]
+    pub yes: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct StopArgs {
+    /// Loop ID
+    pub loop_id: String,
+
+    /// Use SIGKILL instead of SIGTERM
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct AttachArgs {
+    /// Loop ID
+    pub loop_id: String,
+}
+
+#[derive(Parser, Debug)]
+pub struct DiffArgs {
+    /// Loop ID
+    pub loop_id: String,
+
+    /// Show stat only (no diff content)
+    #[arg(long)]
+    pub stat: bool,
+}
+
+/// Execute a loops command.
+pub fn execute(args: LoopsArgs, use_colors: bool) -> Result<()> {
+    match args.command {
+        None | Some(LoopsCommands::List) => list_loops(use_colors),
+        Some(LoopsCommands::Logs(logs_args)) => show_logs(logs_args),
+        Some(LoopsCommands::History(history_args)) => show_history(history_args),
+        Some(LoopsCommands::Retry(retry_args)) => retry_merge(retry_args),
+        Some(LoopsCommands::Discard(discard_args)) => discard_loop(discard_args),
+        Some(LoopsCommands::Stop(stop_args)) => stop_loop(stop_args),
+        Some(LoopsCommands::Prune) => prune_stale(),
+        Some(LoopsCommands::Attach(attach_args)) => attach_to_loop(attach_args),
+        Some(LoopsCommands::Diff(diff_args)) => show_diff(diff_args),
+    }
+}
+
+/// List all loops with their status.
+fn list_loops(use_colors: bool) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let registry = LoopRegistry::new(&cwd);
+    let merge_queue = MergeQueue::new(&cwd);
+
+    // Get loops from registry
+    let loop_entries = registry.list().unwrap_or_default();
+
+    // Get worktrees for additional info
+    let worktrees = list_ralph_worktrees(&cwd).unwrap_or_default();
+
+    // Get merge queue entries
+    let merge_entries = merge_queue.list().unwrap_or_default();
+
+    // Build combined view
+    let mut rows: Vec<LoopRow> = Vec::new();
+
+    // Add running loops from registry
+    for entry in &loop_entries {
+        let status = if entry.is_alive() {
+            "running"
+        } else {
+            "crashed"
+        };
+
+        let location = entry
+            .worktree_path
+            .as_ref()
+            .map(|p| shorten_path(p))
+            .unwrap_or_else(|| "(in-place)".to_string());
+
+        rows.push(LoopRow {
+            id: entry.id.clone(),
+            status: status.to_string(),
+            location,
+            prompt: truncate(&entry.prompt, 40),
+        });
+    }
+
+    // Add merge queue entries not in registry
+    for entry in &merge_entries {
+        let already_listed = rows.iter().any(|r| r.id.ends_with(&entry.loop_id));
+        if !already_listed {
+            let status = match entry.state {
+                MergeState::Queued => "queued",
+                MergeState::Merging => "merging",
+                MergeState::Merged => "merged",
+                MergeState::NeedsReview => "needs-review",
+                MergeState::Discarded => "discarded",
+            };
+
+            rows.push(LoopRow {
+                id: entry.loop_id.clone(),
+                status: status.to_string(),
+                location: "-".to_string(),
+                prompt: truncate(&entry.prompt, 40),
+            });
+        }
+    }
+
+    // Add orphan worktrees (not in registry or merge queue)
+    for wt in &worktrees {
+        if wt.branch.starts_with("ralph/") {
+            let loop_id = wt.branch.trim_start_matches("ralph/");
+            let already_listed = rows.iter().any(|r| r.id.contains(loop_id));
+            if !already_listed {
+                rows.push(LoopRow {
+                    id: loop_id.to_string(),
+                    status: "orphan".to_string(),
+                    location: shorten_path(&wt.path.to_string_lossy()),
+                    prompt: String::new(),
+                });
+            }
+        }
+    }
+
+    if rows.is_empty() {
+        println!("No loops found.");
+        return Ok(());
+    }
+
+    // Print table
+    println!("{:<20} {:<12} {:<25} PROMPT", "ID", "STATUS", "LOCATION");
+    println!("{}", "-".repeat(80));
+
+    for row in rows {
+        let status_display = if use_colors {
+            colorize_status(&row.status)
+        } else {
+            row.status.clone()
+        };
+
+        println!(
+            "{:<20} {:<12} {:<25} {}",
+            truncate(&row.id, 20),
+            status_display,
+            truncate(&row.location, 25),
+            row.prompt
+        );
+    }
+
+    Ok(())
+}
+
+struct LoopRow {
+    id: String,
+    status: String,
+    location: String,
+    prompt: String,
+}
+
+fn colorize_status(status: &str) -> String {
+    match status {
+        "running" => format!("\x1b[32m{}\x1b[0m", status), // green
+        "merging" => format!("\x1b[33m{}\x1b[0m", status), // yellow
+        "merged" => format!("\x1b[34m{}\x1b[0m", status),  // blue
+        "needs-review" => format!("\x1b[31m{}\x1b[0m", status), // red
+        "crashed" => format!("\x1b[31m{}\x1b[0m", status), // red
+        "orphan" => format!("\x1b[90m{}\x1b[0m", status),  // gray
+        "queued" => format!("\x1b[36m{}\x1b[0m", status),  // cyan
+        "discarded" => format!("\x1b[90m{}\x1b[0m", status), // gray
+        _ => status.to_string(),
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}
+
+fn shorten_path(path: &str) -> String {
+    // Show just the last component or relative path
+    if let Some(last) = std::path::Path::new(path).file_name() {
+        last.to_string_lossy().to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+/// Show logs for a loop.
+fn show_logs(args: LogsArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let (loop_id, worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
+
+    let events_path = if let Some(wt_path) = worktree_path {
+        PathBuf::from(wt_path).join(".ralph/events.jsonl")
+    } else {
+        cwd.join(".ralph/events.jsonl")
+    };
+
+    if !events_path.exists() {
+        bail!("No events file found for loop '{}'", loop_id);
+    }
+
+    if args.follow {
+        // Use tail -f for following
+        let status = Command::new("tail")
+            .args(["-f", events_path.to_string_lossy().as_ref()])
+            .status()
+            .context("Failed to run tail")?;
+
+        if !status.success() {
+            bail!("tail exited with error");
+        }
+    } else {
+        // Just cat the file
+        let contents =
+            std::fs::read_to_string(&events_path).context("Failed to read events file")?;
+        print!("{}", contents);
+    }
+
+    Ok(())
+}
+
+/// Show history for a loop.
+fn show_history(args: HistoryArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let (loop_id, worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
+
+    let history_path = if let Some(wt_path) = worktree_path {
+        PathBuf::from(wt_path).join(".ralph/history.jsonl")
+    } else {
+        cwd.join(".ralph/history.jsonl")
+    };
+
+    if !history_path.exists() {
+        bail!("No history file found for loop '{}'", loop_id);
+    }
+
+    let contents = std::fs::read_to_string(&history_path).context("Failed to read history file")?;
+
+    if args.json {
+        print!("{}", contents);
+    } else {
+        // Format as table
+        println!("{:<25} {:<20} DATA", "TIMESTAMP", "TYPE");
+        println!("{}", "-".repeat(80));
+
+        for line in contents.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(event) = serde_json::from_str::<serde_json::Value>(line) {
+                let ts = event.get("ts").and_then(|v| v.as_str()).unwrap_or("-");
+                let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("-");
+                let data = event.get("data").map(|v| v.to_string()).unwrap_or_default();
+                println!(
+                    "{:<25} {:<20} {}",
+                    truncate(ts, 25),
+                    event_type,
+                    truncate(&data, 35)
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Retry merge for a failed loop.
+fn retry_merge(args: RetryArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let merge_queue = MergeQueue::new(&cwd);
+
+    let entry = merge_queue
+        .get_entry(&args.loop_id)?
+        .context(format!("Loop '{}' not found in merge queue", args.loop_id))?;
+
+    if entry.state != MergeState::NeedsReview {
+        bail!(
+            "Loop '{}' is in state {:?}, can only retry 'needs-review' loops",
+            args.loop_id,
+            entry.state
+        );
+    }
+
+    // Spawn merge-ralph
+    println!("Spawning merge-ralph for loop '{}'...", args.loop_id);
+
+    let status = Command::new("ralph")
+        .args([
+            "run",
+            "--preset",
+            "builtin:merge-loop",
+            "-p",
+            &format!(
+                "Merge loop {} from branch ralph/{}",
+                args.loop_id, args.loop_id
+            ),
+        ])
+        .env("RALPH_MERGE_LOOP_ID", &args.loop_id)
+        .status()
+        .context("Failed to spawn merge-ralph")?;
+
+    if !status.success() {
+        bail!("merge-ralph exited with error");
+    }
+
+    Ok(())
+}
+
+/// Discard a loop and clean up.
+fn discard_loop(args: DiscardArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let (loop_id, worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
+
+    // Confirmation unless -y
+    if !args.yes {
+        eprintln!(
+            "This will permanently discard loop '{}' and delete its worktree.",
+            loop_id
+        );
+        eprintln!("Continue? [y/N] ");
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Update merge queue
+    let merge_queue = MergeQueue::new(&cwd);
+    if let Ok(Some(_)) = merge_queue.get_entry(&loop_id) {
+        merge_queue.discard(&loop_id, Some("User requested discard"))?;
+    }
+
+    // Deregister from registry
+    let registry = LoopRegistry::new(&cwd);
+    let _ = registry.deregister(&loop_id);
+
+    // Remove worktree if exists
+    if let Some(wt_path) = worktree_path {
+        println!("Removing worktree at {}...", wt_path);
+        remove_worktree(&cwd, &wt_path)?;
+    }
+
+    println!("Loop '{}' discarded.", loop_id);
+    Ok(())
+}
+
+/// Stop a running loop.
+fn stop_loop(args: StopArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let registry = LoopRegistry::new(&cwd);
+
+    let entry = registry
+        .get(&args.loop_id)?
+        .context(format!("Loop '{}' not found in registry", args.loop_id))?;
+
+    if !entry.is_alive() {
+        bail!(
+            "Loop '{}' is not running (process {} not found)",
+            args.loop_id,
+            entry.pid
+        );
+    }
+
+    let signal = if args.force { "SIGKILL" } else { "SIGTERM" };
+    println!(
+        "Sending {} to loop '{}' (PID {})...",
+        signal, args.loop_id, entry.pid
+    );
+
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+
+        let sig = if args.force {
+            Signal::SIGKILL
+        } else {
+            Signal::SIGTERM
+        };
+
+        kill(Pid::from_raw(entry.pid as i32), sig).context("Failed to send signal")?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        bail!("Stopping loops is only supported on Unix systems");
+    }
+
+    println!("Signal sent.");
+    Ok(())
+}
+
+/// Prune stale loops.
+fn prune_stale() -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let registry = LoopRegistry::new(&cwd);
+
+    let count = registry.clean_stale()?;
+
+    if count == 0 {
+        println!("No stale loops found.");
+    } else {
+        println!("Cleaned up {} stale loop(s).", count);
+    }
+
+    // Also check for orphan worktrees
+    let worktrees = list_ralph_worktrees(&cwd).unwrap_or_default();
+    let loop_entries = registry.list().unwrap_or_default();
+
+    let mut orphan_count = 0;
+    for wt in worktrees {
+        if wt.branch.starts_with("ralph/") {
+            let loop_id = wt.branch.trim_start_matches("ralph/");
+            let in_registry = loop_entries.iter().any(|e| e.id.contains(loop_id));
+            if !in_registry {
+                println!(
+                    "Found orphan worktree: {} (branch: {})",
+                    wt.path.display(),
+                    wt.branch
+                );
+                orphan_count += 1;
+            }
+        }
+    }
+
+    if orphan_count > 0 {
+        println!("\nTo remove orphan worktrees, use: ralph loops discard <id>");
+    }
+
+    Ok(())
+}
+
+/// Attach to a loop's worktree.
+fn attach_to_loop(args: AttachArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let (loop_id, worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
+
+    let wt_path = worktree_path.context(format!(
+        "Loop '{}' is not a worktree-based loop (it runs in-place)",
+        loop_id
+    ))?;
+
+    println!("Attaching to loop '{}' at {}...", loop_id, wt_path);
+    println!("Type 'exit' to return.\n");
+
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+
+    let status = Command::new(&shell)
+        .current_dir(&wt_path)
+        .status()
+        .context("Failed to spawn shell")?;
+
+    if !status.success() {
+        bail!("Shell exited with error");
+    }
+
+    Ok(())
+}
+
+/// Show diff for a loop.
+fn show_diff(args: DiffArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let (loop_id, _worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
+
+    // Find the branch
+    let branch = format!("ralph/{}", loop_id);
+
+    // Check if branch exists
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", &branch])
+        .current_dir(&cwd)
+        .output()
+        .context("Failed to run git")?;
+
+    if !output.status.success() {
+        bail!("Branch '{}' not found", branch);
+    }
+
+    // Show diff from merge-base
+    let mut git_args = vec!["diff", "main..."];
+    git_args.push(&branch);
+
+    if args.stat {
+        git_args.push("--stat");
+    }
+
+    let status = Command::new("git")
+        .args(&git_args)
+        .current_dir(&cwd)
+        .status()
+        .context("Failed to run git diff")?;
+
+    if !status.success() {
+        bail!("git diff failed");
+    }
+
+    Ok(())
+}
+
+/// Resolve a loop ID to its full ID and worktree path (if any).
+fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<String>)> {
+    let registry = LoopRegistry::new(cwd);
+    let merge_queue = MergeQueue::new(cwd);
+
+    // Try exact match in registry
+    if let Ok(Some(entry)) = registry.get(id) {
+        return Ok((entry.id.clone(), entry.worktree_path.clone()));
+    }
+
+    // Try partial match (e.g., "a3f2" matches "ralph-20250124-143052-a3f2")
+    if let Ok(entries) = registry.list() {
+        for entry in entries {
+            if entry.id.ends_with(id) || entry.id.contains(id) {
+                return Ok((entry.id.clone(), entry.worktree_path.clone()));
+            }
+        }
+    }
+
+    // Try merge queue
+    if let Ok(Some(entry)) = merge_queue.get_entry(id) {
+        // Look up worktree from worktrees list
+        let worktrees = list_ralph_worktrees(cwd).unwrap_or_default();
+        let wt_path = worktrees
+            .iter()
+            .find(|wt| wt.branch.ends_with(&entry.loop_id))
+            .map(|wt| wt.path.to_string_lossy().to_string());
+
+        return Ok((entry.loop_id.clone(), wt_path));
+    }
+
+    // Try worktrees directly
+    let worktrees = list_ralph_worktrees(cwd).unwrap_or_default();
+    for wt in worktrees {
+        if wt.branch.ends_with(id) || wt.branch.contains(id) {
+            let loop_id = wt.branch.trim_start_matches("ralph/").to_string();
+            return Ok((loop_id, Some(wt.path.to_string_lossy().to_string())));
+        }
+    }
+
+    bail!("Loop '{}' not found", id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate() {
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("hello world", 8), "hello...");
+        assert_eq!(truncate("hi", 2), "hi");
+    }
+
+    #[test]
+    fn test_colorize_status() {
+        // Just verify it returns something with escape codes for colored statuses
+        assert!(colorize_status("running").contains("\x1b["));
+        assert!(colorize_status("merged").contains("\x1b["));
+        // Unknown status returns as-is
+        assert_eq!(colorize_status("unknown"), "unknown");
+    }
+
+    #[test]
+    fn test_shorten_path() {
+        assert_eq!(shorten_path("/foo/bar/baz"), "baz");
+        assert_eq!(shorten_path("./worktrees/ralph-abc"), "ralph-abc");
+    }
+}

--- a/crates/ralph-cli/src/loops.rs
+++ b/crates/ralph-cli/src/loops.rs
@@ -439,14 +439,20 @@ fn retry_merge(args: RetryArgs) -> Result<()> {
         );
     }
 
+    // Get the merge-loop preset and write to config file
+    let preset = crate::presets::get_preset("merge-loop").context("merge-loop preset not found")?;
+
+    let config_path = cwd.join(".ralph/merge-loop-config.yml");
+    std::fs::write(&config_path, preset.content).context("Failed to write merge config file")?;
+
     // Spawn merge-ralph
     println!("Spawning merge-ralph for loop '{}'...", args.loop_id);
 
     let status = Command::new("ralph")
         .args([
             "run",
-            "--preset",
-            "builtin:merge-loop",
+            "-c",
+            ".ralph/merge-loop-config.yml",
             "-p",
             &format!(
                 "Merge loop {} from branch ralph/{}",

--- a/crates/ralph-cli/src/presets.rs
+++ b/crates/ralph-cli/src/presets.rs
@@ -83,6 +83,11 @@ const PRESETS: &[EmbeddedPreset] = &[
         content: include_str!("../presets/incident-response.yml"),
     },
     EmbeddedPreset {
+        name: "merge-loop",
+        description: "Merges completed parallel loop from worktree back to main branch",
+        content: include_str!("../presets/merge-loop.yml"),
+    },
+    EmbeddedPreset {
         name: "migration-safety",
         description: "Safe Database/API Migration Workflow",
         content: include_str!("../presets/migration-safety.yml"),
@@ -163,7 +168,7 @@ mod tests {
     #[test]
     fn test_list_presets_returns_all() {
         let presets = list_presets();
-        assert_eq!(presets.len(), 24, "Expected 24 presets");
+        assert_eq!(presets.len(), 25, "Expected 25 presets");
     }
 
     #[test]
@@ -199,6 +204,23 @@ mod tests {
                 .content
                 .contains("If you were triggered by `confession.clean`:")
         );
+    }
+
+    #[test]
+    fn test_merge_loop_preset_is_embedded() {
+        let preset = get_preset("merge-loop").expect("merge-loop preset should exist");
+        assert_eq!(
+            preset.description,
+            "Merges completed parallel loop from worktree back to main branch"
+        );
+        // Verify key merge-related content
+        assert!(preset.content.contains("RALPH_MERGE_LOOP_ID"));
+        assert!(preset.content.contains("merge.start"));
+        assert!(preset.content.contains("MERGE_COMPLETE"));
+        assert!(preset.content.contains("conflict.detected"));
+        assert!(preset.content.contains("conflict.resolved"));
+        assert!(preset.content.contains("git merge"));
+        assert!(preset.content.contains("git worktree remove"));
     }
 
     #[test]
@@ -245,9 +267,10 @@ mod tests {
     #[test]
     fn test_preset_names_returns_all_names() {
         let names = preset_names();
-        assert_eq!(names.len(), 24);
+        assert_eq!(names.len(), 25);
         assert!(names.contains(&"confession-loop"));
         assert!(names.contains(&"tdd-red-green"));
         assert!(names.contains(&"debug"));
+        assert!(names.contains(&"merge-loop"));
     }
 }

--- a/crates/ralph-core/Cargo.toml
+++ b/crates/ralph-core/Cargo.toml
@@ -24,5 +24,9 @@ chrono.workspace = true
 crossterm.workspace = true
 regex.workspace = true
 
+# For Unix file locking (flock)
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
+
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/ralph-core/src/event_logger.rs
+++ b/crates/ralph-core/src/event_logger.rs
@@ -3,6 +3,7 @@
 //! Logs all events to `.ralph/events.jsonl` as specified in the event-loop spec.
 //! The observer pattern allows hooking into the event bus without modifying routing.
 
+use crate::loop_context::LoopContext;
 use ralph_proto::{Event, HatId};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fs::{self, File, OpenOptions};
@@ -153,6 +154,14 @@ impl EventLogger {
         Self::new(Self::DEFAULT_PATH)
     }
 
+    /// Creates a logger using the events path from a LoopContext.
+    ///
+    /// This ensures the logger writes to the correct location when running
+    /// in a worktree or other isolated workspace.
+    pub fn from_context(context: &LoopContext) -> Self {
+        Self::new(context.events_path())
+    }
+
     /// Ensures the parent directory exists and opens the file.
     fn ensure_open(&mut self) -> std::io::Result<&mut File> {
         if self.file.is_none() {
@@ -210,6 +219,14 @@ impl EventHistory {
     /// Creates a reader for the default path.
     pub fn default_path() -> Self {
         Self::new(EventLogger::DEFAULT_PATH)
+    }
+
+    /// Creates a history reader using the events path from a LoopContext.
+    ///
+    /// This ensures the reader looks in the correct location when running
+    /// in a worktree or other isolated workspace.
+    pub fn from_context(context: &LoopContext) -> Self {
+        Self::new(context.events_path())
     }
 
     /// Returns true if the history file exists.

--- a/crates/ralph-core/src/file_lock.rs
+++ b/crates/ralph-core/src/file_lock.rs
@@ -1,0 +1,493 @@
+//! File locking for shared resources in multi-loop scenarios.
+//!
+//! Provides fine-grained file locking using `flock()` for concurrent access
+//! to shared resources like `.agent/tasks.jsonl` and `.agent/memories.md`.
+//! This enables multiple Ralph loops (in worktrees) to safely read and write
+//! shared state files.
+//!
+//! # Design
+//!
+//! - **Shared locks** for reading: Multiple readers can hold shared locks simultaneously
+//! - **Exclusive locks** for writing: Only one writer at a time, blocks readers
+//! - **Blocking by default**: Operations wait for lock availability
+//! - **RAII guards**: Locks are automatically released when guards are dropped
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ralph_core::file_lock::FileLock;
+//!
+//! fn read_tasks(path: &std::path::Path) -> std::io::Result<String> {
+//!     let lock = FileLock::new(path)?;
+//!     let _guard = lock.shared()?;  // Acquire shared lock
+//!     std::fs::read_to_string(path)
+//! }
+//!
+//! fn write_tasks(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+//!     let lock = FileLock::new(path)?;
+//!     let _guard = lock.exclusive()?;  // Acquire exclusive lock
+//!     std::fs::write(path, content)
+//! }
+//! ```
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// A file lock for coordinating concurrent access to shared files.
+///
+/// Uses a `.lock` file alongside the target file for locking.
+/// This avoids issues with locking the target file directly
+/// (which can interfere with truncation/replacement).
+#[derive(Debug)]
+pub struct FileLock {
+    /// Path to the lock file.
+    lock_path: PathBuf,
+}
+
+impl FileLock {
+    /// Creates a new file lock for the given path.
+    ///
+    /// The lock file is created at `{path}.lock`.
+    /// The parent directory is created if it doesn't exist.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        let path = path.as_ref();
+        let lock_path = path.with_extension(format!(
+            "{}.lock",
+            path.extension()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default()
+        ));
+
+        // Ensure parent directory exists
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        Ok(Self { lock_path })
+    }
+
+    /// Acquires a shared (read) lock.
+    ///
+    /// Multiple processes can hold shared locks simultaneously.
+    /// Blocks until the lock is available.
+    pub fn shared(&self) -> io::Result<LockGuard> {
+        self.acquire(LockType::Shared)
+    }
+
+    /// Tries to acquire a shared (read) lock without blocking.
+    ///
+    /// Returns `Ok(None)` if the lock is not available.
+    pub fn try_shared(&self) -> io::Result<Option<LockGuard>> {
+        self.try_acquire(LockType::Shared)
+    }
+
+    /// Acquires an exclusive (write) lock.
+    ///
+    /// Only one process can hold an exclusive lock.
+    /// Blocks until the lock is available.
+    pub fn exclusive(&self) -> io::Result<LockGuard> {
+        self.acquire(LockType::Exclusive)
+    }
+
+    /// Tries to acquire an exclusive (write) lock without blocking.
+    ///
+    /// Returns `Ok(None)` if the lock is not available.
+    pub fn try_exclusive(&self) -> io::Result<Option<LockGuard>> {
+        self.try_acquire(LockType::Exclusive)
+    }
+
+    /// Acquires a lock of the specified type (blocking).
+    fn acquire(&self, lock_type: LockType) -> io::Result<LockGuard> {
+        let file = self.open_lock_file()?;
+
+        #[cfg(unix)]
+        {
+            use nix::fcntl::{Flock, FlockArg};
+
+            let arg = match lock_type {
+                LockType::Shared => FlockArg::LockShared,
+                LockType::Exclusive => FlockArg::LockExclusive,
+            };
+
+            match Flock::lock(file, arg) {
+                Ok(flock) => Ok(LockGuard {
+                    _flock: flock,
+                    _lock_type: lock_type,
+                }),
+                Err((_, errno)) => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("flock failed: {}", errno),
+                )),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = (file, lock_type);
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "File locking not supported on this platform",
+            ))
+        }
+    }
+
+    /// Tries to acquire a lock of the specified type (non-blocking).
+    fn try_acquire(&self, lock_type: LockType) -> io::Result<Option<LockGuard>> {
+        let file = self.open_lock_file()?;
+
+        #[cfg(unix)]
+        {
+            use nix::errno::Errno;
+            use nix::fcntl::{Flock, FlockArg};
+
+            let arg = match lock_type {
+                LockType::Shared => FlockArg::LockSharedNonblock,
+                LockType::Exclusive => FlockArg::LockExclusiveNonblock,
+            };
+
+            match Flock::lock(file, arg) {
+                Ok(flock) => Ok(Some(LockGuard {
+                    _flock: flock,
+                    _lock_type: lock_type,
+                })),
+                Err((_, errno)) if errno == Errno::EWOULDBLOCK || errno == Errno::EAGAIN => {
+                    Ok(None)
+                }
+                Err((_, errno)) => Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("flock failed: {}", errno),
+                )),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = (file, lock_type);
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "File locking not supported on this platform",
+            ))
+        }
+    }
+
+    /// Opens or creates the lock file.
+    fn open_lock_file(&self) -> io::Result<File> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.lock_path)
+    }
+
+    /// Returns the path to the lock file.
+    pub fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+}
+
+/// Type of lock to acquire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LockType {
+    /// Shared (read) lock - multiple holders allowed.
+    Shared,
+    /// Exclusive (write) lock - single holder only.
+    Exclusive,
+}
+
+/// A guard that holds the file lock. The lock is released when dropped.
+#[derive(Debug)]
+pub struct LockGuard {
+    /// The flock guard (Unix only).
+    #[cfg(unix)]
+    _flock: nix::fcntl::Flock<File>,
+
+    /// The type of lock held.
+    _lock_type: LockType,
+}
+
+/// A locked file that provides safe read/write access.
+///
+/// This is a convenience wrapper that combines file locking with
+/// read/write operations in a single API.
+pub struct LockedFile {
+    lock: FileLock,
+}
+
+impl LockedFile {
+    /// Creates a new locked file handle for the given path.
+    pub fn new(path: impl AsRef<Path>) -> io::Result<Self> {
+        Ok(Self {
+            lock: FileLock::new(path)?,
+        })
+    }
+
+    /// Reads the file contents with a shared lock.
+    ///
+    /// If the file doesn't exist, returns an empty string.
+    pub fn read(&self, path: &Path) -> io::Result<String> {
+        let _guard = self.lock.shared()?;
+        if path.exists() {
+            std::fs::read_to_string(path)
+        } else {
+            Ok(String::new())
+        }
+    }
+
+    /// Writes content to the file with an exclusive lock.
+    pub fn write(&self, path: &Path, content: &str) -> io::Result<()> {
+        let _guard = self.lock.exclusive()?;
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, content)
+    }
+
+    /// Executes a read operation with a shared lock.
+    pub fn with_shared_lock<T, F>(&self, f: F) -> io::Result<T>
+    where
+        F: FnOnce() -> io::Result<T>,
+    {
+        let _guard = self.lock.shared()?;
+        f()
+    }
+
+    /// Executes a write operation with an exclusive lock.
+    pub fn with_exclusive_lock<T, F>(&self, f: F) -> io::Result<T>
+    where
+        F: FnOnce() -> io::Result<T>,
+    {
+        let _guard = self.lock.exclusive()?;
+        f()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_lock_file_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.jsonl");
+
+        let lock = FileLock::new(&file_path).unwrap();
+        assert_eq!(lock.lock_path(), temp_dir.path().join("test.jsonl.lock"));
+    }
+
+    #[test]
+    fn test_lock_file_path_no_extension() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("tasks");
+
+        let lock = FileLock::new(&file_path).unwrap();
+        assert_eq!(lock.lock_path(), temp_dir.path().join("tasks..lock"));
+    }
+
+    #[test]
+    fn test_shared_lock_acquired() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let lock = FileLock::new(&file_path).unwrap();
+        let guard = lock.shared();
+        assert!(guard.is_ok());
+    }
+
+    #[test]
+    fn test_exclusive_lock_acquired() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let lock = FileLock::new(&file_path).unwrap();
+        let guard = lock.exclusive();
+        assert!(guard.is_ok());
+    }
+
+    #[test]
+    fn test_multiple_shared_locks() {
+        // Multiple shared locks should be allowed
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let lock1 = FileLock::new(&file_path).unwrap();
+        let lock2 = FileLock::new(&file_path).unwrap();
+
+        let _guard1 = lock1.shared().unwrap();
+        let guard2 = lock2.try_shared();
+
+        // Should be able to acquire second shared lock
+        assert!(guard2.is_ok());
+        assert!(guard2.unwrap().is_some());
+    }
+
+    #[test]
+    fn test_exclusive_blocks_shared() {
+        // Exclusive lock should block new shared locks
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let lock1 = FileLock::new(&file_path).unwrap();
+        let lock2 = FileLock::new(&file_path).unwrap();
+
+        let _guard1 = lock1.exclusive().unwrap();
+        let guard2 = lock2.try_shared();
+
+        // Should not be able to acquire shared lock while exclusive is held
+        assert!(guard2.is_ok());
+        assert!(guard2.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_shared_blocks_exclusive() {
+        // Shared lock should block exclusive locks
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let lock1 = FileLock::new(&file_path).unwrap();
+        let lock2 = FileLock::new(&file_path).unwrap();
+
+        let _guard1 = lock1.shared().unwrap();
+        let guard2 = lock2.try_exclusive();
+
+        // Should not be able to acquire exclusive lock while shared is held
+        assert!(guard2.is_ok());
+        assert!(guard2.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_lock_released_on_drop() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let lock1 = FileLock::new(&file_path).unwrap();
+        let lock2 = FileLock::new(&file_path).unwrap();
+
+        {
+            let _guard1 = lock1.exclusive().unwrap();
+            // Lock is held
+        }
+        // Guard dropped, lock released
+
+        // Should be able to acquire exclusive lock now
+        let guard2 = lock2.try_exclusive();
+        assert!(guard2.is_ok());
+        assert!(guard2.unwrap().is_some());
+    }
+
+    #[test]
+    fn test_locked_file_read_write() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let locked = LockedFile::new(&file_path).unwrap();
+
+        // Write content
+        locked.write(&file_path, "Hello, World!").unwrap();
+
+        // Read content
+        let content = locked.read(&file_path).unwrap();
+        assert_eq!(content, "Hello, World!");
+    }
+
+    #[test]
+    fn test_locked_file_read_nonexistent() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("nonexistent.txt");
+
+        let locked = LockedFile::new(&file_path).unwrap();
+        let content = locked.read(&file_path).unwrap();
+        assert!(content.is_empty());
+    }
+
+    #[test]
+    fn test_concurrent_writes_serialized() {
+        // Test that concurrent writes are properly serialized
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("counter.txt");
+        let file_path_clone = file_path.clone();
+
+        // Initialize file
+        std::fs::write(&file_path, "0").unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        let handle1 = thread::spawn(move || {
+            let locked = LockedFile::new(&file_path).unwrap();
+            barrier.wait();
+
+            locked
+                .with_exclusive_lock(|| {
+                    let content = std::fs::read_to_string(&file_path)?;
+                    let n: i32 = content.trim().parse().unwrap_or(0);
+                    // Small delay to increase chance of race condition without lock
+                    thread::sleep(Duration::from_millis(10));
+                    std::fs::write(&file_path, format!("{}", n + 1))
+                })
+                .unwrap();
+        });
+
+        let handle2 = thread::spawn(move || {
+            let locked = LockedFile::new(&file_path_clone).unwrap();
+            barrier_clone.wait();
+
+            locked
+                .with_exclusive_lock(|| {
+                    let content = std::fs::read_to_string(&file_path_clone)?;
+                    let n: i32 = content.trim().parse().unwrap_or(0);
+                    thread::sleep(Duration::from_millis(10));
+                    std::fs::write(&file_path_clone, format!("{}", n + 1))
+                })
+                .unwrap();
+        });
+
+        handle1.join().unwrap();
+        handle2.join().unwrap();
+
+        // With proper locking, final value should be 2
+        let final_content = std::fs::read_to_string(temp_dir.path().join("counter.txt")).unwrap();
+        assert_eq!(final_content.trim(), "2");
+    }
+
+    #[test]
+    fn test_blocking_lock_waits() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("wait.txt");
+        let file_path_clone = file_path.clone();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        let handle1 = thread::spawn(move || {
+            let lock = FileLock::new(&file_path).unwrap();
+            let _guard = lock.exclusive().unwrap();
+
+            barrier.wait();
+            // Hold lock for a bit
+            thread::sleep(Duration::from_millis(50));
+            // Guard dropped here
+        });
+
+        let start = Instant::now();
+        let handle2 = thread::spawn(move || {
+            let lock = FileLock::new(&file_path_clone).unwrap();
+            barrier_clone.wait();
+
+            // This should block until handle1 releases the lock
+            let _guard = lock.exclusive().unwrap();
+        });
+
+        handle1.join().unwrap();
+        handle2.join().unwrap();
+
+        // Second thread should have waited
+        assert!(start.elapsed() >= Duration::from_millis(40));
+    }
+}

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -17,12 +17,19 @@ mod event_logger;
 mod event_loop;
 mod event_parser;
 mod event_reader;
+pub mod file_lock;
 mod hat_registry;
 mod hatless_ralph;
 mod instructions;
+pub mod loop_completion;
+pub mod loop_context;
+pub mod loop_history;
+pub mod loop_lock;
+pub mod loop_registry;
 mod memory;
 pub mod memory_parser;
 mod memory_store;
+pub mod merge_queue;
 mod session_player;
 mod session_recorder;
 mod summary_writer;
@@ -33,6 +40,7 @@ pub mod testing;
 mod text;
 pub mod utils;
 pub mod workspace;
+pub mod worktree;
 
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
@@ -44,12 +52,21 @@ pub use event_logger::{EventHistory, EventLogger, EventRecord};
 pub use event_loop::{EventLoop, LoopState, TerminationReason};
 pub use event_parser::EventParser;
 pub use event_reader::{Event, EventReader, MalformedLine, ParseResult};
+pub use file_lock::{FileLock, LockGuard as FileLockGuard, LockedFile};
 pub use hat_registry::HatRegistry;
 pub use hatless_ralph::{HatInfo, HatTopology, HatlessRalph};
 pub use instructions::InstructionBuilder;
+pub use loop_completion::{CompletionAction, CompletionError, LoopCompletionHandler};
+pub use loop_context::LoopContext;
+pub use loop_history::{HistoryError, HistoryEvent, HistoryEventType, HistorySummary, LoopHistory};
+pub use loop_lock::{LockError, LockGuard, LockMetadata, LoopLock};
+pub use loop_registry::{LoopEntry, LoopRegistry, RegistryError};
 pub use memory::{Memory, MemoryType};
 pub use memory_store::{
     DEFAULT_MEMORIES_PATH, MarkdownMemoryStore, format_memories_as_markdown, truncate_to_budget,
+};
+pub use merge_queue::{
+    MergeEntry, MergeEvent, MergeEventType, MergeQueue, MergeQueueError, MergeState,
 };
 pub use session_player::{PlayerConfig, ReplayMode, SessionPlayer, TimestampedRecord};
 pub use session_recorder::{Record, SessionRecorder};
@@ -63,4 +80,8 @@ pub use text::truncate_with_ellipsis;
 pub use workspace::{
     CleanupPolicy, TaskWorkspace, VerificationResult, WorkspaceError, WorkspaceInfo,
     WorkspaceManager,
+};
+pub use worktree::{
+    Worktree, WorktreeConfig, WorktreeError, create_worktree, ensure_gitignore,
+    list_ralph_worktrees, list_worktrees, remove_worktree, worktree_exists,
 };

--- a/crates/ralph-core/src/loop_completion.rs
+++ b/crates/ralph-core/src/loop_completion.rs
@@ -1,0 +1,239 @@
+//! Loop completion handler for worktree-based loops.
+//!
+//! Handles post-completion actions for loops running in git worktrees,
+//! including auto-merge queue integration.
+//!
+//! # Design
+//!
+//! When a loop completes successfully (CompletionPromise):
+//! - **Primary loop**: No special handling (runs in main workspace)
+//! - **Worktree loop with auto-merge**: Enqueue to merge queue for merge-ralph
+//! - **Worktree loop without auto-merge**: Log completion, leave worktree for manual merge
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ralph_core::loop_completion::{LoopCompletionHandler, CompletionAction};
+//! use ralph_core::loop_context::LoopContext;
+//! use std::path::PathBuf;
+//!
+//! // Primary loop - no special action
+//! let primary = LoopContext::primary(PathBuf::from("/project"));
+//! let handler = LoopCompletionHandler::new(true); // auto_merge enabled
+//! let action = handler.handle_completion(&primary, "implement auth").unwrap();
+//! assert!(matches!(action, CompletionAction::None));
+//!
+//! // Worktree loop with auto-merge - enqueues to merge queue
+//! let worktree = LoopContext::worktree(
+//!     "ralph-20250124-a3f2",
+//!     PathBuf::from("/project/.worktrees/ralph-20250124-a3f2"),
+//!     PathBuf::from("/project"),
+//! );
+//! let action = handler.handle_completion(&worktree, "implement auth").unwrap();
+//! assert!(matches!(action, CompletionAction::Enqueued { .. }));
+//! ```
+
+use crate::loop_context::LoopContext;
+use crate::merge_queue::{MergeQueue, MergeQueueError};
+use tracing::{debug, info};
+
+/// Action taken upon loop completion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompletionAction {
+    /// No action needed (primary loop or non-worktree context).
+    None,
+
+    /// Loop was enqueued to the merge queue.
+    Enqueued {
+        /// The loop ID that was enqueued.
+        loop_id: String,
+    },
+
+    /// Auto-merge is disabled; worktree left for manual handling.
+    ManualMerge {
+        /// The loop ID.
+        loop_id: String,
+        /// Path to the worktree directory.
+        worktree_path: String,
+    },
+}
+
+/// Errors that can occur during completion handling.
+#[derive(Debug, thiserror::Error)]
+pub enum CompletionError {
+    /// Failed to enqueue to merge queue.
+    #[error("Failed to enqueue to merge queue: {0}")]
+    EnqueueFailed(#[from] MergeQueueError),
+}
+
+/// Handler for loop completion events.
+///
+/// Determines the appropriate action when a loop completes based on
+/// whether it's a worktree loop and the auto-merge configuration.
+pub struct LoopCompletionHandler {
+    /// Whether auto-merge is enabled (default: true).
+    auto_merge: bool,
+}
+
+impl Default for LoopCompletionHandler {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl LoopCompletionHandler {
+    /// Creates a new completion handler.
+    ///
+    /// # Arguments
+    ///
+    /// * `auto_merge` - If true, completed worktree loops are enqueued for merge-ralph.
+    ///   If false, worktrees are left for manual merge.
+    pub fn new(auto_merge: bool) -> Self {
+        Self { auto_merge }
+    }
+
+    /// Handles loop completion, taking appropriate action based on context.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - The loop context (primary or worktree)
+    /// * `prompt` - The prompt that was executed (for merge queue metadata)
+    ///
+    /// # Returns
+    ///
+    /// The action that was taken, or an error if the action failed.
+    pub fn handle_completion(
+        &self,
+        context: &LoopContext,
+        prompt: &str,
+    ) -> Result<CompletionAction, CompletionError> {
+        // Primary loops don't need special handling
+        if context.is_primary() {
+            debug!("Primary loop completed - no special action needed");
+            return Ok(CompletionAction::None);
+        }
+
+        // Get loop ID from context (worktree loops always have one)
+        let loop_id = match context.loop_id() {
+            Some(id) => id.to_string(),
+            None => {
+                // Shouldn't happen for worktree contexts, but handle gracefully
+                debug!("Loop completed without loop ID - treating as primary");
+                return Ok(CompletionAction::None);
+            }
+        };
+
+        let worktree_path = context.workspace().to_string_lossy().to_string();
+
+        if self.auto_merge {
+            // Enqueue to merge queue for automatic merge-ralph processing
+            let queue = MergeQueue::new(context.repo_root());
+            queue.enqueue(&loop_id, prompt)?;
+
+            info!(
+                loop_id = %loop_id,
+                worktree = %worktree_path,
+                "Loop completed and enqueued for auto-merge"
+            );
+
+            Ok(CompletionAction::Enqueued { loop_id })
+        } else {
+            // Leave worktree for manual handling
+            info!(
+                loop_id = %loop_id,
+                worktree = %worktree_path,
+                "Loop completed - worktree preserved for manual merge (--no-auto-merge)"
+            );
+
+            Ok(CompletionAction::ManualMerge {
+                loop_id,
+                worktree_path,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_primary_loop_no_action() {
+        let temp = TempDir::new().unwrap();
+        let context = LoopContext::primary(temp.path().to_path_buf());
+        let handler = LoopCompletionHandler::new(true);
+
+        let action = handler.handle_completion(&context, "test prompt").unwrap();
+        assert_eq!(action, CompletionAction::None);
+    }
+
+    #[test]
+    fn test_worktree_loop_auto_merge_enqueues() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().to_path_buf();
+        let worktree_path = repo_root.join(".worktrees/ralph-test-1234");
+
+        // Create necessary directories
+        std::fs::create_dir_all(&worktree_path).unwrap();
+        std::fs::create_dir_all(repo_root.join(".ralph")).unwrap();
+
+        let context = LoopContext::worktree("ralph-test-1234", worktree_path, repo_root.clone());
+
+        let handler = LoopCompletionHandler::new(true); // auto_merge enabled
+
+        let action = handler
+            .handle_completion(&context, "implement feature X")
+            .unwrap();
+
+        match action {
+            CompletionAction::Enqueued { loop_id } => {
+                assert_eq!(loop_id, "ralph-test-1234");
+
+                // Verify it was actually enqueued
+                let queue = MergeQueue::new(&repo_root);
+                let entry = queue.get_entry("ralph-test-1234").unwrap().unwrap();
+                assert_eq!(entry.prompt, "implement feature X");
+            }
+            _ => panic!("Expected Enqueued action, got {:?}", action),
+        }
+    }
+
+    #[test]
+    fn test_worktree_loop_no_auto_merge_manual() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().to_path_buf();
+        let worktree_path = repo_root.join(".worktrees/ralph-test-5678");
+
+        std::fs::create_dir_all(&worktree_path).unwrap();
+
+        let context =
+            LoopContext::worktree("ralph-test-5678", worktree_path.clone(), repo_root.clone());
+
+        let handler = LoopCompletionHandler::new(false); // auto_merge disabled
+
+        let action = handler.handle_completion(&context, "test prompt").unwrap();
+
+        match action {
+            CompletionAction::ManualMerge {
+                loop_id,
+                worktree_path: path,
+            } => {
+                assert_eq!(loop_id, "ralph-test-5678");
+                assert_eq!(path, worktree_path.to_string_lossy());
+            }
+            _ => panic!("Expected ManualMerge action, got {:?}", action),
+        }
+
+        // Verify nothing was enqueued
+        let queue = MergeQueue::new(&repo_root);
+        let entry = queue.get_entry("ralph-test-5678").unwrap();
+        assert!(entry.is_none());
+    }
+
+    #[test]
+    fn test_default_handler_has_auto_merge_enabled() {
+        let handler = LoopCompletionHandler::default();
+        assert!(handler.auto_merge);
+    }
+}

--- a/crates/ralph-core/src/loop_context.rs
+++ b/crates/ralph-core/src/loop_context.rs
@@ -1,0 +1,471 @@
+//! Loop context for path resolution in multi-loop scenarios.
+//!
+//! When running multiple Ralph loops concurrently, each loop needs its own
+//! isolated paths for state files (events, tasks, scratchpad) while sharing
+//! memories across loops for cross-loop learning.
+//!
+//! # Design
+//!
+//! - **Primary loop**: Runs in the main workspace, paths resolve to standard locations
+//! - **Worktree loop**: Runs in a git worktree, paths resolve to worktree-local locations
+//! - **Shared memories**: Memories are symlinked in worktrees, pointing to main workspace
+//!
+//! # Example
+//!
+//! ```
+//! use ralph_core::loop_context::LoopContext;
+//! use std::path::PathBuf;
+//!
+//! // Primary loop runs in current directory
+//! let primary = LoopContext::primary(PathBuf::from("/project"));
+//! assert_eq!(primary.events_path().to_string_lossy(), "/project/.ralph/events.jsonl");
+//! assert_eq!(primary.tasks_path().to_string_lossy(), "/project/.agent/tasks.jsonl");
+//!
+//! // Worktree loop runs in isolated directory
+//! let worktree = LoopContext::worktree(
+//!     "loop-1234-abcd",
+//!     PathBuf::from("/project/.worktrees/loop-1234-abcd"),
+//!     PathBuf::from("/project"),
+//! );
+//! assert_eq!(worktree.events_path().to_string_lossy(),
+//!            "/project/.worktrees/loop-1234-abcd/.ralph/events.jsonl");
+//! ```
+
+use std::path::{Path, PathBuf};
+
+/// Context for resolving paths within a Ralph loop.
+///
+/// Encapsulates the working directory and loop identity, providing
+/// consistent path resolution for all loop-local state files.
+#[derive(Debug, Clone)]
+pub struct LoopContext {
+    /// The loop identifier (None for primary loop).
+    loop_id: Option<String>,
+
+    /// Working directory for this loop.
+    /// For primary: the repo root.
+    /// For worktree: the worktree directory.
+    workspace: PathBuf,
+
+    /// The main repo root (for memory symlink target).
+    /// Same as workspace for primary loops.
+    repo_root: PathBuf,
+
+    /// Whether this is the primary loop (holds loop.lock).
+    is_primary: bool,
+}
+
+impl LoopContext {
+    /// Creates context for the primary loop running in the main workspace.
+    ///
+    /// The primary loop holds the loop lock and runs directly in the
+    /// repository root without filesystem isolation.
+    pub fn primary(workspace: PathBuf) -> Self {
+        Self {
+            loop_id: None,
+            repo_root: workspace.clone(),
+            workspace,
+            is_primary: true,
+        }
+    }
+
+    /// Creates context for a worktree-based loop.
+    ///
+    /// Worktree loops run in isolated git worktrees with their own
+    /// `.ralph/` and `.agent/` directories, but share memories via symlink.
+    ///
+    /// # Arguments
+    ///
+    /// * `loop_id` - Unique identifier for this loop (e.g., "loop-1234-abcd")
+    /// * `worktree_path` - Path to the worktree directory
+    /// * `repo_root` - Path to the main repository root (for memory symlink)
+    pub fn worktree(
+        loop_id: impl Into<String>,
+        worktree_path: PathBuf,
+        repo_root: PathBuf,
+    ) -> Self {
+        Self {
+            loop_id: Some(loop_id.into()),
+            workspace: worktree_path,
+            repo_root,
+            is_primary: false,
+        }
+    }
+
+    /// Returns the loop identifier, if any.
+    ///
+    /// Primary loops return None; worktree loops return their unique ID.
+    pub fn loop_id(&self) -> Option<&str> {
+        self.loop_id.as_deref()
+    }
+
+    /// Returns true if this is the primary loop.
+    pub fn is_primary(&self) -> bool {
+        self.is_primary
+    }
+
+    /// Returns the workspace root for this loop.
+    ///
+    /// This is the directory where the loop executes:
+    /// - Primary: the repo root
+    /// - Worktree: the worktree directory
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    /// Returns the main repository root.
+    ///
+    /// For worktree loops, this is different from `workspace()` and
+    /// is used to locate shared resources like the main memories file.
+    pub fn repo_root(&self) -> &Path {
+        &self.repo_root
+    }
+
+    // -------------------------------------------------------------------------
+    // Path resolution methods
+    // -------------------------------------------------------------------------
+
+    /// Path to the `.ralph/` directory for this loop.
+    pub fn ralph_dir(&self) -> PathBuf {
+        self.workspace.join(".ralph")
+    }
+
+    /// Path to the `.agent/` directory for this loop.
+    pub fn agent_dir(&self) -> PathBuf {
+        self.workspace.join(".agent")
+    }
+
+    /// Path to the events JSONL file.
+    ///
+    /// Each loop has its own isolated events file.
+    pub fn events_path(&self) -> PathBuf {
+        self.ralph_dir().join("events.jsonl")
+    }
+
+    /// Path to the current-events marker file.
+    ///
+    /// This file contains the path to the active events file.
+    pub fn current_events_marker(&self) -> PathBuf {
+        self.ralph_dir().join("current-events")
+    }
+
+    /// Path to the tasks JSONL file.
+    ///
+    /// Each loop has its own isolated tasks file.
+    pub fn tasks_path(&self) -> PathBuf {
+        self.agent_dir().join("tasks.jsonl")
+    }
+
+    /// Path to the scratchpad markdown file.
+    ///
+    /// Each loop has its own isolated scratchpad.
+    pub fn scratchpad_path(&self) -> PathBuf {
+        self.agent_dir().join("scratchpad.md")
+    }
+
+    /// Path to the memories markdown file.
+    ///
+    /// For primary loops, this is the actual memories file.
+    /// For worktree loops, this is a symlink to the main repo's memories.
+    pub fn memories_path(&self) -> PathBuf {
+        self.agent_dir().join("memories.md")
+    }
+
+    /// Path to the main repository's memories file.
+    ///
+    /// Used to create symlinks in worktree loops.
+    pub fn main_memories_path(&self) -> PathBuf {
+        self.repo_root.join(".agent").join("memories.md")
+    }
+
+    /// Path to the summary markdown file.
+    ///
+    /// Each loop has its own isolated summary.
+    pub fn summary_path(&self) -> PathBuf {
+        self.agent_dir().join("summary.md")
+    }
+
+    /// Path to the diagnostics directory.
+    ///
+    /// Each loop has its own diagnostics output.
+    pub fn diagnostics_dir(&self) -> PathBuf {
+        self.ralph_dir().join("diagnostics")
+    }
+
+    /// Path to the loop history JSONL file.
+    ///
+    /// Event-sourced history for crash recovery and debugging.
+    pub fn history_path(&self) -> PathBuf {
+        self.ralph_dir().join("history.jsonl")
+    }
+
+    /// Path to the loop lock file (only meaningful for primary loop detection).
+    pub fn loop_lock_path(&self) -> PathBuf {
+        // Lock is always in the main repo root
+        self.repo_root.join(".ralph").join("loop.lock")
+    }
+
+    /// Path to the merge queue JSONL file.
+    ///
+    /// The merge queue is shared across all loops (in main repo).
+    pub fn merge_queue_path(&self) -> PathBuf {
+        self.repo_root.join(".ralph").join("merge-queue.jsonl")
+    }
+
+    /// Path to the loop registry JSON file.
+    ///
+    /// The registry is shared across all loops (in main repo).
+    pub fn loop_registry_path(&self) -> PathBuf {
+        self.repo_root.join(".ralph").join("loops.json")
+    }
+
+    // -------------------------------------------------------------------------
+    // Directory management
+    // -------------------------------------------------------------------------
+
+    /// Ensures the `.ralph/` directory exists.
+    pub fn ensure_ralph_dir(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(self.ralph_dir())
+    }
+
+    /// Ensures the `.agent/` directory exists.
+    pub fn ensure_agent_dir(&self) -> std::io::Result<()> {
+        std::fs::create_dir_all(self.agent_dir())
+    }
+
+    /// Ensures both `.ralph/` and `.agent/` directories exist.
+    pub fn ensure_directories(&self) -> std::io::Result<()> {
+        self.ensure_ralph_dir()?;
+        self.ensure_agent_dir()
+    }
+
+    /// Creates the memory symlink in a worktree pointing to main repo.
+    ///
+    /// This is only relevant for worktree loops. For primary loops,
+    /// this is a no-op.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` - Symlink was created
+    /// - `Ok(false)` - Already exists or is primary loop
+    /// - `Err(_)` - Symlink creation failed
+    #[cfg(unix)]
+    pub fn setup_memory_symlink(&self) -> std::io::Result<bool> {
+        if self.is_primary {
+            return Ok(false);
+        }
+
+        let memories_path = self.memories_path();
+        let main_memories = self.main_memories_path();
+
+        // Skip if already exists (symlink or file)
+        if memories_path.exists() || memories_path.is_symlink() {
+            return Ok(false);
+        }
+
+        // Ensure parent directory exists
+        self.ensure_agent_dir()?;
+
+        // Create symlink
+        std::os::unix::fs::symlink(&main_memories, &memories_path)?;
+        Ok(true)
+    }
+
+    /// Creates the memory symlink in a worktree (non-Unix stub).
+    #[cfg(not(unix))]
+    pub fn setup_memory_symlink(&self) -> std::io::Result<bool> {
+        // On non-Unix platforms, we don't create symlinks
+        // (worktree mode not supported)
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_primary_context() {
+        let ctx = LoopContext::primary(PathBuf::from("/project"));
+
+        assert!(ctx.is_primary());
+        assert!(ctx.loop_id().is_none());
+        assert_eq!(ctx.workspace(), Path::new("/project"));
+        assert_eq!(ctx.repo_root(), Path::new("/project"));
+    }
+
+    #[test]
+    fn test_worktree_context() {
+        let ctx = LoopContext::worktree(
+            "loop-1234-abcd",
+            PathBuf::from("/project/.worktrees/loop-1234-abcd"),
+            PathBuf::from("/project"),
+        );
+
+        assert!(!ctx.is_primary());
+        assert_eq!(ctx.loop_id(), Some("loop-1234-abcd"));
+        assert_eq!(
+            ctx.workspace(),
+            Path::new("/project/.worktrees/loop-1234-abcd")
+        );
+        assert_eq!(ctx.repo_root(), Path::new("/project"));
+    }
+
+    #[test]
+    fn test_primary_path_resolution() {
+        let ctx = LoopContext::primary(PathBuf::from("/project"));
+
+        assert_eq!(ctx.ralph_dir(), PathBuf::from("/project/.ralph"));
+        assert_eq!(ctx.agent_dir(), PathBuf::from("/project/.agent"));
+        assert_eq!(
+            ctx.events_path(),
+            PathBuf::from("/project/.ralph/events.jsonl")
+        );
+        assert_eq!(
+            ctx.tasks_path(),
+            PathBuf::from("/project/.agent/tasks.jsonl")
+        );
+        assert_eq!(
+            ctx.scratchpad_path(),
+            PathBuf::from("/project/.agent/scratchpad.md")
+        );
+        assert_eq!(
+            ctx.memories_path(),
+            PathBuf::from("/project/.agent/memories.md")
+        );
+        assert_eq!(
+            ctx.summary_path(),
+            PathBuf::from("/project/.agent/summary.md")
+        );
+        assert_eq!(
+            ctx.diagnostics_dir(),
+            PathBuf::from("/project/.ralph/diagnostics")
+        );
+        assert_eq!(
+            ctx.history_path(),
+            PathBuf::from("/project/.ralph/history.jsonl")
+        );
+    }
+
+    #[test]
+    fn test_worktree_path_resolution() {
+        let ctx = LoopContext::worktree(
+            "loop-1234-abcd",
+            PathBuf::from("/project/.worktrees/loop-1234-abcd"),
+            PathBuf::from("/project"),
+        );
+
+        // Loop-local paths resolve to worktree
+        assert_eq!(
+            ctx.ralph_dir(),
+            PathBuf::from("/project/.worktrees/loop-1234-abcd/.ralph")
+        );
+        assert_eq!(
+            ctx.events_path(),
+            PathBuf::from("/project/.worktrees/loop-1234-abcd/.ralph/events.jsonl")
+        );
+        assert_eq!(
+            ctx.tasks_path(),
+            PathBuf::from("/project/.worktrees/loop-1234-abcd/.agent/tasks.jsonl")
+        );
+        assert_eq!(
+            ctx.scratchpad_path(),
+            PathBuf::from("/project/.worktrees/loop-1234-abcd/.agent/scratchpad.md")
+        );
+
+        // Memories path is in worktree (symlink to main repo)
+        assert_eq!(
+            ctx.memories_path(),
+            PathBuf::from("/project/.worktrees/loop-1234-abcd/.agent/memories.md")
+        );
+
+        // Main memories path is in repo root
+        assert_eq!(
+            ctx.main_memories_path(),
+            PathBuf::from("/project/.agent/memories.md")
+        );
+
+        // Shared resources resolve to main repo
+        assert_eq!(
+            ctx.loop_lock_path(),
+            PathBuf::from("/project/.ralph/loop.lock")
+        );
+        assert_eq!(
+            ctx.merge_queue_path(),
+            PathBuf::from("/project/.ralph/merge-queue.jsonl")
+        );
+        assert_eq!(
+            ctx.loop_registry_path(),
+            PathBuf::from("/project/.ralph/loops.json")
+        );
+    }
+
+    #[test]
+    fn test_ensure_directories() {
+        let temp = TempDir::new().unwrap();
+        let ctx = LoopContext::primary(temp.path().to_path_buf());
+
+        // Directories don't exist initially
+        assert!(!ctx.ralph_dir().exists());
+        assert!(!ctx.agent_dir().exists());
+
+        // Create them
+        ctx.ensure_directories().unwrap();
+
+        // Now they exist
+        assert!(ctx.ralph_dir().exists());
+        assert!(ctx.agent_dir().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_memory_symlink_primary_noop() {
+        let temp = TempDir::new().unwrap();
+        let ctx = LoopContext::primary(temp.path().to_path_buf());
+
+        // Primary loop doesn't create symlinks
+        let created = ctx.setup_memory_symlink().unwrap();
+        assert!(!created);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_memory_symlink_worktree() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().to_path_buf();
+        let worktree_path = repo_root.join(".worktrees/loop-1234");
+
+        // Create the main memories file
+        std::fs::create_dir_all(repo_root.join(".agent")).unwrap();
+        std::fs::write(repo_root.join(".agent/memories.md"), "# Memories\n").unwrap();
+
+        let ctx = LoopContext::worktree("loop-1234", worktree_path.clone(), repo_root.clone());
+
+        // Create symlink
+        ctx.ensure_agent_dir().unwrap();
+        let created = ctx.setup_memory_symlink().unwrap();
+        assert!(created);
+
+        // Verify symlink exists and points to main memories
+        let memories = ctx.memories_path();
+        assert!(memories.is_symlink());
+        assert_eq!(
+            std::fs::read_link(&memories).unwrap(),
+            ctx.main_memories_path()
+        );
+
+        // Second call is a no-op
+        let created_again = ctx.setup_memory_symlink().unwrap();
+        assert!(!created_again);
+    }
+
+    #[test]
+    fn test_current_events_marker() {
+        let ctx = LoopContext::primary(PathBuf::from("/project"));
+        assert_eq!(
+            ctx.current_events_marker(),
+            PathBuf::from("/project/.ralph/current-events")
+        );
+    }
+}

--- a/crates/ralph-core/src/loop_history.rs
+++ b/crates/ralph-core/src/loop_history.rs
@@ -1,0 +1,589 @@
+//! Event-sourced loop history for crash recovery and debugging.
+//!
+//! Each loop maintains an append-only event log in `.ralph/history.jsonl`.
+//! This provides:
+//! - **Crash recovery**: Resume from last known state after crash
+//! - **Debugging**: Replay loop execution to understand failures
+//! - **Auditing**: Complete trace of what happened and when
+//! - **Source of truth**: Registry state can be derived from history
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::file_lock::FileLock;
+
+/// Errors that can occur during history operations.
+#[derive(Debug, Error)]
+pub enum HistoryError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON serialization error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// A single event in the loop history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEvent {
+    /// Timestamp when the event occurred.
+    #[serde(rename = "ts")]
+    pub timestamp: DateTime<Utc>,
+
+    /// Type of the event.
+    #[serde(rename = "type")]
+    pub event_type: HistoryEventType,
+
+    /// Optional additional data.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl HistoryEvent {
+    /// Create a new history event with current timestamp.
+    pub fn new(event_type: HistoryEventType) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            event_type,
+            data: None,
+        }
+    }
+
+    /// Create a new history event with data.
+    pub fn with_data(event_type: HistoryEventType, data: serde_json::Value) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            event_type,
+            data: Some(data),
+        }
+    }
+}
+
+/// Types of events that can be recorded in loop history.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HistoryEventType {
+    /// Loop started with given prompt.
+    LoopStarted { prompt: String },
+
+    /// Iteration started.
+    IterationStarted { iteration: u32 },
+
+    /// An event was published during the iteration.
+    EventPublished { topic: String, payload: String },
+
+    /// Iteration completed.
+    IterationCompleted { iteration: u32, success: bool },
+
+    /// Loop completed successfully.
+    LoopCompleted { reason: String },
+
+    /// Loop was resumed from a previous state.
+    LoopResumed { from_iteration: u32 },
+
+    /// Loop was terminated (SIGTERM or similar).
+    LoopTerminated { signal: String },
+
+    /// Loop was queued for merge.
+    MergeQueued,
+
+    /// Merge-ralph started.
+    MergeStarted { pid: u32 },
+
+    /// Merge completed successfully.
+    MergeCompleted { commit: String },
+
+    /// Merge failed.
+    MergeFailed { reason: String },
+
+    /// Loop was discarded.
+    LoopDiscarded { reason: String },
+}
+
+/// Loop history manager for a single loop.
+///
+/// Wraps an append-only JSONL file for recording loop events.
+pub struct LoopHistory {
+    path: PathBuf,
+}
+
+impl LoopHistory {
+    /// Create a new loop history at the given path.
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Create a loop history from a loop context.
+    pub fn from_context(context: &crate::LoopContext) -> Self {
+        Self::new(context.history_path())
+    }
+
+    /// Get the path to the history file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append an event to the history file.
+    ///
+    /// This is thread-safe via file locking.
+    pub fn append(&self, event: HistoryEvent) -> Result<(), HistoryError> {
+        // Ensure parent directory exists
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Acquire exclusive lock
+        let file_lock = FileLock::new(&self.path)?;
+        let _lock = file_lock.exclusive()?;
+
+        // Open file in append mode
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+
+        // Serialize and write
+        let json = serde_json::to_string(&event)?;
+        writeln!(file, "{}", json)?;
+        file.flush()?;
+
+        Ok(())
+    }
+
+    /// Read all events from the history file.
+    pub fn read_all(&self) -> Result<Vec<HistoryEvent>, HistoryError> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+
+        // Acquire shared lock
+        let file_lock = FileLock::new(&self.path)?;
+        let _lock = file_lock.shared()?;
+
+        let file = File::open(&self.path)?;
+        let reader = BufReader::new(file);
+
+        let mut events = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            // Skip malformed lines (best-effort parsing)
+            if let Ok(event) = serde_json::from_str::<HistoryEvent>(&line) {
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+
+    /// Find the last completed iteration number.
+    ///
+    /// Returns None if no iterations have been completed.
+    pub fn last_iteration(&self) -> Result<Option<u32>, HistoryError> {
+        let events = self.read_all()?;
+
+        let mut last_completed = None;
+
+        for event in events {
+            if let HistoryEventType::IterationCompleted { iteration, .. } = event.event_type {
+                last_completed = Some(iteration);
+            }
+        }
+
+        Ok(last_completed)
+    }
+
+    /// Check if the loop completed successfully.
+    pub fn is_completed(&self) -> Result<bool, HistoryError> {
+        let events = self.read_all()?;
+
+        for event in events.iter().rev() {
+            match &event.event_type {
+                HistoryEventType::LoopCompleted { .. } => return Ok(true),
+                HistoryEventType::LoopTerminated { .. } => return Ok(false),
+                HistoryEventType::LoopDiscarded { .. } => return Ok(false),
+                _ => {}
+            }
+        }
+
+        Ok(false)
+    }
+
+    /// Get the original prompt that started the loop.
+    pub fn get_prompt(&self) -> Result<Option<String>, HistoryError> {
+        let events = self.read_all()?;
+
+        for event in events {
+            if let HistoryEventType::LoopStarted { prompt } = event.event_type {
+                return Ok(Some(prompt));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Get summary statistics about the loop.
+    pub fn summary(&self) -> Result<HistorySummary, HistoryError> {
+        let events = self.read_all()?;
+
+        let mut summary = HistorySummary::default();
+
+        for event in &events {
+            match &event.event_type {
+                HistoryEventType::LoopStarted { prompt } => {
+                    summary.prompt = Some(prompt.clone());
+                    summary.started_at = Some(event.timestamp);
+                }
+                HistoryEventType::IterationCompleted { iteration, success } => {
+                    summary.iterations_completed = *iteration;
+                    if !success {
+                        summary.iterations_failed += 1;
+                    }
+                }
+                HistoryEventType::EventPublished { .. } => {
+                    summary.events_published += 1;
+                }
+                HistoryEventType::LoopCompleted { reason } => {
+                    summary.completed = true;
+                    summary.completion_reason = Some(reason.clone());
+                    summary.ended_at = Some(event.timestamp);
+                }
+                HistoryEventType::LoopTerminated { signal } => {
+                    summary.terminated = true;
+                    summary.termination_signal = Some(signal.clone());
+                    summary.ended_at = Some(event.timestamp);
+                }
+                HistoryEventType::MergeCompleted { commit } => {
+                    summary.merge_commit = Some(commit.clone());
+                }
+                HistoryEventType::MergeFailed { reason } => {
+                    summary.merge_failed = true;
+                    summary.merge_failure_reason = Some(reason.clone());
+                }
+                _ => {}
+            }
+        }
+
+        Ok(summary)
+    }
+
+    /// Record loop started event.
+    pub fn record_started(&self, prompt: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::LoopStarted {
+            prompt: prompt.to_string(),
+        }))
+    }
+
+    /// Record iteration started event.
+    pub fn record_iteration_started(&self, iteration: u32) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::IterationStarted {
+            iteration,
+        }))
+    }
+
+    /// Record event published event.
+    pub fn record_event_published(&self, topic: &str, payload: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::EventPublished {
+            topic: topic.to_string(),
+            payload: payload.to_string(),
+        }))
+    }
+
+    /// Record iteration completed event.
+    pub fn record_iteration_completed(
+        &self,
+        iteration: u32,
+        success: bool,
+    ) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::IterationCompleted {
+            iteration,
+            success,
+        }))
+    }
+
+    /// Record loop completed event.
+    pub fn record_completed(&self, reason: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::LoopCompleted {
+            reason: reason.to_string(),
+        }))
+    }
+
+    /// Record loop resumed event.
+    pub fn record_resumed(&self, from_iteration: u32) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::LoopResumed {
+            from_iteration,
+        }))
+    }
+
+    /// Record loop terminated event.
+    pub fn record_terminated(&self, signal: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::LoopTerminated {
+            signal: signal.to_string(),
+        }))
+    }
+
+    /// Record merge queued event.
+    pub fn record_merge_queued(&self) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::MergeQueued))
+    }
+
+    /// Record merge started event.
+    pub fn record_merge_started(&self, pid: u32) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::MergeStarted { pid }))
+    }
+
+    /// Record merge completed event.
+    pub fn record_merge_completed(&self, commit: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::MergeCompleted {
+            commit: commit.to_string(),
+        }))
+    }
+
+    /// Record merge failed event.
+    pub fn record_merge_failed(&self, reason: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::MergeFailed {
+            reason: reason.to_string(),
+        }))
+    }
+
+    /// Record loop discarded event.
+    pub fn record_discarded(&self, reason: &str) -> Result<(), HistoryError> {
+        self.append(HistoryEvent::new(HistoryEventType::LoopDiscarded {
+            reason: reason.to_string(),
+        }))
+    }
+}
+
+/// Summary statistics for a loop history.
+#[derive(Debug, Default)]
+pub struct HistorySummary {
+    /// Original prompt.
+    pub prompt: Option<String>,
+
+    /// When the loop started.
+    pub started_at: Option<DateTime<Utc>>,
+
+    /// When the loop ended.
+    pub ended_at: Option<DateTime<Utc>>,
+
+    /// Number of completed iterations.
+    pub iterations_completed: u32,
+
+    /// Number of failed iterations.
+    pub iterations_failed: u32,
+
+    /// Number of events published.
+    pub events_published: u32,
+
+    /// Whether the loop completed successfully.
+    pub completed: bool,
+
+    /// Completion reason (if completed).
+    pub completion_reason: Option<String>,
+
+    /// Whether the loop was terminated.
+    pub terminated: bool,
+
+    /// Termination signal (if terminated).
+    pub termination_signal: Option<String>,
+
+    /// Merge commit SHA (if merged).
+    pub merge_commit: Option<String>,
+
+    /// Whether merge failed.
+    pub merge_failed: bool,
+
+    /// Merge failure reason (if failed).
+    pub merge_failure_reason: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn temp_history() -> (TempDir, LoopHistory) {
+        let dir = TempDir::new().unwrap();
+        let history = LoopHistory::new(dir.path().join("history.jsonl"));
+        (dir, history)
+    }
+
+    #[test]
+    fn test_append_and_read() {
+        let (_dir, history) = temp_history();
+
+        history.record_started("test prompt").unwrap();
+        history.record_iteration_started(1).unwrap();
+        history.record_iteration_completed(1, true).unwrap();
+        history.record_completed("completion_promise").unwrap();
+
+        let events = history.read_all().unwrap();
+        assert_eq!(events.len(), 4);
+
+        assert!(matches!(
+            events[0].event_type,
+            HistoryEventType::LoopStarted { .. }
+        ));
+        assert!(matches!(
+            events[1].event_type,
+            HistoryEventType::IterationStarted { iteration: 1 }
+        ));
+        assert!(matches!(
+            events[2].event_type,
+            HistoryEventType::IterationCompleted {
+                iteration: 1,
+                success: true
+            }
+        ));
+        assert!(matches!(
+            events[3].event_type,
+            HistoryEventType::LoopCompleted { .. }
+        ));
+    }
+
+    #[test]
+    fn test_last_iteration() {
+        let (_dir, history) = temp_history();
+
+        assert_eq!(history.last_iteration().unwrap(), None);
+
+        history.record_started("test").unwrap();
+        history.record_iteration_started(1).unwrap();
+        history.record_iteration_completed(1, true).unwrap();
+        assert_eq!(history.last_iteration().unwrap(), Some(1));
+
+        history.record_iteration_started(2).unwrap();
+        history.record_iteration_completed(2, true).unwrap();
+        assert_eq!(history.last_iteration().unwrap(), Some(2));
+
+        history.record_iteration_started(3).unwrap();
+        history.record_iteration_completed(3, false).unwrap();
+        assert_eq!(history.last_iteration().unwrap(), Some(3));
+    }
+
+    #[test]
+    fn test_is_completed() {
+        let (_dir, history) = temp_history();
+
+        assert!(!history.is_completed().unwrap());
+
+        history.record_started("test").unwrap();
+        assert!(!history.is_completed().unwrap());
+
+        history.record_completed("done").unwrap();
+        assert!(history.is_completed().unwrap());
+    }
+
+    #[test]
+    fn test_is_completed_terminated() {
+        let (_dir, history) = temp_history();
+
+        history.record_started("test").unwrap();
+        history.record_terminated("SIGTERM").unwrap();
+        assert!(!history.is_completed().unwrap());
+    }
+
+    #[test]
+    fn test_get_prompt() {
+        let (_dir, history) = temp_history();
+
+        assert!(history.get_prompt().unwrap().is_none());
+
+        history.record_started("my test prompt").unwrap();
+        assert_eq!(
+            history.get_prompt().unwrap(),
+            Some("my test prompt".to_string())
+        );
+    }
+
+    #[test]
+    fn test_summary() {
+        let (_dir, history) = temp_history();
+
+        history.record_started("test prompt").unwrap();
+        history.record_iteration_started(1).unwrap();
+        history
+            .record_event_published("build.task", "task 1")
+            .unwrap();
+        history.record_iteration_completed(1, true).unwrap();
+        history.record_iteration_started(2).unwrap();
+        history
+            .record_event_published("build.done", "done")
+            .unwrap();
+        history.record_iteration_completed(2, true).unwrap();
+        history.record_completed("completion_promise").unwrap();
+
+        let summary = history.summary().unwrap();
+        assert_eq!(summary.prompt, Some("test prompt".to_string()));
+        assert_eq!(summary.iterations_completed, 2);
+        assert_eq!(summary.events_published, 2);
+        assert!(summary.completed);
+        assert_eq!(
+            summary.completion_reason,
+            Some("completion_promise".to_string())
+        );
+    }
+
+    #[test]
+    fn test_empty_file() {
+        let (_dir, history) = temp_history();
+
+        let events = history.read_all().unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_merge_events() {
+        let (_dir, history) = temp_history();
+
+        history.record_merge_queued().unwrap();
+        history.record_merge_started(12345).unwrap();
+        history.record_merge_completed("abc123").unwrap();
+
+        let events = history.read_all().unwrap();
+        assert_eq!(events.len(), 3);
+
+        assert!(matches!(
+            events[0].event_type,
+            HistoryEventType::MergeQueued
+        ));
+        assert!(matches!(
+            events[1].event_type,
+            HistoryEventType::MergeStarted { pid: 12345 }
+        ));
+        assert!(matches!(
+            events[2].event_type,
+            HistoryEventType::MergeCompleted { .. }
+        ));
+    }
+
+    #[test]
+    fn test_serialization_format() {
+        let event = HistoryEvent::new(HistoryEventType::LoopStarted {
+            prompt: "test".to_string(),
+        });
+
+        let json = serde_json::to_string(&event).unwrap();
+        // Check that it contains expected fields
+        assert!(json.contains("\"ts\""));
+        assert!(json.contains("\"type\""));
+        assert!(json.contains("\"kind\":\"loop_started\""));
+        assert!(json.contains("\"prompt\":\"test\""));
+
+        // Verify it can be deserialized back
+        let parsed: HistoryEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed.event_type,
+            HistoryEventType::LoopStarted { prompt } if prompt == "test"
+        ));
+    }
+}

--- a/crates/ralph-core/src/loop_lock.rs
+++ b/crates/ralph-core/src/loop_lock.rs
@@ -1,0 +1,443 @@
+//! Loop lock mechanism for preventing concurrent Ralph loops in the same workspace.
+//!
+//! Uses `flock()` on `.ralph/loop.lock` to ensure only one primary loop runs at a time.
+//! When a second loop attempts to start, it can detect the existing lock and spawn
+//! into a git worktree instead.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ralph_core::loop_lock::{LoopLock, LockError};
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     match LoopLock::try_acquire(".", "implement auth") {
+//!         Ok(guard) => {
+//!             // We're the primary loop - run normally
+//!             println!("Acquired lock, running as primary loop");
+//!             // Lock is held until guard is dropped
+//!         }
+//!         Err(LockError::AlreadyLocked(existing)) => {
+//!             // Another loop is running - spawn into worktree
+//!             println!("Lock held by PID {}, spawning worktree", existing.pid);
+//!         }
+//!         Err(e) => return Err(e.into()),
+//!     }
+//!     Ok(())
+//! }
+//! ```
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+
+/// Metadata stored in the lock file, readable by other processes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockMetadata {
+    /// Process ID of the lock holder.
+    pub pid: u32,
+
+    /// When the lock was acquired.
+    pub started: DateTime<Utc>,
+
+    /// The prompt/task being executed.
+    pub prompt: String,
+}
+
+/// A guard that holds the loop lock. The lock is released when this is dropped.
+#[derive(Debug)]
+pub struct LockGuard {
+    /// The open file handle (keeps the flock).
+    #[cfg(unix)]
+    _flock: nix::fcntl::Flock<File>,
+
+    /// Placeholder for non-unix (compilation only, never actually used)
+    #[cfg(not(unix))]
+    _file: File,
+
+    /// Path to the lock file.
+    lock_path: PathBuf,
+}
+
+impl LockGuard {
+    /// Returns the path to the lock file.
+    pub fn lock_path(&self) -> &Path {
+        &self.lock_path
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        // The Flock is automatically released when dropped.
+        tracing::debug!("Releasing loop lock at {}", self.lock_path.display());
+    }
+}
+
+/// Errors that can occur during lock operations.
+#[derive(Debug, thiserror::Error)]
+pub enum LockError {
+    /// The lock is already held by another process.
+    #[error("Lock already held by PID {}", .0.pid)]
+    AlreadyLocked(LockMetadata),
+
+    /// IO error during lock operations.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Failed to parse lock metadata.
+    #[error("Failed to parse lock metadata: {0}")]
+    ParseError(String),
+
+    /// Platform not supported (non-Unix).
+    #[error("File locking not supported on this platform")]
+    UnsupportedPlatform,
+}
+
+/// The loop lock mechanism.
+///
+/// Uses `flock()` to provide advisory locking on `.ralph/loop.lock`.
+/// The lock is automatically released when the process exits (even on crash).
+pub struct LoopLock;
+
+impl LoopLock {
+    /// The relative path to the lock file within the workspace.
+    pub const LOCK_FILE: &'static str = ".ralph/loop.lock";
+
+    /// Try to acquire the loop lock (non-blocking).
+    ///
+    /// # Arguments
+    ///
+    /// * `workspace_root` - Root directory of the workspace
+    /// * `prompt` - The prompt/task being executed (stored in lock metadata)
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(LockGuard)` - Lock acquired successfully
+    /// * `Err(LockError::AlreadyLocked(metadata))` - Another process holds the lock
+    /// * `Err(LockError::Io(_))` - IO error
+    pub fn try_acquire(
+        workspace_root: impl AsRef<Path>,
+        prompt: &str,
+    ) -> Result<LockGuard, LockError> {
+        let lock_path = workspace_root.as_ref().join(Self::LOCK_FILE);
+
+        // Ensure .ralph directory exists
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Open or create the lock file
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+
+        // Try to acquire exclusive lock (non-blocking)
+        #[cfg(unix)]
+        {
+            use nix::fcntl::{Flock, FlockArg};
+
+            match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+                Ok(flock) => {
+                    // We got the lock - write our metadata
+                    Self::write_metadata(&flock, prompt)?;
+
+                    tracing::debug!("Acquired loop lock at {}", lock_path.display());
+
+                    Ok(LockGuard {
+                        _flock: flock,
+                        lock_path,
+                    })
+                }
+                Err((file, errno)) => {
+                    use nix::errno::Errno;
+                    // EWOULDBLOCK and EAGAIN are the same on some platforms (macOS)
+                    if errno == Errno::EWOULDBLOCK || errno == Errno::EAGAIN {
+                        // Lock is held by another process - read their metadata
+                        let metadata = Self::read_metadata(&file)?;
+                        Err(LockError::AlreadyLocked(metadata))
+                    } else {
+                        Err(LockError::Io(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("flock failed: {}", errno),
+                        )))
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = file;
+            let _ = prompt;
+            Err(LockError::UnsupportedPlatform)
+        }
+    }
+
+    /// Acquire the loop lock, blocking until available.
+    ///
+    /// This should be used with the `--exclusive` flag to wait for the
+    /// primary loop slot instead of spawning into a worktree.
+    ///
+    /// # Arguments
+    ///
+    /// * `workspace_root` - Root directory of the workspace
+    /// * `prompt` - The prompt/task being executed
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(LockGuard)` - Lock acquired successfully
+    /// * `Err(LockError::Io(_))` - IO error
+    pub fn acquire_blocking(
+        workspace_root: impl AsRef<Path>,
+        prompt: &str,
+    ) -> Result<LockGuard, LockError> {
+        let lock_path = workspace_root.as_ref().join(Self::LOCK_FILE);
+
+        // Ensure .ralph directory exists
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+
+        #[cfg(unix)]
+        {
+            use nix::fcntl::{Flock, FlockArg};
+
+            match Flock::lock(file, FlockArg::LockExclusive) {
+                Ok(flock) => {
+                    // We got the lock - write our metadata
+                    Self::write_metadata(&flock, prompt)?;
+
+                    tracing::debug!("Acquired loop lock (blocking) at {}", lock_path.display());
+
+                    Ok(LockGuard {
+                        _flock: flock,
+                        lock_path,
+                    })
+                }
+                Err((_, errno)) => Err(LockError::Io(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("flock failed: {}", errno),
+                ))),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = file;
+            let _ = prompt;
+            Err(LockError::UnsupportedPlatform)
+        }
+    }
+
+    /// Read the metadata from an existing lock file.
+    ///
+    /// This can be used to check who holds the lock without acquiring it.
+    pub fn read_existing(
+        workspace_root: impl AsRef<Path>,
+    ) -> Result<Option<LockMetadata>, LockError> {
+        let lock_path = workspace_root.as_ref().join(Self::LOCK_FILE);
+
+        if !lock_path.exists() {
+            return Ok(None);
+        }
+
+        let file = File::open(&lock_path)?;
+        match Self::read_metadata(&file) {
+            Ok(metadata) => Ok(Some(metadata)),
+            Err(LockError::ParseError(_)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Check if the lock is currently held (without acquiring it).
+    ///
+    /// Returns `true` if another process holds the lock.
+    pub fn is_locked(workspace_root: impl AsRef<Path>) -> Result<bool, LockError> {
+        let lock_path = workspace_root.as_ref().join(Self::LOCK_FILE);
+
+        if !lock_path.exists() {
+            return Ok(false);
+        }
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true) // Need write for exclusive lock
+            .open(&lock_path)?;
+
+        #[cfg(unix)]
+        {
+            use nix::errno::Errno;
+            use nix::fcntl::{Flock, FlockArg};
+
+            match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
+                Ok(_flock) => {
+                    // We got the lock - it will be released when _flock is dropped
+                    Ok(false)
+                }
+                Err((_, errno)) => {
+                    if errno == Errno::EWOULDBLOCK || errno == Errno::EAGAIN {
+                        Ok(true)
+                    } else {
+                        Err(LockError::Io(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("flock failed: {}", errno),
+                        )))
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = file;
+            Err(LockError::UnsupportedPlatform)
+        }
+    }
+
+    /// Write lock metadata to the file.
+    fn write_metadata(file: &File, prompt: &str) -> Result<(), LockError> {
+        let metadata = LockMetadata {
+            pid: process::id(),
+            started: Utc::now(),
+            prompt: prompt.to_string(),
+        };
+
+        // Use a mutable reference via clone for writing
+        let mut file_clone = file.try_clone()?;
+        file_clone.set_len(0)?;
+        file_clone.seek(SeekFrom::Start(0))?;
+
+        let json = serde_json::to_string_pretty(&metadata)
+            .map_err(|e| LockError::ParseError(e.to_string()))?;
+
+        file_clone.write_all(json.as_bytes())?;
+        file_clone.sync_all()?;
+
+        Ok(())
+    }
+
+    /// Read lock metadata from the file.
+    fn read_metadata(file: &File) -> Result<LockMetadata, LockError> {
+        let mut file_clone = file.try_clone()?;
+        file_clone.seek(SeekFrom::Start(0))?;
+        let mut contents = String::new();
+        file_clone.read_to_string(&mut contents)?;
+
+        if contents.trim().is_empty() {
+            return Err(LockError::ParseError("Empty lock file".to_string()));
+        }
+
+        serde_json::from_str(&contents).map_err(|e| LockError::ParseError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_acquire_lock_success() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let guard = LoopLock::try_acquire(temp_dir.path(), "test prompt");
+        assert!(guard.is_ok());
+
+        // Lock file should exist
+        let lock_path = temp_dir.path().join(".ralph/loop.lock");
+        assert!(lock_path.exists());
+
+        // Metadata should be readable
+        let contents = fs::read_to_string(&lock_path).unwrap();
+        let metadata: LockMetadata = serde_json::from_str(&contents).unwrap();
+        assert_eq!(metadata.pid, process::id());
+        assert_eq!(metadata.prompt, "test prompt");
+    }
+
+    #[test]
+    fn test_lock_released_on_drop() {
+        let temp_dir = TempDir::new().unwrap();
+
+        {
+            let _guard = LoopLock::try_acquire(temp_dir.path(), "first").unwrap();
+            // Lock is held
+        }
+        // Guard dropped, lock released
+
+        // Should be able to acquire again
+        let guard = LoopLock::try_acquire(temp_dir.path(), "second");
+        assert!(guard.is_ok());
+    }
+
+    #[test]
+    fn test_is_locked() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Initially not locked
+        assert!(!LoopLock::is_locked(temp_dir.path()).unwrap());
+
+        let _guard = LoopLock::try_acquire(temp_dir.path(), "test").unwrap();
+
+        // Now locked (from our perspective - same process can re-lock)
+        // Note: flock allows same process to re-acquire, so this test
+        // might not work as expected in single-process context
+    }
+
+    #[test]
+    fn test_read_existing_no_file() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let result = LoopLock::read_existing(temp_dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_read_existing_with_lock() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let _guard = LoopLock::try_acquire(temp_dir.path(), "my prompt").unwrap();
+
+        let metadata = LoopLock::read_existing(temp_dir.path()).unwrap().unwrap();
+        assert_eq!(metadata.pid, process::id());
+        assert_eq!(metadata.prompt, "my prompt");
+    }
+
+    #[test]
+    fn test_creates_ralph_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let ralph_dir = temp_dir.path().join(".ralph");
+
+        assert!(!ralph_dir.exists());
+
+        let _guard = LoopLock::try_acquire(temp_dir.path(), "test").unwrap();
+
+        assert!(ralph_dir.exists());
+    }
+
+    #[test]
+    fn test_lock_metadata_serialization() {
+        let metadata = LockMetadata {
+            pid: 12345,
+            started: Utc::now(),
+            prompt: "implement feature".to_string(),
+        };
+
+        let json = serde_json::to_string(&metadata).unwrap();
+        let deserialized: LockMetadata = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.pid, 12345);
+        assert_eq!(deserialized.prompt, "implement feature");
+    }
+}

--- a/crates/ralph-core/src/loop_registry.rs
+++ b/crates/ralph-core/src/loop_registry.rs
@@ -1,0 +1,580 @@
+//! Loop registry for tracking active Ralph loops across workspaces.
+//!
+//! The registry maintains a list of running loops with their metadata,
+//! providing discovery and coordination capabilities for multi-loop scenarios.
+//!
+//! # Design
+//!
+//! - **JSON persistence**: Single JSON file at `.ralph/loops.json`
+//! - **File locking**: Uses `flock()` for concurrent access safety
+//! - **PID-based stale detection**: Automatically cleans up entries for dead processes
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ralph_core::loop_registry::{LoopRegistry, LoopEntry};
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let registry = LoopRegistry::new(".");
+//!
+//!     // Register this loop
+//!     let entry = LoopEntry::new("implement auth", Some("/path/to/worktree"));
+//!     let id = registry.register(entry)?;
+//!
+//!     // List all active loops
+//!     for loop_entry in registry.list()? {
+//!         println!("Loop {}: {}", loop_entry.id, loop_entry.prompt);
+//!     }
+//!
+//!     // Deregister when done
+//!     registry.deregister(&id)?;
+//!     Ok(())
+//! }
+//! ```
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+
+/// Metadata for a registered loop.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LoopEntry {
+    /// Unique loop ID: loop-{unix_timestamp}-{4_hex_chars}
+    pub id: String,
+
+    /// Process ID of the loop.
+    pub pid: u32,
+
+    /// When the loop was started.
+    pub started: DateTime<Utc>,
+
+    /// The prompt/task being executed.
+    pub prompt: String,
+
+    /// Path to the worktree (None if running in main workspace).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+
+    /// The workspace root where the loop is running.
+    pub workspace: String,
+}
+
+impl LoopEntry {
+    /// Creates a new loop entry for the current process.
+    pub fn new(prompt: impl Into<String>, worktree_path: Option<impl Into<String>>) -> Self {
+        Self {
+            id: Self::generate_id(),
+            pid: process::id(),
+            started: Utc::now(),
+            prompt: prompt.into(),
+            worktree_path: worktree_path.map(Into::into),
+            workspace: std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Creates a new loop entry with a specific workspace.
+    pub fn with_workspace(
+        prompt: impl Into<String>,
+        worktree_path: Option<impl Into<String>>,
+        workspace: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: Self::generate_id(),
+            pid: process::id(),
+            started: Utc::now(),
+            prompt: prompt.into(),
+            worktree_path: worktree_path.map(Into::into),
+            workspace: workspace.into(),
+        }
+    }
+
+    /// Generates a unique loop ID: loop-{timestamp}-{hex_suffix}
+    fn generate_id() -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let duration = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let timestamp = duration.as_secs();
+        let hex_suffix = format!("{:04x}", duration.subsec_micros() % 0x10000);
+        format!("loop-{}-{}", timestamp, hex_suffix)
+    }
+
+    /// Checks if the process for this loop is still running.
+    #[cfg(unix)]
+    pub fn is_alive(&self) -> bool {
+        use nix::sys::signal::{Signal, kill};
+        use nix::unistd::Pid;
+
+        // Signal 0 checks if process exists without sending a signal
+        kill(Pid::from_raw(self.pid as i32), Signal::SIGCONT)
+            .map(|_| true)
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    pub fn is_alive(&self) -> bool {
+        // On non-Unix platforms, assume alive (conservative)
+        true
+    }
+}
+
+/// The persisted registry data.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct RegistryData {
+    loops: Vec<LoopEntry>,
+}
+
+/// Errors that can occur during registry operations.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    /// IO error during registry operations.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Failed to parse registry data.
+    #[error("Failed to parse registry: {0}")]
+    ParseError(String),
+
+    /// Loop entry not found.
+    #[error("Loop not found: {0}")]
+    NotFound(String),
+
+    /// Platform not supported.
+    #[error("File locking not supported on this platform")]
+    UnsupportedPlatform,
+}
+
+/// Registry for tracking active Ralph loops.
+///
+/// Provides thread-safe registration and discovery of running loops.
+pub struct LoopRegistry {
+    /// Path to the registry file.
+    registry_path: PathBuf,
+}
+
+impl LoopRegistry {
+    /// The relative path to the registry file within the workspace.
+    pub const REGISTRY_FILE: &'static str = ".ralph/loops.json";
+
+    /// Creates a new registry instance for the given workspace.
+    pub fn new(workspace_root: impl AsRef<Path>) -> Self {
+        Self {
+            registry_path: workspace_root.as_ref().join(Self::REGISTRY_FILE),
+        }
+    }
+
+    /// Registers a new loop entry.
+    ///
+    /// Returns the entry's ID for later deregistration.
+    pub fn register(&self, entry: LoopEntry) -> Result<String, RegistryError> {
+        let id = entry.id.clone();
+        self.with_lock(|data| {
+            // Remove any existing entry with the same PID (stale from crash)
+            data.loops.retain(|e| e.pid != entry.pid);
+            data.loops.push(entry);
+        })?;
+        Ok(id)
+    }
+
+    /// Deregisters a loop by ID.
+    pub fn deregister(&self, id: &str) -> Result<(), RegistryError> {
+        let mut found = false;
+        self.with_lock(|data| {
+            let original_len = data.loops.len();
+            data.loops.retain(|e| e.id != id);
+            found = data.loops.len() != original_len;
+        })?;
+        if !found {
+            return Err(RegistryError::NotFound(id.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Gets a loop entry by ID.
+    pub fn get(&self, id: &str) -> Result<Option<LoopEntry>, RegistryError> {
+        let mut result = None;
+        self.with_lock(|data| {
+            result = data.loops.iter().find(|e| e.id == id).cloned();
+        })?;
+        Ok(result)
+    }
+
+    /// Lists all active loops (after cleaning stale entries).
+    pub fn list(&self) -> Result<Vec<LoopEntry>, RegistryError> {
+        let mut result = Vec::new();
+        self.with_lock(|data| {
+            result = data.loops.clone();
+        })?;
+        Ok(result)
+    }
+
+    /// Cleans stale entries (dead PIDs) and returns the number removed.
+    pub fn clean_stale(&self) -> Result<usize, RegistryError> {
+        let mut removed = 0;
+        self.with_lock(|data| {
+            let original_len = data.loops.len();
+            data.loops.retain(|e| e.is_alive());
+            removed = original_len - data.loops.len();
+        })?;
+        Ok(removed)
+    }
+
+    /// Executes an operation with the registry file locked.
+    #[cfg(unix)]
+    fn with_lock<F>(&self, f: F) -> Result<(), RegistryError>
+    where
+        F: FnOnce(&mut RegistryData),
+    {
+        use nix::fcntl::{Flock, FlockArg};
+
+        // Ensure .ralph directory exists
+        if let Some(parent) = self.registry_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Open or create the file
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.registry_path)?;
+
+        // Acquire exclusive lock (blocking)
+        let flock = Flock::lock(file, FlockArg::LockExclusive).map_err(|(_, errno)| {
+            RegistryError::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("flock failed: {}", errno),
+            ))
+        })?;
+
+        // Read existing data using the locked file
+        let mut data = self.read_data_from_file(&flock)?;
+
+        // Clean stale entries before any operation
+        data.loops.retain(|e| e.is_alive());
+
+        // Execute the user function
+        f(&mut data);
+
+        // Write back the data
+        self.write_data_to_file(&flock, &data)?;
+
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    fn with_lock<F>(&self, _f: F) -> Result<(), RegistryError>
+    where
+        F: FnOnce(&mut RegistryData),
+    {
+        Err(RegistryError::UnsupportedPlatform)
+    }
+
+    /// Reads registry data from a locked file.
+    #[cfg(unix)]
+    fn read_data_from_file(
+        &self,
+        flock: &nix::fcntl::Flock<File>,
+    ) -> Result<RegistryData, RegistryError> {
+        use std::os::fd::AsFd;
+
+        // Get a clone of the underlying file via BorrowedFd
+        let borrowed_fd = flock.as_fd();
+        let owned_fd = borrowed_fd.try_clone_to_owned()?;
+        let mut file: File = owned_fd.into();
+
+        file.seek(SeekFrom::Start(0))?;
+
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        if contents.trim().is_empty() {
+            return Ok(RegistryData::default());
+        }
+
+        serde_json::from_str(&contents).map_err(|e| RegistryError::ParseError(e.to_string()))
+    }
+
+    /// Writes registry data to a locked file.
+    #[cfg(unix)]
+    fn write_data_to_file(
+        &self,
+        flock: &nix::fcntl::Flock<File>,
+        data: &RegistryData,
+    ) -> Result<(), RegistryError> {
+        use std::os::fd::AsFd;
+
+        // Get a clone of the underlying file via BorrowedFd
+        let borrowed_fd = flock.as_fd();
+        let owned_fd = borrowed_fd.try_clone_to_owned()?;
+        let mut file: File = owned_fd.into();
+
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+
+        let json = serde_json::to_string_pretty(data)
+            .map_err(|e| RegistryError::ParseError(e.to_string()))?;
+
+        file.write_all(json.as_bytes())?;
+        file.sync_all()?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_loop_entry_creation() {
+        let entry = LoopEntry::new("test prompt", None::<String>);
+        assert!(entry.id.starts_with("loop-"));
+        assert_eq!(entry.pid, process::id());
+        assert_eq!(entry.prompt, "test prompt");
+        assert!(entry.worktree_path.is_none());
+    }
+
+    #[test]
+    fn test_loop_entry_with_worktree() {
+        let entry = LoopEntry::new("test prompt", Some("/path/to/worktree"));
+        assert_eq!(entry.worktree_path, Some("/path/to/worktree".to_string()));
+    }
+
+    #[test]
+    fn test_loop_entry_id_format() {
+        let entry = LoopEntry::new("test", None::<String>);
+        let parts: Vec<&str> = entry.id.split('-').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], "loop");
+    }
+
+    #[test]
+    fn test_loop_entry_is_alive() {
+        let entry = LoopEntry::new("test", None::<String>);
+        // Current process should be alive
+        assert!(entry.is_alive());
+    }
+
+    #[test]
+    fn test_registry_creates_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry_path = temp_dir.path().join(".ralph/loops.json");
+
+        assert!(!registry_path.exists());
+
+        let registry = LoopRegistry::new(temp_dir.path());
+        let entry = LoopEntry::new("test prompt", None::<String>);
+        registry.register(entry).unwrap();
+
+        assert!(registry_path.exists());
+    }
+
+    #[test]
+    fn test_registry_register_and_list() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        let entry = LoopEntry::new("test prompt", None::<String>);
+        let id = entry.id.clone();
+
+        registry.register(entry).unwrap();
+
+        let loops = registry.list().unwrap();
+        assert_eq!(loops.len(), 1);
+        assert_eq!(loops[0].id, id);
+        assert_eq!(loops[0].prompt, "test prompt");
+    }
+
+    #[test]
+    fn test_registry_get() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        let entry = LoopEntry::new("test prompt", None::<String>);
+        let id = entry.id.clone();
+
+        registry.register(entry).unwrap();
+
+        let retrieved = registry.get(&id).unwrap();
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().prompt, "test prompt");
+    }
+
+    #[test]
+    fn test_registry_get_nonexistent() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        // Need to create the file first
+        let entry = LoopEntry::new("dummy", None::<String>);
+        let id = entry.id.clone();
+        registry.register(entry).unwrap();
+        registry.deregister(&id).unwrap();
+
+        let retrieved = registry.get("nonexistent").unwrap();
+        assert!(retrieved.is_none());
+    }
+
+    #[test]
+    fn test_registry_deregister() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        let entry = LoopEntry::new("test prompt", None::<String>);
+        let id = entry.id.clone();
+
+        registry.register(entry).unwrap();
+        assert_eq!(registry.list().unwrap().len(), 1);
+
+        registry.deregister(&id).unwrap();
+        assert_eq!(registry.list().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_registry_deregister_nonexistent() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        // Register and deregister to create the file
+        let entry = LoopEntry::new("dummy", None::<String>);
+        let id = entry.id.clone();
+        registry.register(entry).unwrap();
+        registry.deregister(&id).unwrap();
+
+        let result = registry.deregister("nonexistent");
+        assert!(matches!(result, Err(RegistryError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_registry_same_pid_replaces() {
+        // Same PID entries replace each other (prevents stale entries from crashes)
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        let entry1 = LoopEntry::new("prompt 1", None::<String>);
+        let entry2 = LoopEntry::new("prompt 2", Some("/worktree"));
+
+        // Both entries have the same PID (current process)
+        assert_eq!(entry1.pid, entry2.pid);
+
+        registry.register(entry1).unwrap();
+        registry.register(entry2).unwrap();
+
+        // Second entry should replace first (same PID)
+        let loops = registry.list().unwrap();
+        assert_eq!(loops.len(), 1);
+        assert_eq!(loops[0].prompt, "prompt 2");
+    }
+
+    #[test]
+    fn test_registry_different_pids_coexist() {
+        // Entries with different PIDs should coexist
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        // Create entry with current PID
+        let entry1 = LoopEntry::new("prompt 1", None::<String>);
+        let id1 = entry1.id.clone();
+        registry.register(entry1).unwrap();
+
+        // Manually create entry with different PID (simulating another process)
+        let mut entry2 = LoopEntry::new("prompt 2", Some("/worktree"));
+        entry2.pid = 99999; // Fake PID - won't exist so will be cleaned as stale
+        let id2 = entry2.id.clone();
+
+        // Write entry2 directly to file to bypass PID check
+        let registry_path = temp_dir.path().join(".ralph/loops.json");
+        let content = fs::read_to_string(&registry_path).unwrap();
+        let mut data: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let loops = data["loops"].as_array_mut().unwrap();
+        loops.push(serde_json::json!({
+            "id": id2,
+            "pid": 99999,
+            "started": entry2.started,
+            "prompt": "prompt 2",
+            "worktree_path": "/worktree",
+            "workspace": entry2.workspace
+        }));
+        fs::write(&registry_path, serde_json::to_string_pretty(&data).unwrap()).unwrap();
+
+        // List should clean the stale entry (PID 99999 doesn't exist)
+        // But our current process entry should remain
+        let loops = registry.list().unwrap();
+        assert_eq!(loops.len(), 1);
+        assert_eq!(loops[0].id, id1);
+    }
+
+    #[test]
+    fn test_registry_replaces_same_pid() {
+        let temp_dir = TempDir::new().unwrap();
+        let registry = LoopRegistry::new(temp_dir.path());
+
+        // Register first entry
+        let entry1 = LoopEntry::new("prompt 1", None::<String>);
+        registry.register(entry1).unwrap();
+
+        // Register second entry with same PID (simulates restart)
+        let entry2 = LoopEntry::new("prompt 2", None::<String>);
+        registry.register(entry2).unwrap();
+
+        // Should only have one entry (the new one replaced the old)
+        let loops = registry.list().unwrap();
+        assert_eq!(loops.len(), 1);
+        assert_eq!(loops[0].prompt, "prompt 2");
+    }
+
+    #[test]
+    fn test_registry_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let id = {
+            let registry = LoopRegistry::new(temp_dir.path());
+            let entry = LoopEntry::new("persistent prompt", None::<String>);
+            let id = entry.id.clone();
+            registry.register(entry).unwrap();
+            id
+        };
+
+        // Load again and verify data persisted
+        let registry = LoopRegistry::new(temp_dir.path());
+        let loops = registry.list().unwrap();
+        assert_eq!(loops.len(), 1);
+        assert_eq!(loops[0].id, id);
+        assert_eq!(loops[0].prompt, "persistent prompt");
+    }
+
+    #[test]
+    fn test_entry_serialization() {
+        let entry = LoopEntry::new("test prompt", Some("/worktree/path"));
+        let json = serde_json::to_string(&entry).unwrap();
+        let deserialized: LoopEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.id, entry.id);
+        assert_eq!(deserialized.pid, entry.pid);
+        assert_eq!(deserialized.prompt, "test prompt");
+        assert_eq!(
+            deserialized.worktree_path,
+            Some("/worktree/path".to_string())
+        );
+    }
+
+    #[test]
+    fn test_entry_serialization_no_worktree() {
+        let entry = LoopEntry::new("test prompt", None::<String>);
+        let json = serde_json::to_string(&entry).unwrap();
+
+        // Verify worktree_path is not in JSON when None
+        assert!(!json.contains("worktree_path"));
+
+        let deserialized: LoopEntry = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.worktree_path.is_none());
+    }
+}

--- a/crates/ralph-core/src/merge_queue.rs
+++ b/crates/ralph-core/src/merge_queue.rs
@@ -1,0 +1,792 @@
+//! Merge queue for tracking parallel loop merges.
+//!
+//! The merge queue maintains an append-only log of merge events, tracking
+//! loops from completion through successful merge or failure. It uses JSONL
+//! format for durability and easy debugging.
+//!
+//! # Design
+//!
+//! - **JSONL persistence**: Append-only log at `.ralph/merge-queue.jsonl`
+//! - **File locking**: Uses `flock()` for concurrent access safety
+//! - **Event sourcing**: State is derived from event history
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ralph_core::merge_queue::{MergeQueue, MergeQueueError};
+//!
+//! fn main() -> Result<(), MergeQueueError> {
+//!     let queue = MergeQueue::new(".");
+//!
+//!     // Queue a completed loop for merge
+//!     queue.enqueue("ralph-20250124-a3f2", "implement auth")?;
+//!
+//!     // Get next pending loop
+//!     if let Some(entry) = queue.next_pending()? {
+//!         // Mark as merging
+//!         queue.mark_merging(&entry.loop_id, std::process::id())?;
+//!
+//!         // ... perform merge ...
+//!
+//!         // Mark result
+//!         queue.mark_merged(&entry.loop_id, "abc123def")?;
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+/// A merge queue event recorded in the JSONL log.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MergeEvent {
+    /// Timestamp of the event.
+    pub ts: DateTime<Utc>,
+
+    /// Loop ID this event relates to.
+    pub loop_id: String,
+
+    /// Type of event.
+    pub event: MergeEventType,
+}
+
+/// Types of merge events.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MergeEventType {
+    /// Loop has been queued for merge.
+    Queued {
+        /// The prompt that was executed in this loop.
+        prompt: String,
+    },
+
+    /// Merge operation has started.
+    Merging {
+        /// PID of the merge-ralph process.
+        pid: u32,
+    },
+
+    /// Merge completed successfully.
+    Merged {
+        /// The commit SHA of the merge commit.
+        commit: String,
+    },
+
+    /// Merge failed and needs manual review.
+    NeedsReview {
+        /// Reason for the failure.
+        reason: String,
+    },
+
+    /// Loop was manually discarded.
+    Discarded {
+        /// Reason for discarding (optional).
+        reason: Option<String>,
+    },
+}
+
+/// Current state of a loop in the merge queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeState {
+    /// Waiting to be merged.
+    Queued,
+    /// Currently being merged.
+    Merging,
+    /// Successfully merged.
+    Merged,
+    /// Needs manual review.
+    NeedsReview,
+    /// Discarded by user.
+    Discarded,
+}
+
+/// Summary of a loop's merge status.
+#[derive(Debug, Clone)]
+pub struct MergeEntry {
+    /// Loop ID.
+    pub loop_id: String,
+
+    /// Original prompt.
+    pub prompt: String,
+
+    /// Current state.
+    pub state: MergeState,
+
+    /// When the loop was queued.
+    pub queued_at: DateTime<Utc>,
+
+    /// PID of merge-ralph if merging.
+    pub merge_pid: Option<u32>,
+
+    /// Merge commit SHA if merged.
+    pub merge_commit: Option<String>,
+
+    /// Failure reason if needs_review.
+    pub failure_reason: Option<String>,
+
+    /// Discard reason if discarded.
+    pub discard_reason: Option<String>,
+}
+
+/// Errors that can occur during merge queue operations.
+#[derive(Debug, thiserror::Error)]
+pub enum MergeQueueError {
+    /// IO error during queue operations.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Failed to parse queue data.
+    #[error("Failed to parse merge queue: {0}")]
+    ParseError(String),
+
+    /// Loop entry not found.
+    #[error("Loop not found in queue: {0}")]
+    NotFound(String),
+
+    /// Invalid state transition.
+    #[error("Invalid state transition for {0}: cannot transition from {1:?} to {2:?}")]
+    InvalidTransition(String, MergeState, MergeState),
+
+    /// Platform not supported.
+    #[error("File locking not supported on this platform")]
+    UnsupportedPlatform,
+}
+
+/// Merge queue for tracking parallel loop merges.
+///
+/// The queue maintains an append-only JSONL log of merge events.
+/// State is derived by replaying events for each loop.
+pub struct MergeQueue {
+    /// Path to the merge queue file.
+    queue_path: PathBuf,
+}
+
+impl MergeQueue {
+    /// The relative path to the merge queue file within the workspace.
+    pub const QUEUE_FILE: &'static str = ".ralph/merge-queue.jsonl";
+
+    /// Creates a new merge queue instance for the given workspace.
+    pub fn new(workspace_root: impl AsRef<Path>) -> Self {
+        Self {
+            queue_path: workspace_root.as_ref().join(Self::QUEUE_FILE),
+        }
+    }
+
+    /// Enqueues a completed loop for merging.
+    ///
+    /// # Arguments
+    ///
+    /// * `loop_id` - The loop identifier
+    /// * `prompt` - The prompt that was executed
+    pub fn enqueue(&self, loop_id: &str, prompt: &str) -> Result<(), MergeQueueError> {
+        let event = MergeEvent {
+            ts: Utc::now(),
+            loop_id: loop_id.to_string(),
+            event: MergeEventType::Queued {
+                prompt: prompt.to_string(),
+            },
+        };
+        self.append_event(&event)
+    }
+
+    /// Marks a loop as being merged.
+    ///
+    /// # Arguments
+    ///
+    /// * `loop_id` - The loop identifier
+    /// * `pid` - PID of the merge-ralph process
+    pub fn mark_merging(&self, loop_id: &str, pid: u32) -> Result<(), MergeQueueError> {
+        // Verify loop is in queued or needs_review state
+        let entry = self.get_entry(loop_id)?;
+        match entry {
+            Some(e) if e.state == MergeState::Queued || e.state == MergeState::NeedsReview => {}
+            Some(e) => {
+                return Err(MergeQueueError::InvalidTransition(
+                    loop_id.to_string(),
+                    e.state,
+                    MergeState::Merging,
+                ));
+            }
+            None => return Err(MergeQueueError::NotFound(loop_id.to_string())),
+        }
+
+        let event = MergeEvent {
+            ts: Utc::now(),
+            loop_id: loop_id.to_string(),
+            event: MergeEventType::Merging { pid },
+        };
+        self.append_event(&event)
+    }
+
+    /// Marks a loop as successfully merged.
+    ///
+    /// # Arguments
+    ///
+    /// * `loop_id` - The loop identifier
+    /// * `commit` - The merge commit SHA
+    pub fn mark_merged(&self, loop_id: &str, commit: &str) -> Result<(), MergeQueueError> {
+        // Verify loop is in merging state
+        let entry = self.get_entry(loop_id)?;
+        match entry {
+            Some(e) if e.state == MergeState::Merging => {}
+            Some(e) => {
+                return Err(MergeQueueError::InvalidTransition(
+                    loop_id.to_string(),
+                    e.state,
+                    MergeState::Merged,
+                ));
+            }
+            None => return Err(MergeQueueError::NotFound(loop_id.to_string())),
+        }
+
+        let event = MergeEvent {
+            ts: Utc::now(),
+            loop_id: loop_id.to_string(),
+            event: MergeEventType::Merged {
+                commit: commit.to_string(),
+            },
+        };
+        self.append_event(&event)
+    }
+
+    /// Marks a loop as needing manual review.
+    ///
+    /// # Arguments
+    ///
+    /// * `loop_id` - The loop identifier
+    /// * `reason` - Reason for the failure
+    pub fn mark_needs_review(&self, loop_id: &str, reason: &str) -> Result<(), MergeQueueError> {
+        // Verify loop is in merging state
+        let entry = self.get_entry(loop_id)?;
+        match entry {
+            Some(e) if e.state == MergeState::Merging => {}
+            Some(e) => {
+                return Err(MergeQueueError::InvalidTransition(
+                    loop_id.to_string(),
+                    e.state,
+                    MergeState::NeedsReview,
+                ));
+            }
+            None => return Err(MergeQueueError::NotFound(loop_id.to_string())),
+        }
+
+        let event = MergeEvent {
+            ts: Utc::now(),
+            loop_id: loop_id.to_string(),
+            event: MergeEventType::NeedsReview {
+                reason: reason.to_string(),
+            },
+        };
+        self.append_event(&event)
+    }
+
+    /// Marks a loop as discarded.
+    ///
+    /// # Arguments
+    ///
+    /// * `loop_id` - The loop identifier
+    /// * `reason` - Optional reason for discarding
+    pub fn discard(&self, loop_id: &str, reason: Option<&str>) -> Result<(), MergeQueueError> {
+        // Can discard from queued or needs_review states
+        let entry = self.get_entry(loop_id)?;
+        match entry {
+            Some(e) if e.state == MergeState::Queued || e.state == MergeState::NeedsReview => {}
+            Some(e) => {
+                return Err(MergeQueueError::InvalidTransition(
+                    loop_id.to_string(),
+                    e.state,
+                    MergeState::Discarded,
+                ));
+            }
+            None => return Err(MergeQueueError::NotFound(loop_id.to_string())),
+        }
+
+        let event = MergeEvent {
+            ts: Utc::now(),
+            loop_id: loop_id.to_string(),
+            event: MergeEventType::Discarded {
+                reason: reason.map(String::from),
+            },
+        };
+        self.append_event(&event)
+    }
+
+    /// Gets the next pending loop ready for merge (FIFO order).
+    ///
+    /// Returns the oldest loop in `Queued` state.
+    pub fn next_pending(&self) -> Result<Option<MergeEntry>, MergeQueueError> {
+        let entries = self.list()?;
+        Ok(entries.into_iter().find(|e| e.state == MergeState::Queued))
+    }
+
+    /// Gets the entry for a specific loop.
+    pub fn get_entry(&self, loop_id: &str) -> Result<Option<MergeEntry>, MergeQueueError> {
+        let entries = self.list()?;
+        Ok(entries.into_iter().find(|e| e.loop_id == loop_id))
+    }
+
+    /// Lists all entries in the merge queue.
+    ///
+    /// Returns entries in chronological order (oldest first).
+    pub fn list(&self) -> Result<Vec<MergeEntry>, MergeQueueError> {
+        let events = self.read_all_events()?;
+        Ok(Self::derive_state(&events))
+    }
+
+    /// Lists entries filtered by state.
+    pub fn list_by_state(&self, state: MergeState) -> Result<Vec<MergeEntry>, MergeQueueError> {
+        let entries = self.list()?;
+        Ok(entries.into_iter().filter(|e| e.state == state).collect())
+    }
+
+    /// Reads all events from the queue file.
+    fn read_all_events(&self) -> Result<Vec<MergeEvent>, MergeQueueError> {
+        if !self.queue_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        self.with_shared_lock(|file| {
+            let reader = BufReader::new(file);
+            let mut events = Vec::new();
+
+            for (line_num, line) in reader.lines().enumerate() {
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+
+                let event: MergeEvent = serde_json::from_str(&line).map_err(|e| {
+                    MergeQueueError::ParseError(format!("Line {}: {}", line_num + 1, e))
+                })?;
+                events.push(event);
+            }
+
+            Ok(events)
+        })
+    }
+
+    /// Derives the current state of all loops from the event history.
+    fn derive_state(events: &[MergeEvent]) -> Vec<MergeEntry> {
+        use std::collections::HashMap;
+
+        // Build up state for each loop
+        let mut loop_states: HashMap<String, MergeEntry> = HashMap::new();
+
+        for event in events {
+            let entry = loop_states
+                .entry(event.loop_id.clone())
+                .or_insert_with(|| MergeEntry {
+                    loop_id: event.loop_id.clone(),
+                    prompt: String::new(),
+                    state: MergeState::Queued,
+                    queued_at: event.ts,
+                    merge_pid: None,
+                    merge_commit: None,
+                    failure_reason: None,
+                    discard_reason: None,
+                });
+
+            match &event.event {
+                MergeEventType::Queued { prompt } => {
+                    entry.prompt = prompt.clone();
+                    entry.state = MergeState::Queued;
+                    entry.queued_at = event.ts;
+                }
+                MergeEventType::Merging { pid } => {
+                    entry.state = MergeState::Merging;
+                    entry.merge_pid = Some(*pid);
+                }
+                MergeEventType::Merged { commit } => {
+                    entry.state = MergeState::Merged;
+                    entry.merge_commit = Some(commit.clone());
+                }
+                MergeEventType::NeedsReview { reason } => {
+                    entry.state = MergeState::NeedsReview;
+                    entry.failure_reason = Some(reason.clone());
+                }
+                MergeEventType::Discarded { reason } => {
+                    entry.state = MergeState::Discarded;
+                    entry.discard_reason = reason.clone();
+                }
+            }
+        }
+
+        // Sort by queued_at to maintain FIFO order
+        let mut entries: Vec<_> = loop_states.into_values().collect();
+        entries.sort_by(|a, b| a.queued_at.cmp(&b.queued_at));
+        entries
+    }
+
+    /// Appends an event to the queue file.
+    fn append_event(&self, event: &MergeEvent) -> Result<(), MergeQueueError> {
+        self.with_exclusive_lock(|mut file| {
+            // Seek to end
+            file.seek(SeekFrom::End(0))?;
+
+            // Write event as JSON line
+            let json = serde_json::to_string(event)
+                .map_err(|e| MergeQueueError::ParseError(e.to_string()))?;
+            writeln!(file, "{}", json)?;
+
+            file.sync_all()?;
+            Ok(())
+        })
+    }
+
+    /// Executes an operation with a shared (read) lock on the queue file.
+    #[cfg(unix)]
+    fn with_shared_lock<T, F>(&self, f: F) -> Result<T, MergeQueueError>
+    where
+        F: FnOnce(&File) -> Result<T, MergeQueueError>,
+    {
+        use nix::fcntl::{Flock, FlockArg};
+
+        let file = File::open(&self.queue_path)?;
+
+        // Acquire shared lock (blocking)
+        let flock = Flock::lock(file, FlockArg::LockShared).map_err(|(_, errno)| {
+            MergeQueueError::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("flock failed: {}", errno),
+            ))
+        })?;
+
+        // Get a reference to the inner file
+        use std::os::fd::AsFd;
+        let borrowed_fd = flock.as_fd();
+        let owned_fd = borrowed_fd.try_clone_to_owned()?;
+        let file: File = owned_fd.into();
+
+        f(&file)
+    }
+
+    #[cfg(not(unix))]
+    fn with_shared_lock<T, F>(&self, _f: F) -> Result<T, MergeQueueError>
+    where
+        F: FnOnce(&File) -> Result<T, MergeQueueError>,
+    {
+        Err(MergeQueueError::UnsupportedPlatform)
+    }
+
+    /// Executes an operation with an exclusive (write) lock on the queue file.
+    #[cfg(unix)]
+    fn with_exclusive_lock<T, F>(&self, f: F) -> Result<T, MergeQueueError>
+    where
+        F: FnOnce(File) -> Result<T, MergeQueueError>,
+    {
+        use nix::fcntl::{Flock, FlockArg};
+
+        // Ensure .ralph directory exists
+        if let Some(parent) = self.queue_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        // Open or create the file
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&self.queue_path)?;
+
+        // Acquire exclusive lock (blocking)
+        let flock = Flock::lock(file, FlockArg::LockExclusive).map_err(|(_, errno)| {
+            MergeQueueError::Io(io::Error::new(
+                io::ErrorKind::Other,
+                format!("flock failed: {}", errno),
+            ))
+        })?;
+
+        // Get a clone of the underlying file
+        use std::os::fd::AsFd;
+        let borrowed_fd = flock.as_fd();
+        let owned_fd = borrowed_fd.try_clone_to_owned()?;
+        let file: File = owned_fd.into();
+
+        f(file)
+    }
+
+    #[cfg(not(unix))]
+    fn with_exclusive_lock<T, F>(&self, _f: F) -> Result<T, MergeQueueError>
+    where
+        F: FnOnce(File) -> Result<T, MergeQueueError>,
+    {
+        Err(MergeQueueError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_enqueue() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-123", "implement auth").unwrap();
+
+        let entries = queue.list().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].loop_id, "loop-123");
+        assert_eq!(entries[0].prompt, "implement auth");
+        assert_eq!(entries[0].state, MergeState::Queued);
+    }
+
+    #[test]
+    fn test_full_merge_lifecycle() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        // Enqueue
+        queue.enqueue("loop-abc", "test prompt").unwrap();
+        let entry = queue.get_entry("loop-abc").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::Queued);
+
+        // Start merging
+        queue.mark_merging("loop-abc", 12345).unwrap();
+        let entry = queue.get_entry("loop-abc").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::Merging);
+        assert_eq!(entry.merge_pid, Some(12345));
+
+        // Complete merge
+        queue.mark_merged("loop-abc", "commit-sha-123").unwrap();
+        let entry = queue.get_entry("loop-abc").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::Merged);
+        assert_eq!(entry.merge_commit, Some("commit-sha-123".to_string()));
+    }
+
+    #[test]
+    fn test_merge_needs_review() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-def", "test").unwrap();
+        queue.mark_merging("loop-def", 99999).unwrap();
+        queue
+            .mark_needs_review("loop-def", "Conflicting changes in src/auth.rs")
+            .unwrap();
+
+        let entry = queue.get_entry("loop-def").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::NeedsReview);
+        assert_eq!(
+            entry.failure_reason,
+            Some("Conflicting changes in src/auth.rs".to_string())
+        );
+    }
+
+    #[test]
+    fn test_discard_from_queued() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-xyz", "test").unwrap();
+        queue.discard("loop-xyz", Some("No longer needed")).unwrap();
+
+        let entry = queue.get_entry("loop-xyz").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::Discarded);
+        assert_eq!(entry.discard_reason, Some("No longer needed".to_string()));
+    }
+
+    #[test]
+    fn test_discard_from_needs_review() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-xyz", "test").unwrap();
+        queue.mark_merging("loop-xyz", 123).unwrap();
+        queue.mark_needs_review("loop-xyz", "conflicts").unwrap();
+        queue.discard("loop-xyz", None).unwrap();
+
+        let entry = queue.get_entry("loop-xyz").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::Discarded);
+    }
+
+    #[test]
+    fn test_next_pending_fifo() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-1", "first").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        queue.enqueue("loop-2", "second").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        queue.enqueue("loop-3", "third").unwrap();
+
+        // First pending should be loop-1
+        let pending = queue.next_pending().unwrap().unwrap();
+        assert_eq!(pending.loop_id, "loop-1");
+
+        // Mark loop-1 as merging
+        queue.mark_merging("loop-1", 123).unwrap();
+
+        // Next pending should be loop-2
+        let pending = queue.next_pending().unwrap().unwrap();
+        assert_eq!(pending.loop_id, "loop-2");
+    }
+
+    #[test]
+    fn test_invalid_transition_queued_to_merged() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-xyz", "test").unwrap();
+
+        // Can't go directly from queued to merged
+        let result = queue.mark_merged("loop-xyz", "commit");
+        assert!(matches!(
+            result,
+            Err(MergeQueueError::InvalidTransition(
+                _,
+                MergeState::Queued,
+                MergeState::Merged
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_invalid_transition_merged_to_needs_review() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-xyz", "test").unwrap();
+        queue.mark_merging("loop-xyz", 123).unwrap();
+        queue.mark_merged("loop-xyz", "abc").unwrap();
+
+        // Can't go from merged to needs_review
+        let result = queue.mark_needs_review("loop-xyz", "error");
+        assert!(matches!(
+            result,
+            Err(MergeQueueError::InvalidTransition(
+                _,
+                MergeState::Merged,
+                MergeState::NeedsReview
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        let result = queue.mark_merging("nonexistent", 123);
+        assert!(matches!(result, Err(MergeQueueError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_retry_from_needs_review() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-retry", "test").unwrap();
+        queue.mark_merging("loop-retry", 100).unwrap();
+        queue.mark_needs_review("loop-retry", "conflicts").unwrap();
+
+        // Can retry (mark_merging) from needs_review
+        queue.mark_merging("loop-retry", 200).unwrap();
+        let entry = queue.get_entry("loop-retry").unwrap().unwrap();
+        assert_eq!(entry.state, MergeState::Merging);
+        assert_eq!(entry.merge_pid, Some(200));
+    }
+
+    #[test]
+    fn test_list_by_state() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        queue.enqueue("loop-1", "test 1").unwrap();
+        queue.enqueue("loop-2", "test 2").unwrap();
+        queue.enqueue("loop-3", "test 3").unwrap();
+
+        queue.mark_merging("loop-1", 123).unwrap();
+        queue.mark_merged("loop-1", "abc").unwrap();
+
+        queue.mark_merging("loop-2", 456).unwrap();
+
+        let queued = queue.list_by_state(MergeState::Queued).unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].loop_id, "loop-3");
+
+        let merging = queue.list_by_state(MergeState::Merging).unwrap();
+        assert_eq!(merging.len(), 1);
+        assert_eq!(merging[0].loop_id, "loop-2");
+
+        let merged = queue.list_by_state(MergeState::Merged).unwrap();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].loop_id, "loop-1");
+    }
+
+    #[test]
+    fn test_empty_queue() {
+        let temp_dir = TempDir::new().unwrap();
+        let queue = MergeQueue::new(temp_dir.path());
+
+        let entries = queue.list().unwrap();
+        assert!(entries.is_empty());
+
+        let pending = queue.next_pending().unwrap();
+        assert!(pending.is_none());
+    }
+
+    #[test]
+    fn test_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+
+        {
+            let queue = MergeQueue::new(temp_dir.path());
+            queue.enqueue("loop-persist", "test persistence").unwrap();
+        }
+
+        // Load again and verify data persisted
+        {
+            let queue = MergeQueue::new(temp_dir.path());
+            let entries = queue.list().unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].loop_id, "loop-persist");
+            assert_eq!(entries[0].prompt, "test persistence");
+        }
+    }
+
+    #[test]
+    fn test_event_serialization() {
+        let event = MergeEvent {
+            ts: Utc::now(),
+            loop_id: "loop-test".to_string(),
+            event: MergeEventType::Queued {
+                prompt: "test prompt".to_string(),
+            },
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: MergeEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.loop_id, event.loop_id);
+        match parsed.event {
+            MergeEventType::Queued { prompt } => assert_eq!(prompt, "test prompt"),
+            _ => panic!("Wrong event type"),
+        }
+    }
+
+    #[test]
+    fn test_creates_ralph_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let ralph_dir = temp_dir.path().join(".ralph");
+        let queue_file = ralph_dir.join("merge-queue.jsonl");
+
+        assert!(!ralph_dir.exists());
+        assert!(!queue_file.exists());
+
+        let queue = MergeQueue::new(temp_dir.path());
+        queue.enqueue("loop-dir", "test").unwrap();
+
+        assert!(ralph_dir.exists());
+        assert!(queue_file.exists());
+    }
+}

--- a/crates/ralph-core/src/task_store.rs
+++ b/crates/ralph-core/src/task_store.rs
@@ -2,14 +2,28 @@
 //!
 //! TaskStore provides load/save operations for the .agent/tasks.jsonl file,
 //! with convenience methods for querying and updating tasks.
+//!
+//! # Multi-loop Safety
+//!
+//! When multiple Ralph loops run concurrently (in worktrees), this store uses
+//! file locking to ensure safe concurrent access:
+//!
+//! - **Shared locks** for reading: Multiple loops can read simultaneously
+//! - **Exclusive locks** for writing: Only one loop can write at a time
+//!
+//! Use `load()` and `save()` for simple single-operation access, or use
+//! `with_exclusive_lock()` for read-modify-write operations that need atomicity.
 
+use crate::file_lock::FileLock;
 use crate::task::{Task, TaskStatus};
+use std::io;
 use std::path::Path;
 
-/// A store for managing tasks with JSONL persistence.
+/// A store for managing tasks with JSONL persistence and file locking.
 pub struct TaskStore {
     path: std::path::PathBuf,
     tasks: Vec<Task>,
+    lock: FileLock,
 }
 
 impl TaskStore {
@@ -17,7 +31,12 @@ impl TaskStore {
     ///
     /// If the file doesn't exist, returns an empty store.
     /// Silently skips malformed JSON lines.
-    pub fn load(path: &Path) -> std::io::Result<Self> {
+    ///
+    /// Uses a shared lock to allow concurrent reads from multiple loops.
+    pub fn load(path: &Path) -> io::Result<Self> {
+        let lock = FileLock::new(path)?;
+        let _guard = lock.shared()?;
+
         let tasks = if path.exists() {
             let content = std::fs::read_to_string(path)?;
             content
@@ -28,16 +47,21 @@ impl TaskStore {
         } else {
             Vec::new()
         };
+
         Ok(Self {
             path: path.to_path_buf(),
             tasks,
+            lock,
         })
     }
 
     /// Saves all tasks to the JSONL file.
     ///
     /// Creates parent directories if they don't exist.
-    pub fn save(&self) -> std::io::Result<()> {
+    /// Uses an exclusive lock to prevent concurrent writes.
+    pub fn save(&self) -> io::Result<()> {
+        let _guard = self.lock.exclusive()?;
+
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -55,6 +79,83 @@ impl TaskStore {
                 content + "\n"
             },
         )
+    }
+
+    /// Reloads tasks from disk, useful after external modifications.
+    ///
+    /// Uses a shared lock to allow concurrent reads.
+    pub fn reload(&mut self) -> io::Result<()> {
+        let _guard = self.lock.shared()?;
+
+        self.tasks = if self.path.exists() {
+            let content = std::fs::read_to_string(&self.path)?;
+            content
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .filter_map(|line| serde_json::from_str(line).ok())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        Ok(())
+    }
+
+    /// Executes a read-modify-write operation atomically.
+    ///
+    /// Acquires an exclusive lock, reloads from disk, executes the
+    /// provided function, and saves back to disk. This ensures that
+    /// concurrent modifications from other loops are not lost.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// store.with_exclusive_lock(|store| {
+    ///     let task = Task::new("New task".to_string(), 1);
+    ///     store.add(task);
+    /// })?;
+    /// ```
+    pub fn with_exclusive_lock<F, T>(&mut self, f: F) -> io::Result<T>
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        let _guard = self.lock.exclusive()?;
+
+        // Reload to get latest changes from other loops
+        self.tasks = if self.path.exists() {
+            let content = std::fs::read_to_string(&self.path)?;
+            content
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .filter_map(|line| serde_json::from_str(line).ok())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Execute the user function
+        let result = f(self);
+
+        // Save changes
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let content: String = self
+            .tasks
+            .iter()
+            .map(|t| serde_json::to_string(t).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(
+            &self.path,
+            if content.is_empty() {
+                String::new()
+            } else {
+                content + "\n"
+            },
+        )?;
+
+        Ok(result)
     }
 
     /// Adds a new task to the store and returns a reference to it.
@@ -140,7 +241,9 @@ mod tests {
 
     #[test]
     fn test_get_task() {
-        let mut store = TaskStore::load(&std::path::PathBuf::from("/dev/null")).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+        let mut store = TaskStore::load(&path).unwrap();
         let task = Task::new("Test".to_string(), 1);
         let id = task.id.clone();
         store.add(task);
@@ -151,7 +254,9 @@ mod tests {
 
     #[test]
     fn test_close_task() {
-        let mut store = TaskStore::load(&std::path::PathBuf::from("/dev/null")).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+        let mut store = TaskStore::load(&path).unwrap();
         let task = Task::new("Test".to_string(), 1);
         let id = task.id.clone();
         store.add(task);
@@ -163,7 +268,9 @@ mod tests {
 
     #[test]
     fn test_open_tasks() {
-        let mut store = TaskStore::load(&std::path::PathBuf::from("/dev/null")).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+        let mut store = TaskStore::load(&path).unwrap();
 
         let task1 = Task::new("Open 1".to_string(), 1);
         store.add(task1);
@@ -177,7 +284,9 @@ mod tests {
 
     #[test]
     fn test_ready_tasks() {
-        let mut store = TaskStore::load(&std::path::PathBuf::from("/dev/null")).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+        let mut store = TaskStore::load(&path).unwrap();
 
         let task1 = Task::new("Ready".to_string(), 1);
         let id1 = task1.id.clone();
@@ -194,7 +303,9 @@ mod tests {
 
     #[test]
     fn test_has_open_tasks() {
-        let mut store = TaskStore::load(&std::path::PathBuf::from("/dev/null")).unwrap();
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+        let mut store = TaskStore::load(&path).unwrap();
 
         assert!(!store.has_open_tasks());
 
@@ -202,5 +313,89 @@ mod tests {
         store.add(task);
 
         assert!(store.has_open_tasks());
+    }
+
+    #[test]
+    fn test_reload() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+
+        // Create and save initial store
+        let mut store1 = TaskStore::load(&path).unwrap();
+        store1.add(Task::new("Task 1".to_string(), 1));
+        store1.save().unwrap();
+
+        // Create second store that reads the same file
+        let mut store2 = TaskStore::load(&path).unwrap();
+        store2.add(Task::new("Task 2".to_string(), 1));
+        store2.save().unwrap();
+
+        // Reload first store to see changes
+        store1.reload().unwrap();
+        assert_eq!(store1.all().len(), 2);
+    }
+
+    #[test]
+    fn test_with_exclusive_lock() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+
+        let mut store = TaskStore::load(&path).unwrap();
+
+        // Use with_exclusive_lock for atomic operation
+        store
+            .with_exclusive_lock(|s| {
+                s.add(Task::new("Atomic task".to_string(), 1));
+            })
+            .unwrap();
+
+        // Verify the task was saved
+        let loaded = TaskStore::load(&path).unwrap();
+        assert_eq!(loaded.all().len(), 1);
+        assert_eq!(loaded.all()[0].title, "Atomic task");
+    }
+
+    #[test]
+    fn test_concurrent_writes_with_lock() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("tasks.jsonl");
+        let path_clone = path.clone();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        // Thread 1: Add task 1
+        let handle1 = thread::spawn(move || {
+            let mut store = TaskStore::load(&path).unwrap();
+            barrier.wait();
+
+            store
+                .with_exclusive_lock(|s| {
+                    s.add(Task::new("Task from thread 1".to_string(), 1));
+                })
+                .unwrap();
+        });
+
+        // Thread 2: Add task 2
+        let handle2 = thread::spawn(move || {
+            let mut store = TaskStore::load(&path_clone).unwrap();
+            barrier_clone.wait();
+
+            store
+                .with_exclusive_lock(|s| {
+                    s.add(Task::new("Task from thread 2".to_string(), 1));
+                })
+                .unwrap();
+        });
+
+        handle1.join().unwrap();
+        handle2.join().unwrap();
+
+        // Both tasks should be present
+        let final_store = TaskStore::load(tmp.path().join("tasks.jsonl").as_ref()).unwrap();
+        assert_eq!(final_store.all().len(), 2);
     }
 }

--- a/crates/ralph-core/src/worktree.rs
+++ b/crates/ralph-core/src/worktree.rs
@@ -1,0 +1,713 @@
+//! Git worktree management for parallel Ralph loops.
+//!
+//! Provides filesystem isolation for concurrent loops using git worktrees.
+//! Each parallel loop gets its own working directory with full filesystem
+//! isolation, sharing only `.git` history. Conflicts are resolved at merge time.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ralph_core::worktree::{Worktree, WorktreeConfig, create_worktree, remove_worktree, list_worktrees};
+//!
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let config = WorktreeConfig::default();
+//!
+//!     // Create worktree for a parallel loop
+//!     let worktree = create_worktree(".", "ralph-20250124-a3f2", &config)?;
+//!     println!("Created worktree at: {}", worktree.path.display());
+//!
+//!     // List all worktrees
+//!     let worktrees = list_worktrees(".")?;
+//!     for wt in worktrees {
+//!         println!("  {}: {}", wt.branch, wt.path.display());
+//!     }
+//!
+//!     // Clean up when done
+//!     remove_worktree(".", &worktree.path)?;
+//!     Ok(())
+//! }
+//! ```
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Configuration for worktree operations.
+#[derive(Debug, Clone)]
+pub struct WorktreeConfig {
+    /// Directory where worktrees are created (default: `.worktrees`).
+    pub worktree_dir: PathBuf,
+}
+
+impl Default for WorktreeConfig {
+    fn default() -> Self {
+        Self {
+            worktree_dir: PathBuf::from(".worktrees"),
+        }
+    }
+}
+
+impl WorktreeConfig {
+    /// Create config with custom worktree directory.
+    pub fn with_dir(dir: impl Into<PathBuf>) -> Self {
+        Self {
+            worktree_dir: dir.into(),
+        }
+    }
+
+    /// Get the absolute path to worktree directory relative to repo root.
+    pub fn worktree_path(&self, repo_root: &Path) -> PathBuf {
+        if self.worktree_dir.is_absolute() {
+            self.worktree_dir.clone()
+        } else {
+            repo_root.join(&self.worktree_dir)
+        }
+    }
+}
+
+/// Information about a git worktree.
+#[derive(Debug, Clone)]
+pub struct Worktree {
+    /// Absolute path to the worktree directory.
+    pub path: PathBuf,
+
+    /// The branch checked out in this worktree.
+    pub branch: String,
+
+    /// Whether this is the main worktree.
+    pub is_main: bool,
+
+    /// HEAD commit (if available).
+    pub head: Option<String>,
+}
+
+/// Errors that can occur during worktree operations.
+#[derive(Debug, thiserror::Error)]
+pub enum WorktreeError {
+    /// IO error.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Git command failed.
+    #[error("Git command failed: {0}")]
+    Git(String),
+
+    /// Worktree already exists.
+    #[error("Worktree already exists: {0}")]
+    AlreadyExists(String),
+
+    /// Worktree not found.
+    #[error("Worktree not found: {0}")]
+    NotFound(String),
+
+    /// Not a git repository.
+    #[error("Not a git repository: {0}")]
+    NotARepo(String),
+
+    /// Branch already exists.
+    #[error("Branch already exists: {0}")]
+    BranchExists(String),
+}
+
+/// Create a new worktree for a parallel Ralph loop.
+///
+/// Creates a new branch and worktree at `{config.worktree_dir}/{loop_id}`.
+/// The branch is created from HEAD of the current branch.
+///
+/// # Arguments
+///
+/// * `repo_root` - Root of the git repository
+/// * `loop_id` - Unique identifier for the loop (e.g., "ralph-20250124-a3f2")
+/// * `config` - Worktree configuration
+///
+/// # Returns
+///
+/// Information about the created worktree.
+pub fn create_worktree(
+    repo_root: impl AsRef<Path>,
+    loop_id: &str,
+    config: &WorktreeConfig,
+) -> Result<Worktree, WorktreeError> {
+    let repo_root = repo_root.as_ref();
+
+    // Verify this is a git repository
+    if !repo_root.join(".git").exists() && !repo_root.join(".git").is_file() {
+        return Err(WorktreeError::NotARepo(
+            repo_root.to_string_lossy().to_string(),
+        ));
+    }
+
+    let worktree_base = config.worktree_path(repo_root);
+    let worktree_path = worktree_base.join(loop_id);
+    let branch_name = format!("ralph/{loop_id}");
+
+    // Check if worktree already exists
+    if worktree_path.exists() {
+        return Err(WorktreeError::AlreadyExists(
+            worktree_path.to_string_lossy().to_string(),
+        ));
+    }
+
+    // Ensure worktree directory exists
+    fs::create_dir_all(&worktree_base)?;
+
+    // Create worktree with new branch
+    // git worktree add -b <branch> <path>
+    let output = Command::new("git")
+        .args(["worktree", "add", "-b", &branch_name])
+        .arg(&worktree_path)
+        .current_dir(repo_root)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // Check for specific error cases
+        if stderr.contains("already exists") {
+            if stderr.contains("branch") {
+                return Err(WorktreeError::BranchExists(branch_name));
+            }
+            return Err(WorktreeError::AlreadyExists(
+                worktree_path.to_string_lossy().to_string(),
+            ));
+        }
+
+        return Err(WorktreeError::Git(stderr.to_string()));
+    }
+
+    // Get the HEAD commit
+    let head = get_head_commit(&worktree_path).ok();
+
+    tracing::debug!(
+        "Created worktree at {} on branch {}",
+        worktree_path.display(),
+        branch_name
+    );
+
+    Ok(Worktree {
+        path: worktree_path,
+        branch: branch_name,
+        is_main: false,
+        head,
+    })
+}
+
+/// Remove a worktree and optionally its branch.
+///
+/// # Arguments
+///
+/// * `repo_root` - Root of the git repository
+/// * `worktree_path` - Path to the worktree to remove
+///
+/// # Note
+///
+/// This also deletes the associated branch if it exists.
+pub fn remove_worktree(
+    repo_root: impl AsRef<Path>,
+    worktree_path: impl AsRef<Path>,
+) -> Result<(), WorktreeError> {
+    let repo_root = repo_root.as_ref();
+    let worktree_path = worktree_path.as_ref();
+
+    if !worktree_path.exists() {
+        return Err(WorktreeError::NotFound(
+            worktree_path.to_string_lossy().to_string(),
+        ));
+    }
+
+    // Get the branch name before removing
+    let branch = get_worktree_branch(worktree_path);
+
+    // Remove the worktree (--force handles uncommitted changes)
+    let output = Command::new("git")
+        .args(["worktree", "remove", "--force"])
+        .arg(worktree_path)
+        .current_dir(repo_root)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(WorktreeError::Git(stderr.to_string()));
+    }
+
+    // Delete the branch if it was a ralph/* branch
+    if let Some(branch) = branch
+        && branch.starts_with("ralph/")
+    {
+        let output = Command::new("git")
+            .args(["branch", "-D", &branch])
+            .current_dir(repo_root)
+            .output()?;
+
+        if !output.status.success() {
+            // Non-fatal: branch might already be deleted
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::debug!("Failed to delete branch {}: {}", branch, stderr);
+        }
+    }
+
+    // Prune worktree refs
+    let _ = Command::new("git")
+        .args(["worktree", "prune"])
+        .current_dir(repo_root)
+        .output();
+
+    tracing::debug!("Removed worktree at {}", worktree_path.display());
+
+    Ok(())
+}
+
+/// List all git worktrees in the repository.
+///
+/// # Arguments
+///
+/// * `repo_root` - Root of the git repository (can be any worktree)
+///
+/// # Returns
+///
+/// List of all worktrees, including the main worktree.
+pub fn list_worktrees(repo_root: impl AsRef<Path>) -> Result<Vec<Worktree>, WorktreeError> {
+    let repo_root = repo_root.as_ref();
+
+    let output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_root)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(WorktreeError::Git(stderr.to_string()));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_worktree_list(&stdout)
+}
+
+/// Parse the porcelain output of `git worktree list`.
+fn parse_worktree_list(output: &str) -> Result<Vec<Worktree>, WorktreeError> {
+    let mut worktrees = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut current_head: Option<String> = None;
+    let mut current_branch: Option<String> = None;
+    let mut is_bare = false;
+
+    for line in output.lines() {
+        if line.starts_with("worktree ") {
+            // Save previous worktree if any
+            if let Some(path) = current_path.take()
+                && !is_bare
+            {
+                worktrees.push(Worktree {
+                    path,
+                    branch: current_branch
+                        .take()
+                        .unwrap_or_else(|| "(detached)".to_string()),
+                    is_main: worktrees.is_empty(), // First one is main
+                    head: current_head.take(),
+                });
+            }
+
+            current_path = Some(PathBuf::from(line.strip_prefix("worktree ").unwrap()));
+            current_head = None;
+            current_branch = None;
+            is_bare = false;
+        } else if line.starts_with("HEAD ") {
+            current_head = Some(line.strip_prefix("HEAD ").unwrap().to_string());
+        } else if line.starts_with("branch ") {
+            // Branch is in format "refs/heads/branch-name"
+            let branch_ref = line.strip_prefix("branch ").unwrap();
+            current_branch = Some(
+                branch_ref
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(branch_ref)
+                    .to_string(),
+            );
+        } else if line == "bare" {
+            is_bare = true;
+        }
+    }
+
+    // Don't forget the last one
+    if let Some(path) = current_path
+        && !is_bare
+    {
+        worktrees.push(Worktree {
+            path,
+            branch: current_branch.unwrap_or_else(|| "(detached)".to_string()),
+            is_main: worktrees.is_empty(),
+            head: current_head,
+        });
+    }
+
+    Ok(worktrees)
+}
+
+/// Ensure the worktree directory is in `.gitignore`.
+///
+/// Appends the pattern to `.gitignore` if not already present.
+///
+/// # Arguments
+///
+/// * `repo_root` - Root of the git repository
+/// * `worktree_dir` - The worktree directory pattern to ignore (e.g., ".worktrees")
+pub fn ensure_gitignore(
+    repo_root: impl AsRef<Path>,
+    worktree_dir: &str,
+) -> Result<(), WorktreeError> {
+    let repo_root = repo_root.as_ref();
+    let gitignore_path = repo_root.join(".gitignore");
+
+    // Pattern to add (with trailing slash for directory)
+    let pattern = if worktree_dir.ends_with('/') {
+        worktree_dir.to_string()
+    } else {
+        format!("{}/", worktree_dir)
+    };
+
+    // Check if pattern already exists
+    if gitignore_path.exists() {
+        let file = File::open(&gitignore_path)?;
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let line = line?;
+            let trimmed = line.trim();
+
+            // Check if this line matches our pattern (with or without trailing slash)
+            if trimmed == pattern || trimmed == pattern.trim_end_matches('/') {
+                tracing::debug!("Pattern {} already in .gitignore", pattern);
+                return Ok(());
+            }
+        }
+    }
+
+    // Append the pattern
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&gitignore_path)?;
+
+    // Add newline before if file exists and doesn't end with newline
+    if gitignore_path.exists() {
+        let contents = fs::read_to_string(&gitignore_path)?;
+        if !contents.is_empty() && !contents.ends_with('\n') {
+            writeln!(file)?;
+        }
+    }
+
+    writeln!(file, "{}", pattern)?;
+
+    tracing::debug!("Added {} to .gitignore", pattern);
+
+    Ok(())
+}
+
+/// Get the branch name for a worktree.
+fn get_worktree_branch(worktree_path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(worktree_path)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if branch != "HEAD" {
+            return Some(branch);
+        }
+    }
+    None
+}
+
+/// Get the HEAD commit SHA for a worktree.
+fn get_head_commit(worktree_path: &Path) -> Result<String, WorktreeError> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(worktree_path)
+        .output()?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(WorktreeError::Git(stderr.to_string()))
+    }
+}
+
+/// Get the list of Ralph-specific worktrees (those with `ralph/` branches).
+pub fn list_ralph_worktrees(repo_root: impl AsRef<Path>) -> Result<Vec<Worktree>, WorktreeError> {
+    let all = list_worktrees(repo_root)?;
+    Ok(all
+        .into_iter()
+        .filter(|wt| wt.branch.starts_with("ralph/"))
+        .collect())
+}
+
+/// Check if a worktree exists for the given loop ID.
+pub fn worktree_exists(
+    repo_root: impl AsRef<Path>,
+    loop_id: &str,
+    config: &WorktreeConfig,
+) -> bool {
+    let worktree_path = config.worktree_path(repo_root.as_ref()).join(loop_id);
+    worktree_path.exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn init_git_repo(dir: &Path) {
+        Command::new("git")
+            .args(["init", "--initial-branch=main"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+
+        Command::new("git")
+            .args(["config", "user.email", "test@test.local"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+
+        // Create initial commit (required for worktrees)
+        fs::write(dir.join("README.md"), "# Test").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_worktree_config_default() {
+        let config = WorktreeConfig::default();
+        assert_eq!(config.worktree_dir, PathBuf::from(".worktrees"));
+    }
+
+    #[test]
+    fn test_worktree_config_path() {
+        let config = WorktreeConfig::default();
+        let repo = Path::new("/repo");
+        assert_eq!(
+            config.worktree_path(repo),
+            PathBuf::from("/repo/.worktrees")
+        );
+
+        let absolute_config = WorktreeConfig::with_dir("/tmp/worktrees");
+        assert_eq!(
+            absolute_config.worktree_path(repo),
+            PathBuf::from("/tmp/worktrees")
+        );
+    }
+
+    #[test]
+    fn test_create_and_remove_worktree() {
+        let temp_dir = TempDir::new().unwrap();
+        init_git_repo(temp_dir.path());
+
+        let config = WorktreeConfig::default();
+        let loop_id = "test-loop-123";
+
+        // Create worktree
+        let worktree = create_worktree(temp_dir.path(), loop_id, &config).unwrap();
+
+        assert!(worktree.path.exists());
+        assert_eq!(worktree.branch, "ralph/test-loop-123");
+        assert!(!worktree.is_main);
+        assert!(worktree.head.is_some());
+
+        // Verify README was copied
+        assert!(worktree.path.join("README.md").exists());
+
+        // Remove worktree
+        remove_worktree(temp_dir.path(), &worktree.path).unwrap();
+        assert!(!worktree.path.exists());
+    }
+
+    #[test]
+    fn test_create_worktree_already_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        init_git_repo(temp_dir.path());
+
+        let config = WorktreeConfig::default();
+        let loop_id = "duplicate";
+
+        // Create first worktree
+        let _wt = create_worktree(temp_dir.path(), loop_id, &config).unwrap();
+
+        // Try to create duplicate
+        let result = create_worktree(temp_dir.path(), loop_id, &config);
+        assert!(matches!(result, Err(WorktreeError::AlreadyExists(_))));
+    }
+
+    #[test]
+    fn test_list_worktrees() {
+        let temp_dir = TempDir::new().unwrap();
+        init_git_repo(temp_dir.path());
+
+        // Initially just the main worktree
+        let worktrees = list_worktrees(temp_dir.path()).unwrap();
+        assert_eq!(worktrees.len(), 1);
+        assert!(worktrees[0].is_main);
+
+        // Add a worktree
+        let config = WorktreeConfig::default();
+        let _wt = create_worktree(temp_dir.path(), "loop-1", &config).unwrap();
+
+        let worktrees = list_worktrees(temp_dir.path()).unwrap();
+        assert_eq!(worktrees.len(), 2);
+    }
+
+    #[test]
+    fn test_list_ralph_worktrees() {
+        let temp_dir = TempDir::new().unwrap();
+        init_git_repo(temp_dir.path());
+
+        let config = WorktreeConfig::default();
+        let _wt1 = create_worktree(temp_dir.path(), "loop-1", &config).unwrap();
+        let _wt2 = create_worktree(temp_dir.path(), "loop-2", &config).unwrap();
+
+        let ralph_worktrees = list_ralph_worktrees(temp_dir.path()).unwrap();
+        assert_eq!(ralph_worktrees.len(), 2);
+        assert!(
+            ralph_worktrees
+                .iter()
+                .all(|wt| wt.branch.starts_with("ralph/"))
+        );
+    }
+
+    #[test]
+    fn test_ensure_gitignore_new_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let gitignore = temp_dir.path().join(".gitignore");
+
+        assert!(!gitignore.exists());
+
+        ensure_gitignore(temp_dir.path(), ".worktrees").unwrap();
+
+        assert!(gitignore.exists());
+        let contents = fs::read_to_string(&gitignore).unwrap();
+        assert!(contents.contains(".worktrees/"));
+    }
+
+    #[test]
+    fn test_ensure_gitignore_existing_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let gitignore = temp_dir.path().join(".gitignore");
+
+        fs::write(&gitignore, "node_modules/\n").unwrap();
+
+        ensure_gitignore(temp_dir.path(), ".worktrees").unwrap();
+
+        let contents = fs::read_to_string(&gitignore).unwrap();
+        assert!(contents.contains("node_modules/"));
+        assert!(contents.contains(".worktrees/"));
+    }
+
+    #[test]
+    fn test_ensure_gitignore_already_present() {
+        let temp_dir = TempDir::new().unwrap();
+        let gitignore = temp_dir.path().join(".gitignore");
+
+        fs::write(&gitignore, ".worktrees/\n").unwrap();
+
+        ensure_gitignore(temp_dir.path(), ".worktrees").unwrap();
+
+        let contents = fs::read_to_string(&gitignore).unwrap();
+        // Should only appear once
+        assert_eq!(contents.matches(".worktrees/").count(), 1);
+    }
+
+    #[test]
+    fn test_ensure_gitignore_without_trailing_slash() {
+        let temp_dir = TempDir::new().unwrap();
+        let gitignore = temp_dir.path().join(".gitignore");
+
+        // Existing pattern without trailing slash
+        fs::write(&gitignore, ".worktrees\n").unwrap();
+
+        ensure_gitignore(temp_dir.path(), ".worktrees").unwrap();
+
+        let contents = fs::read_to_string(&gitignore).unwrap();
+        // Should not add duplicate
+        assert!(!contents.contains(".worktrees/\n.worktrees/"));
+    }
+
+    #[test]
+    fn test_worktree_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        init_git_repo(temp_dir.path());
+
+        let config = WorktreeConfig::default();
+        let loop_id = "check-exists";
+
+        assert!(!worktree_exists(temp_dir.path(), loop_id, &config));
+
+        let _wt = create_worktree(temp_dir.path(), loop_id, &config).unwrap();
+
+        assert!(worktree_exists(temp_dir.path(), loop_id, &config));
+    }
+
+    #[test]
+    fn test_not_a_repo() {
+        let temp_dir = TempDir::new().unwrap();
+        // Don't init git
+
+        let config = WorktreeConfig::default();
+        let result = create_worktree(temp_dir.path(), "loop-1", &config);
+
+        assert!(matches!(result, Err(WorktreeError::NotARepo(_))));
+    }
+
+    #[test]
+    fn test_remove_nonexistent_worktree() {
+        let temp_dir = TempDir::new().unwrap();
+        init_git_repo(temp_dir.path());
+
+        let result = remove_worktree(temp_dir.path(), temp_dir.path().join("nonexistent"));
+
+        assert!(matches!(result, Err(WorktreeError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_parse_worktree_list() {
+        let output = r"worktree /path/to/main
+HEAD abc123def
+branch refs/heads/main
+
+worktree /path/to/.worktrees/loop-1
+HEAD def456ghi
+branch refs/heads/ralph/loop-1
+
+";
+
+        let worktrees = parse_worktree_list(output).unwrap();
+        assert_eq!(worktrees.len(), 2);
+
+        assert_eq!(worktrees[0].path, PathBuf::from("/path/to/main"));
+        assert_eq!(worktrees[0].branch, "main");
+        assert!(worktrees[0].is_main);
+        assert_eq!(worktrees[0].head, Some("abc123def".to_string()));
+
+        assert_eq!(
+            worktrees[1].path,
+            PathBuf::from("/path/to/.worktrees/loop-1")
+        );
+        assert_eq!(worktrees[1].branch, "ralph/loop-1");
+        assert!(!worktrees[1].is_main);
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for running multiple Ralph orchestration loops in parallel using git worktrees for filesystem isolation. This enables working on multiple independent tasks simultaneously without conflicts.

### Key Features

- **Automatic worktree spawning** — When a loop starts while another is running, it automatically spawns into `.worktrees/<loop-id>/`
- **Lock-based coordination** — Primary loop holds `.ralph/loop.lock`, additional loops detect this and spawn worktrees
- **Shared memories** — `.agent/memories.md` is symlinked to main repo, enabling cross-loop learning
- **Isolated state** — Events, tasks, and scratchpad are per-loop
- **Queue-based auto-merge** — Completed worktree loops queue for merge; primary loop processes queue on completion
- **AI-powered conflict resolution** — Merge-ralph uses hat collection (merger, resolver, tester, cleaner) to handle merges

### New CLI Commands

```bash
ralph loops              # List all loops with status
ralph loops logs <id>    # View loop output (--follow for streaming)
ralph loops history <id> # Show event history
ralph loops diff <id>    # Show changes from merge-base
ralph loops attach <id>  # Open shell in worktree
ralph loops retry <id>   # Re-run merge for failed loop
ralph loops stop <id>    # Terminate running loop
ralph loops discard <id> # Abandon and cleanup
ralph loops prune        # Clean up stale loops
```

### New `ralph run` Options

| Option | Description |
|--------|-------------|
| `--exclusive` | Wait for primary loop slot instead of spawning worktree |
| `--no-auto-merge` | Skip automatic merge after worktree loop completes |

### Architecture

```
Primary Loop (holds .ralph/loop.lock)
├── Runs in main workspace
├── Processes merge queue on completion
└── Spawns merge-ralph for queued loops

Worktree Loops (.worktrees/<loop-id>/)
├── Isolated filesystem via git worktree  
├── Symlinked memories → main repo
├── Queue for merge on completion
└── Exit cleanly (no spawn)
```

### Files Changed

| Area | Files | Purpose |
|------|-------|---------|
| Core | `loop_lock.rs`, `loop_registry.rs`, `merge_queue.rs`, `worktree.rs`, `loop_context.rs`, `loop_completion.rs`, `loop_history.rs`, `file_lock.rs` | Lock coordination, registry, merge queue, worktree management |
| CLI | `loops.rs`, `loop_runner.rs`, `main.rs`, `presets.rs` | Loop commands, queue processing, merge preset |
| Presets | `merge-loop.yml` | Hat collection for AI-powered merge workflow |
| Docs | `README.md`, `AGENTS.md` | Comprehensive user and developer documentation |

## Test plan

- [x] Manual E2E test: Two parallel loops modifying same file → successful merge
- [x] Lock coordination: Second loop spawns to worktree when lock held
- [x] Queue-based merge: Worktree queues, primary processes on completion
- [x] Conflict resolution: AI resolves conflicts and runs tests
- [x] All unit tests pass (`cargo test`)
- [ ] CI pipeline validation