### PR TITLE
Fix Markdown syntax for "Documentation Pattern" prompt example

### DIFF
--- a/docs/guide/prompts.md
+++ b/docs/guide/prompts.md
@@ -122,7 +122,7 @@ The orchestrator will run until completion criteria are met or limits reached.
 
 ### 2. Documentation Pattern
 
-```markdown
+````markdown
 # Create User Documentation
 
 ## Objective
@@ -161,7 +161,7 @@ docs/
 - [ ] No broken links
 
 The orchestrator will continue iterations until limits are reached.
-```
+````
 
 ### 3. Data Analysis Pattern
 


### PR DESCRIPTION
The documentation site had a problem rendering this example:

<img width="1058" height="1009" alt="image" src="https://github.com/user-attachments/assets/a11dec26-c39c-4cd4-9331-16b2a4828dff" />

Now it's fixed :)
<img width="996" height="1204" alt="image" src="https://github.com/user-attachments/assets/c46d5669-c4ec-4fef-9bf1-67e75eef0b7b" />
