### PR TITLE
feat: add claude session controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,19 @@ MIT License — See [LICENSE](LICENSE) for details.
 ---
 
 *"I'm learnding!" - Ralph Wiggum*
+
+```yaml
+cli:
+  backend: "claude"
+  claude:
+    plugin_dirs:
+      - "~/.factory/claude/plugins/official"
+    mcp_configs:
+      - "~/.factory/claude/mcp-policy.json"
+    allowed_tools:
+      - "filesystem"
+    append_system_prompts:
+      - "Cite skill names explicitly."
+    append_system_prompt_files:
+      - "~/.factory/policy/claude-system.txt"
+```

--- a/crates/ralph-adapters/Cargo.toml
+++ b/crates/ralph-adapters/Cargo.toml
@@ -36,3 +36,4 @@ nix.workspace = true
 crossterm.workspace = true
 vt100.workspace = true
 strip-ansi-escapes.workspace = true
+shellexpand = "3"

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -662,6 +662,32 @@ impl CoreConfig {
     }
 }
 
+/// Claude CLI-specific configuration.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ClaudeCliConfig {
+    #[serde(default)]
+    pub plugin_dirs: Vec<String>,
+
+    #[serde(default)]
+    pub mcp_configs: Vec<String>,
+
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+
+    #[serde(default)]
+    pub append_system_prompts: Vec<String>,
+
+    #[serde(default)]
+    pub append_system_prompt_files: Vec<String>,
+
+    #[serde(default = "default_skip_permissions")]
+    pub dangerously_skip_permissions: bool,
+}
+
+fn default_skip_permissions() -> bool {
+    true
+}
+
 /// CLI backend configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliConfig {
@@ -696,6 +722,10 @@ pub struct CliConfig {
     /// If None, defaults to "-p" for arg mode.
     #[serde(default)]
     pub prompt_flag: Option<String>,
+
+    /// Claude-specific configuration.
+    #[serde(default)]
+    pub claude: ClaudeCliConfig,
 }
 
 fn default_backend() -> String {
@@ -724,6 +754,7 @@ impl Default for CliConfig {
             idle_timeout_secs: default_idle_timeout(),
             args: Vec::new(),
             prompt_flag: None,
+            claude: ClaudeCliConfig::default(),
         }
     }
 }


### PR DESCRIPTION
## 概要

Ralph Orchestrator が Claude CLI セッションを構成するための設定機能を追加します。
Ralph 側に独自のプラグイン/Skills 機構を実装することなく、Claude Code の既存機能（Plugins, MCP, Tools）を安全かつ柔軟に制御できるようになります。

## 主な変更点

*   **Config 設定の追加**: `cli.claude` セクションにて以下を設定可能になりました
    *   `plugin_dirs`: `--plugin-dir` で読み込むディレクトリ（`~` 展開対応）
    *   `mcp_configs`: `--mcp-config` で読み込む設定ファイル（`~` 展開対応）
    *   `allowed_tools`: `--allowedTools` で許可するツールリスト
    *   `append_system_prompts`: `--append-system-prompt` で直接渡す文字列
    *   `append_system_prompt_files`: ポリシーファイルを読み込んで system prompt として渡す（読み込み失敗時は Warn）
*   **BackendKind Enum の導入**: 文字列比較 (`command == "claude"`) に依存せず、バックエンドの種類を型安全に判定するようにしました。これにより、コマンドをフルパスやラッパーに変更しても Claude 特有の処理（temp file, system prompt append）が正しく動作します。
*   **コマンドオーバーライドのサポート**: `cli.command` 設定により、Claude CLI のパスやラッパーコマンドを変更可能になりました。
*   **互換性の維持**: 既存の `cli.args` を最後に結合するため、既存のカスタム引数設定を壊しません。

## 互換性の保証

既存の設定ファイルで `cli.claude` を指定しない場合、Claude backend の起動引数は従来のデフォルトと同等で動作します（破壊的変更はありません）。

## 設計上の留意点

*   `cli.args` は互換性維持のため最後に結合されていますが、`cli.claude.allowed_tools` などで設定したフラグ（例: `--allowedTools`）と重複する引数を `cli.args` で追加した場合、挙動が不明確になる可能性があります。基本は `cli.claude.*` 設定をご利用ください。