### PR TITLE
fix: clarify cost display as estimate for subscription users

### DIFF
--- a/crates/ralph-adapters/src/stream_handler.rs
+++ b/crates/ralph-adapters/src/stream_handler.rs
@@ -112,7 +112,7 @@ impl StreamHandler for PrettyStreamHandler {
         let _ = self.stdout.queue(style::SetForegroundColor(color));
         let _ = self.stdout.write(
             format!(
-                "Duration: {}ms | Cost: ${:.4} | Turns: {}\n",
+                "Duration: {}ms | Est. cost: ${:.4} | Turns: {}\n",
                 result.duration_ms, result.total_cost_usd, result.num_turns
             )
             .as_bytes(),
@@ -224,7 +224,7 @@ impl StreamHandler for ConsoleStreamHandler {
         if self.verbose {
             let _ = writeln!(
                 self.stdout,
-                "\n--- Session Complete ---\nDuration: {}ms | Cost: ${:.4} | Turns: {}",
+                "\n--- Session Complete ---\nDuration: {}ms | Est. cost: ${:.4} | Turns: {}",
                 result.duration_ms, result.total_cost_usd, result.num_turns
             );
         }
@@ -476,7 +476,7 @@ impl StreamHandler for TuiStreamHandler {
             RatatuiColor::Green
         };
         let summary = format!(
-            "Duration: {}ms | Cost: ${:.4} | Turns: {}",
+            "Duration: {}ms | Est. cost: ${:.4} | Turns: {}",
             result.duration_ms, result.total_cost_usd, result.num_turns
         );
         let line = Line::from(Span::styled(summary, Style::default().fg(color)));

--- a/crates/ralph-cli/src/display.rs
+++ b/crates/ralph-cli/src/display.rs
@@ -168,7 +168,7 @@ pub fn print_termination(
         );
         if state.cumulative_cost > 0.0 {
             println!(
-                "{BOLD}|{RESET}   Cost:        {CYAN}${:.2}{RESET}",
+                "{BOLD}|{RESET}   Est. cost:   {CYAN}${:.2}{RESET}",
                 state.cumulative_cost
             );
         }
@@ -180,7 +180,7 @@ pub fn print_termination(
         println!("|   Iterations:  {}", state.iteration);
         println!("|   Elapsed:     {:.1}s", state.elapsed().as_secs_f64());
         if state.cumulative_cost > 0.0 {
-            println!("|   Cost:        ${:.2}", state.cumulative_cost);
+            println!("|   Est. cost:   ${:.2}", state.cumulative_cost);
         }
         println!("+{}+", "-".repeat(58));
     }

--- a/crates/ralph-core/src/summary_writer.rs
+++ b/crates/ralph-core/src/summary_writer.rs
@@ -114,7 +114,7 @@ impl SummaryWriter {
 
         // Cost (if tracked)
         if state.cumulative_cost > 0.0 {
-            content.push_str(&format!("**Cost:** ${:.2}\n", state.cumulative_cost));
+            content.push_str(&format!("**Est. cost:** ${:.2}\n", state.cumulative_cost));
         }
 
         // Tasks section (read from scratchpad if available)
@@ -326,7 +326,7 @@ More text here.
         assert!(content.contains("# Loop Summary"));
         assert!(content.contains("**Status:** Completed successfully"));
         assert!(content.contains("**Iterations:** 12"));
-        assert!(content.contains("**Cost:** $1.50"));
+        assert!(content.contains("**Est. cost:** $1.50"));
         assert!(content.contains("## Tasks"));
         assert!(content.contains("## Events"));
         assert!(content.contains("## Final Commit"));


### PR DESCRIPTION
## Summary

- Changes `Cost:` to `Est. cost:` across all display locations to clarify this is an estimate of what API calls would cost, not an actual charge
- Addresses confusion for Claude Code subscription users who thought they were being charged

Fixes #110

## Changes

| File | Change |
|------|--------|
| `crates/ralph-cli/src/display.rs` | Loop termination summary |
| `crates/ralph-adapters/src/stream_handler.rs` | Session result displays (Pretty, Console, TUI handlers) |
| `crates/ralph-core/src/summary_writer.rs` | Markdown summary output |

## Before/After

**Before:**
```
|   Cost:        $1.50
```

**After:**
```
|   Est. cost:   $1.50
```