### PR TITLE
feat(hats): add Event Publishing Guide and skip topology when hat active

### DIFF
--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -374,7 +374,10 @@ impl EventLoop {
     /// Initializes the loop by publishing the start event.
     pub fn initialize(&mut self, prompt_content: &str) {
         // Use configured starting_event or default to task.start for backward compatibility
-        let topic = self.config.event_loop.starting_event
+        let topic = self
+            .config
+            .event_loop
+            .starting_event
             .clone()
             .unwrap_or_else(|| "task.start".to_string());
         self.initialize_with_topic(&topic, prompt_content);


### PR DESCRIPTION
## Summary

Two improvements to reduce token usage and improve hat guidance:

1. **Event Publishing Guide**: Auto-inject a guide into each active hat's instructions showing what happens when it publishes events
2. **Skip topology when hat active**: When a specific hat is triggered, skip the table + Mermaid diagram (~300+ tokens saved)

### Before (when hat is active)
```
## HATS

Delegate via events.

| Hat | Triggers On | Publishes | Description |
|-----|-------------|----------|-------------|
| Ralph | task.start, build.done... | build.task | Coordinates workflow... |
| 🔨 Builder | build.task | build.done, build.blocked | Builds code |

[mermaid diagram...]

### 🔨 Builder Instructions
...
```

### After (when hat is active)
```
## ACTIVE HAT

### 🔨 Builder Instructions
...

### Event Publishing Guide

When you publish:
- `build.done` → Received by: 📝 Confessor (produces ConfessionReport)
- `build.blocked` → Received by: Ralph (coordinates next steps)
```

### When Ralph is coordinating (no active hats)
Full topology table + Mermaid still shown - Ralph needs this for delegation decisions.

## Test plan

- [x] Unit tests for `event_publishing_guide()` output format
- [x] Tests for topology shown only when coordinating
- [x] Tests for active hat gets instructions + guide only
- [x] All existing tests updated and passing
- [x] `cargo test -p ralph-core` passes
- [x] `cargo clippy` clean