### PR TITLE
feat: add features.parallel config gate for worktree spawning

### DIFF
--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -1039,6 +1039,15 @@ async fn run_command(
                 debug!("Acquired loop lock after waiting");
                 let context = LoopContext::primary(workspace_root.clone());
                 (context, Some(guard))
+            } else if !config.features.parallel {
+                // Parallel loops disabled via config - error out
+                anyhow::bail!(
+                    "Another loop is already running (PID {}, prompt: \"{}\"). \
+                    Parallel loops are disabled in config (features.parallel: false). \
+                    Use --exclusive to wait for the lock, or enable parallel loops.",
+                    existing.pid,
+                    existing.prompt.chars().take(50).collect::<String>()
+                );
             } else {
                 // Auto-spawn into worktree
                 info!(

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -121,6 +121,10 @@ pub struct RalphConfig {
     /// Tasks configuration for runtime work tracking.
     #[serde(default)]
     pub tasks: TasksConfig,
+
+    /// Feature flags for optional capabilities.
+    #[serde(default)]
+    pub features: FeaturesConfig,
 }
 
 fn default_true() -> bool {
@@ -160,6 +164,8 @@ impl Default for RalphConfig {
             memories: MemoriesConfig::default(),
             // Tasks
             tasks: TasksConfig::default(),
+            // Features
+            features: FeaturesConfig::default(),
         }
     }
 }
@@ -847,6 +853,31 @@ impl Default for TasksConfig {
     fn default() -> Self {
         Self {
             enabled: true, // Tasks enabled by default
+        }
+    }
+}
+
+/// Feature flags for optional Ralph capabilities.
+///
+/// Example configuration:
+/// ```yaml
+/// features:
+///   parallel: true  # Enable parallel loops via git worktrees
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeaturesConfig {
+    /// Whether parallel loops are enabled.
+    ///
+    /// When true (default), if another loop holds the lock, Ralph spawns
+    /// a parallel loop in a git worktree. When false, Ralph errors instead.
+    #[serde(default = "default_true")]
+    pub parallel: bool,
+}
+
+impl Default for FeaturesConfig {
+    fn default() -> Self {
+        Self {
+            parallel: true, // Parallel loops enabled by default
         }
     }
 }

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -44,8 +44,8 @@ pub mod worktree;
 
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
-    CliConfig, CoreConfig, EventLoopConfig, EventMetadata, HatBackend, HatConfig, InjectMode,
-    MemoriesConfig, MemoriesFilter, RalphConfig,
+    CliConfig, CoreConfig, EventLoopConfig, EventMetadata, FeaturesConfig, HatBackend, HatConfig,
+    InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig,
 };
 pub use diagnostics::DiagnosticsCollector;
 pub use event_logger::{EventHistory, EventLogger, EventRecord};


### PR DESCRIPTION
## Context

The parallel worktree feature (auto-spawning loops in git worktrees when another loop holds the lock) has **known bugs**:

- **Recursive spawning issues** — Worktree loops can trigger additional worktree spawns, leading to runaway token consumption
- **Merge queue coordination problems** — The queue-based merge system doesn't always work correctly
- **Orphan worktrees** — Ungraceful exits can leave worktrees that aren't properly cleaned up

Until these issues are resolved, users need a way to **disable the feature entirely**. This PR adds a config gate to do exactly that.

## Summary

Adds a `features.parallel` config option to control whether Ralph spawns worktree loops when the lock is held by another process.

## Changes

- Add `FeaturesConfig` struct with `parallel: bool` field
- Check `config.features.parallel` before spawning worktree
- Error with clear message when parallel is disabled and lock is held

## Usage

```yaml
# ralph.yml
features:
  parallel: false  # Disable worktree spawning to avoid known bugs
```

## Behavior

| `features.parallel` | Lock available | Lock held |
|---------------------|----------------|-----------|
| `true` (default) | Run as primary | Spawn worktree loop (buggy) |
| `false` | Run as primary | Error with clear message |

## Error Message

```
Another loop is already running (PID 12345, prompt: "...").
Parallel loops are disabled in config (features.parallel: false).
Use --exclusive to wait for the lock, or enable parallel loops.
```

## Testing

- [x] `cargo build` passes
- [x] `cargo test` passes (all 447+ tests)
- [x] Manual QA: verified error when `parallel: false` and lock held
- [x] Manual QA: verified worktree spawns when `parallel: true` and lock held