### PR TITLE
docs(concepts): fix .agent/ paths to .ralph/agent/

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -78,8 +78,8 @@ Events flow between hats, each contributing to the task.
 | **Hat** | Specialized Ralph persona with specific triggers and behaviors |
 | **Event** | Typed message that triggers hats and carries state |
 | **Backpressure** | Quality gate (tests, lint, typecheck) that rejects bad work |
-| **Memory** | Persistent learning stored in `.agent/memories.md` |
-| **Task** | Runtime work item stored in `.agent/tasks.jsonl` |
+| **Memory** | Persistent learning stored in `.ralph/agent/memories.md` |
+| **Task** | Runtime work item stored in `.ralph/agent/tasks.jsonl` |
 
 ## Next Steps
 

--- a/docs/concepts/memories-and-tasks.md
+++ b/docs/concepts/memories-and-tasks.md
@@ -6,8 +6,8 @@ Ralph uses two complementary systems for persistent state: memories for cross-se
 
 | System | Storage | Purpose |
 |--------|---------|---------|
-| **Memories** | `.agent/memories.md` | Accumulated wisdom across sessions |
-| **Tasks** | `.agent/tasks.jsonl` | Runtime work items |
+| **Memories** | `.ralph/agent/memories.md` | Accumulated wisdom across sessions |
+| **Tasks** | `.ralph/agent/tasks.jsonl` | Runtime work items |
 
 Both are enabled by default and work together to replace the legacy scratchpad.
 

--- a/docs/concepts/ralph-wiggum-technique.md
+++ b/docs/concepts/ralph-wiggum-technique.md
@@ -55,7 +55,7 @@ Files on disk are the only persistent state:
 - The prompt file (`PROMPT.md`)
 - The codebase itself
 - Git history
-- Memory files (`.agent/memories.md`)
+- Memory files (`.ralph/agent/memories.md`)
 
 ### 3. Eventual Consistency
 

--- a/docs/concepts/tenets.md
+++ b/docs/concepts/tenets.md
@@ -80,8 +80,8 @@ Plans are cheap to regenerate. Don't fight to save a failing plan — just make 
 
 All persistent state lives on disk:
 
-- `.agent/memories.md` — Accumulated wisdom
-- `.agent/tasks.jsonl` — Runtime work tracking
+- `.ralph/agent/memories.md` — Accumulated wisdom
+- `.ralph/agent/tasks.jsonl` — Runtime work tracking
 - The codebase itself
 - Git history
 


### PR DESCRIPTION
A minor fix for the documentation. 