### PR TITLE
fix: hat display stuck on previous iteration's hat

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -1067,12 +1067,11 @@ pub async fn run_loop_impl(
         }
 
         // Read events from JSONL that agent may have written
-        let agent_wrote_events = matches!(
-            event_loop
-                .process_events_from_jsonl()
-                .inspect_err(|e| warn!(error = %e, "Failed to read events from JSONL")),
-            Ok(true)
-        );
+        let agent_wrote_events = event_loop
+            .process_events_from_jsonl()
+            .inspect_err(|e| warn!(error = %e, "Failed to read events from JSONL"))
+            .map(|r| r.had_events)
+            .unwrap_or(false);
 
         // Inject default_publishes for active hats only when agent wrote no events
         if !agent_wrote_events {

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -63,7 +63,7 @@ pub use config::{
 // Re-export loop_name types (also available via FeaturesConfig.loop_naming)
 pub use diagnostics::DiagnosticsCollector;
 pub use event_logger::{EventHistory, EventLogger, EventRecord};
-pub use event_loop::{EventLoop, LoopState, TerminationReason, UserPrompt};
+pub use event_loop::{EventLoop, LoopState, ProcessedEvents, TerminationReason, UserPrompt};
 pub use event_parser::EventParser;
 pub use event_reader::{Event, EventReader, MalformedLine, ParseResult};
 pub use file_lock::{FileLock, LockGuard as FileLockGuard, LockedFile};

--- a/crates/ralph-core/tests/event_loop_ralph.rs
+++ b/crates/ralph-core/tests/event_loop_ralph.rs
@@ -43,13 +43,16 @@ event_loop:
     std::env::set_current_dir(temp_dir.path()).unwrap();
 
     // Process events from JSONL
-    let has_orphans = event_loop.process_events_from_jsonl().unwrap();
+    let result = event_loop.process_events_from_jsonl().unwrap();
 
     // Restore original directory
     std::env::set_current_dir(original_dir).unwrap();
 
     // Verify: Ralph should handle the orphaned event
-    assert!(has_orphans, "Expected orphaned event to trigger Ralph");
+    assert!(
+        result.has_orphans,
+        "Expected orphaned event to trigger Ralph"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This was originally attempted to be fixed in #170, but was unsuccessful. Two bugs caused the TUI to show stale hat state:

1. process_events_from_jsonl returned has_orphans (bool), but the caller in loop_runner.rs treated it as had_events via matches!(Ok(true)). For non-orphan events (topic matches a hat trigger), has_orphans=false caused the caller to think no events were written and inject default_publishes, corrupting hat state. Fix: return a ProcessedEvents struct with separate had_events and has_orphans fields.

2. The TUI header always preferred the frozen IterationBuffer hat over the live pending_hat. After an iteration finishes (elapsed set) but before the next iteration starts, the stale frozen hat was displayed instead of the updated pending_hat. Fix: when iteration is finished and pending_hat is known, show pending_hat.

Both regression tests fail on old code, pass on fix.