### PR TITLE
Fix completion promise false positives

### DIFF
--- a/crates/ralph-core/src/event_parser.rs
+++ b/crates/ralph-core/src/event_parser.rs
@@ -207,6 +207,11 @@ impl EventParser {
     ///    (prevents accidental completion when agents discuss the promise)
     /// 2. Otherwise, checks for the promise in the stripped output
     pub fn contains_promise(output: &str, promise: &str) -> bool {
+        // Treat empty/whitespace-only promise as "disabled".
+        //
+        // This matters because `str::contains("")` is always true, which would
+        // otherwise cause immediate termination when users pass e.g.
+        // `--completion-promise ""`.
         if promise.trim().is_empty() {
             return false;
         }
@@ -361,10 +366,7 @@ Working on implementation...
             "No promise here",
             "LOOP_COMPLETE"
         ));
-        assert!(!EventParser::contains_promise(
-            "LOOP_COMPLETE",
-            ""
-        ));
+        assert!(!EventParser::contains_promise("LOOP_COMPLETE", ""));
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/mikeyobrien/ralph-orchestrator/issues/139

## Problem
Some backends (notably Codex) echo the full prompt back in their transcript. The prompt itself includes Ralph instructions that mention the completion promise token (e.g. `LOOP_COMPLETE`).

Ralph was checking completion by doing a substring match against the raw backend output. That caused false positives:
- A normal iteration that emits `direction.set` could terminate immediately because the echoed prompt contained `LOOP_COMPLETE`.
- `--completion-promise ""` effectively enabled immediate completion because `str::contains("")` is always true.

## Solution
- Treat empty/whitespace-only completion promise as disabled in `EventParser::contains_promise`.
- Strip a single echoed prompt instance from backend output *for parsing only*, but only when it looks like a transcript echo (at start of output or preceded by a common `user` marker). This keeps the behavior conservative and avoids stripping legitimate assistant text.

## Tests
- `cargo test -p ralph-core event_parser --quiet`
- `cargo test -p ralph-cli loop_runner --quiet`
