### PR TITLE
feat(cli): add loop merge command and custom backend args

### DIFF
--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -614,6 +614,10 @@ struct PlanArgs {
     /// Backend to use (overrides config and auto-detection)
     #[arg(short, long, value_name = "BACKEND")]
     backend: Option<String>,
+
+    /// Custom backend command and arguments (use after --)
+    #[arg(last = true)]
+    custom_args: Vec<String>,
 }
 
 /// Arguments for the task subcommand.
@@ -630,6 +634,10 @@ struct CodeTaskArgs {
     /// Backend to use (overrides config and auto-detection)
     #[arg(short, long, value_name = "BACKEND")]
     backend: Option<String>,
+
+    /// Custom backend command and arguments (use after --)
+    #[arg(last = true)]
+    custom_args: Vec<String>,
 }
 
 #[tokio::main]
@@ -1620,6 +1628,11 @@ fn plan_command(
         user_input: args.idea,
         backend_override: args.backend,
         config_path,
+        custom_args: if args.custom_args.is_empty() {
+            None
+        } else {
+            Some(args.custom_args)
+        },
     };
 
     sop_runner::run_sop(config).map_err(|e| match e {
@@ -1668,6 +1681,11 @@ fn code_task_command(
         user_input: args.input,
         backend_override: args.backend,
         config_path,
+        custom_args: if args.custom_args.is_empty() {
+            None
+        } else {
+            Some(args.custom_args)
+        },
     };
 
     sop_runner::run_sop(config).map_err(|e| match e {


### PR DESCRIPTION
## Summary

This PR adds two enhancements to the Ralph CLI:

1. **Manual loop merging** - New `ralph loops merge` command to manually trigger merge of completed loops
2. **Custom backend arguments** - Support for passing custom backend commands/args to `ralph plan` and `ralph task`

Closes #117

## Changes

### Loop Merge Command

- Added `ralph loops merge <loop-id>` command with `--force` option
- Consolidates orphan worktree recovery and retry-merge logic
- Handles various loop states (queued, merging, completed, discarded)
- Force option allows retrying stuck merges

### Custom Backend Arguments (Resolves #117)

- Added `custom_args` field to `PlanArgs` and `CodeTaskArgs` 
- CLI accepts custom backend args after `--` separator
- `sop_runner` supports ad-hoc custom backend configuration
- Enables using any executable as a backend without config file
- Added "custom" as a valid backend name

## Usage Examples

### Custom Backend with Kimi CLI (Issue #117)

```bash
# Use Kimi CLI for planning
ralph plan -i "Add user authentication" -b custom -- kimi --model moonshot-v1-8k

# Use Kimi CLI for task execution
ralph task my-task.md -b custom -- kimi --model moonshot-v1-8k
```

### Loop Merge Command

```bash
# Manually merge a completed loop
ralph loops merge abc123

# Force retry a stuck merge
ralph loops merge abc123 --force
```

### Other Custom Backends

```bash
# Any CLI backend that accepts prompts
ralph plan -i "Add tests" -b custom -- custom-llm --model gpt-4 --temperature 0.7
```

## Technical Details

The implementation:
- Accepts custom args via the `--` separator (clap's `last = true` attribute)
- First arg becomes the backend command, remaining args are passed through
- Assumes `PromptMode::Arg` with prompt appended as last argument
- Falls back to config file if backend is "custom" but no CLI args provided

## Test Plan

- [x] Pre-commit hooks pass (fmt + clippy)
- [ ] Manual testing of loop merge command
- [ ] Manual testing with Kimi CLI (issue #117)
- [ ] Manual testing with other custom backends