### PR TITLE
Fix: TUI display corruption when launched via default command

### DIFF
--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -715,6 +715,7 @@ async fn main() -> Result<()> {
     let tui_enabled = match &cli.command {
         Some(Commands::Run(args)) => !args.no_tui && !args.autonomous,
         Some(Commands::Resume(args)) => !args.no_tui && !args.autonomous,
+        None => true,
         _ => false,
     };
 

--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -116,6 +116,7 @@ impl App {
         execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
+        terminal.clear()?;
 
         // CRITICAL: Ensure terminal cleanup on ANY exit path (normal, abort, or panic).
         // When cleanup_tui() calls handle.abort(), the task is cancelled immediately


### PR DESCRIPTION
### Bug

When launching Ralph without a subcommand (`ralph` instead of `ralph run`), the TUI renders with severe visual corruption - log output bleeds into the terminal display, making it unusable until the window is resized.

### Root Cause

The `tui_enabled` flag in `main.rs` determines whether tracing output is redirected from stdout to a log file. This flag only matched `Some(Commands::Run(...))` and `Some(Commands::Resume(...))`, but the default command (no subcommand) produces `cli.command = None` - which fell through to `_ => false`.

The result: TUI was started by the `None` arm (which creates `RunArgs` with `no_tui: false`), but the tracing subscriber was configured to write to stdout instead of a file. Every `tracing::info!()` call wrote directly to the terminal, corrupting the alternate screen buffer that ratatui manages.

### Steps to Reproduce

1. Run `ralph` (no subcommand) in a project with a valid `ralph.yml`
2. Observe the TUI - log lines render over the TUI content
3. Resize the terminal window - display partially recovers but breaks again on next iteration

### Expected Behavior

TUI renders cleanly with header, content pane, and footer. Log output goes to `.ralph/diagnostics/logs/`.

### Actual Behavior

Raw tracing log lines (`2026-... INFO ralph_core::event_loop: ...`) render directly on the terminal, overlapping and corrupting the TUI layout. Resizing the window temporarily fixes the display because ratatui forces a full repaint, but the next log line corrupts it again.

### Fix

**`crates/ralph-cli/src/main.rs`** - Add `None => true` to the `tui_enabled` match so the default command (no subcommand) correctly redirects logs to a file:

```rust
let tui_enabled = match &cli.command {
    Some(Commands::Run(args)) => !args.no_tui && !args.autonomous,
    Some(Commands::Resume(args)) => !args.no_tui && !args.autonomous,
    None => true, // Default command runs with TUI enabled
    _ => false,
};
```

**`crates/ralph-tui/src/app.rs`** - Add `terminal.clear()` after terminal initialization. This is a ratatui best practice that ensures the first frame renders correctly regardless of the alternate screen's initial state.
