### PR TITLE
fix: prevent UTF-8 truncation panics in prompt previews

### DIFF
--- a/crates/ralph-cli/src/hats.rs
+++ b/crates/ralph-cli/src/hats.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use indicatif::{ProgressBar, ProgressStyle};
 use ralph_adapters::{CliBackend, detect_backend_default};
-use ralph_core::{HatRegistry, RalphConfig};
+use ralph_core::{HatRegistry, RalphConfig, truncate_with_ellipsis};
 use std::collections::HashSet;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -205,8 +205,8 @@ fn list_hats<W: Write>(writer: &mut W, registry: &HatRegistry, _use_colors: bool
         };
 
         // Truncate desc if too long
-        let desc = if desc.len() > 58 {
-            format!("{}...", &desc[..55])
+        let desc = if desc.chars().count() > 58 {
+            truncate_with_ellipsis(desc, 55)
         } else {
             desc.to_string()
         };

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
-use crate::display::{build_tui_hat_map, print_iteration_separator, print_termination};
+use crate::display::{build_tui_hat_map, print_iteration_separator, print_termination, truncate};
 use crate::process_management;
 use crate::{ColorMode, Verbosity};
 
@@ -1453,7 +1453,7 @@ fn get_last_commit_info() -> Option<String> {
 /// Note: CLI overrides are already applied to config before this function is called.
 fn resolve_prompt_content(event_loop_config: &ralph_core::EventLoopConfig) -> Result<String> {
     debug!(
-        inline_prompt = ?event_loop_config.prompt.as_ref().map(|s| format!("{}...", &s[..s.len().min(50)])),
+        inline_prompt = ?event_loop_config.prompt.as_ref().map(|s| truncate(s, 50)),
         prompt_file = %event_loop_config.prompt_file,
         "Resolving prompt content"
     );

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -1234,11 +1234,8 @@ async fn run_command(
 
         // Show prompt source
         if let Some(ref inline) = config.event_loop.prompt {
-            let preview = if inline.len() > 60 {
-                format!("{}...", &inline[..60].replace('\n', " "))
-            } else {
-                inline.replace('\n', " ")
-            };
+            let inline_single_line = inline.replace('\n', " ");
+            let preview = truncate(&inline_single_line, 60);
             println!("  Prompt: inline text ({})", preview);
         } else {
             println!("  Prompt file: {}", config.event_loop.prompt_file);
@@ -2640,13 +2637,7 @@ core:
                     }
                 }
             })
-            .map(|p| {
-                if p.len() > 100 {
-                    format!("{}...", &p[..100])
-                } else {
-                    p
-                }
-            })
+            .map(|p| truncate(&p, 100))
             .unwrap_or_else(|| "[no prompt]".to_string());
 
         // Assert: summary contains file content, NOT the file path
@@ -2685,17 +2676,11 @@ core:
                     }
                 }
             })
-            .map(|p| {
-                if p.len() > 100 {
-                    format!("{}...", &p[..100])
-                } else {
-                    p
-                }
-            })
+            .map(|p| truncate(&p, 100))
             .unwrap_or_else(|| "[no prompt]".to_string());
 
-        // Assert: truncated to 100 chars + "..."
-        assert_eq!(prompt_summary.len(), 103); // 100 + "..."
+        // Assert: truncation uses shared UTF-8 safe helper
+        assert_eq!(prompt_summary, truncate(&long_content, 100));
         assert!(prompt_summary.ends_with("..."));
     }
 
@@ -2723,13 +2708,7 @@ core:
                     }
                 }
             })
-            .map(|p| {
-                if p.len() > 100 {
-                    format!("{}...", &p[..100])
-                } else {
-                    p
-                }
-            })
+            .map(|p| truncate(&p, 100))
             .unwrap_or_else(|| "[no prompt]".to_string());
 
         // Assert: returns "[no prompt]" for missing file

--- a/crates/ralph-cli/src/memory.rs
+++ b/crates/ralph-cli/src/memory.rs
@@ -11,7 +11,7 @@
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
-use ralph_core::{MarkdownMemoryStore, Memory, MemoryType};
+use ralph_core::{MarkdownMemoryStore, Memory, MemoryType, floor_char_boundary};
 use std::path::PathBuf;
 
 /// ANSI color codes for terminal output.
@@ -582,7 +582,8 @@ fn print_memories_table(memories: &[Memory], use_colors: bool) {
         };
         // Longer content preview (50 chars) for better readability
         let content_preview = if memory.content.len() > 50 {
-            format!("{}…", &memory.content[..50].replace('\n', " "))
+            let boundary = floor_char_boundary(&memory.content, 50);
+            format!("{}…", &memory.content[..boundary].replace('\n', " "))
         } else {
             memory.content.replace('\n', " ")
         };
@@ -721,8 +722,10 @@ fn truncate_to_budget(content: &str, budget: usize) -> String {
         return content.to_string();
     }
 
+    let safe_budget = floor_char_boundary(content, char_budget);
+
     // Find a good break point (end of a memory block)
-    let truncated = &content[..char_budget];
+    let truncated = &content[..safe_budget];
 
     // Try to find the last complete memory block (ends with -->)
     if let Some(last_complete) = truncated.rfind("-->") {
@@ -743,10 +746,15 @@ fn truncate_to_budget(content: &str, budget: usize) -> String {
 }
 
 fn truncate_str(s: &str, max_len: usize) -> String {
+    if max_len == 0 {
+        return String::new();
+    }
+
     if s.len() <= max_len {
         s.to_string()
     } else {
-        format!("{}…", &s[..max_len - 1])
+        let boundary = floor_char_boundary(s, max_len.saturating_sub(1));
+        format!("{}…", &s[..boundary])
     }
 }
 

--- a/crates/ralph-core/src/event_reader.rs
+++ b/crates/ralph-core/src/event_reader.rs
@@ -39,11 +39,7 @@ impl MalformedLine {
 
     /// Creates a new MalformedLine, truncating content if needed.
     pub fn new(line_number: u64, content: &str, error: String) -> Self {
-        let content = if content.len() > Self::MAX_CONTENT_LEN {
-            format!("{}...", &content[..Self::MAX_CONTENT_LEN])
-        } else {
-            content.to_string()
-        };
+        let content = crate::text::truncate_with_ellipsis(content, Self::MAX_CONTENT_LEN);
         Self {
             line_number,
             content,
@@ -278,6 +274,14 @@ mod tests {
         assert_eq!(result.malformed[0].line_number, 2);
         assert!(result.malformed[0].content.contains("corrupt json"));
         assert!(!result.malformed[0].error.is_empty());
+    }
+
+    #[test]
+    fn test_malformed_line_utf8_truncation_does_not_panic() {
+        // 100th byte lands inside "中" (3-byte UTF-8 char), which previously panicked.
+        let content = format!("{}中文后缀", "a".repeat(99));
+        let malformed = MalformedLine::new(1, &content, "bad json".to_string());
+        assert_eq!(malformed.content, format!("{}中...", "a".repeat(99)));
     }
 
     #[test]

--- a/crates/ralph-core/src/handoff.rs
+++ b/crates/ralph-core/src/handoff.rs
@@ -278,10 +278,10 @@ impl HandoffWriter {
 /// Truncates a prompt to a maximum length, adding ellipsis if needed.
 fn truncate_prompt(prompt: &str, max_len: usize) -> String {
     let prompt = prompt.trim();
-    if prompt.len() <= max_len {
+    if prompt.chars().count() <= max_len {
         prompt.to_string()
     } else {
-        format!("{}...", &prompt[..max_len])
+        crate::text::truncate_with_ellipsis(prompt, max_len)
     }
 }
 
@@ -377,5 +377,13 @@ mod tests {
         let result = truncate_prompt(&long_prompt, 50);
         assert_eq!(result.len(), 53); // 50 + "..."
         assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_prompt_utf8_boundary_safe() {
+        // 50th byte lands inside "中" (3-byte UTF-8 char), which previously panicked.
+        let prompt = format!("{}中文", "a".repeat(49));
+        let result = truncate_prompt(&prompt, 50);
+        assert_eq!(result, format!("{}中...", "a".repeat(49)));
     }
 }

--- a/crates/ralph-core/src/loop_context.rs
+++ b/crates/ralph-core/src/loop_context.rs
@@ -520,7 +520,7 @@ impl LoopContext {
 
         // Truncate prompt for readability
         let prompt_preview = if prompt.len() > 200 {
-            format!("{}...", &prompt[..200])
+            crate::text::truncate_with_ellipsis(prompt, 200)
         } else {
             prompt.to_string()
         };
@@ -956,6 +956,27 @@ mod tests {
             .generate_context_file("ralph/loop-1234", "Add footer")
             .unwrap();
         assert!(!created_again);
+    }
+
+    #[test]
+    fn test_generate_context_file_handles_utf8_prompt_boundary() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path().to_path_buf();
+        let worktree_path = repo_root.join(".worktrees/loop-utf8");
+
+        let ctx = LoopContext::worktree("loop-utf8", worktree_path.clone(), repo_root.clone());
+        ctx.ensure_agent_dir().unwrap();
+
+        // 200th byte lands inside "中" (3-byte UTF-8 char), which previously panicked.
+        let prompt = format!("{}中xyz", "a".repeat(199));
+        let created = ctx
+            .generate_context_file("ralph/loop-utf8", &prompt)
+            .unwrap();
+        assert!(created);
+
+        let content = std::fs::read_to_string(ctx.context_path()).unwrap();
+        let expected_preview = format!("{}中...", "a".repeat(199));
+        assert!(content.contains(&expected_preview));
     }
 
     #[cfg(unix)]

--- a/crates/ralph-core/src/merge_queue.rs
+++ b/crates/ralph-core/src/merge_queue.rs
@@ -653,14 +653,19 @@ pub fn smart_merge_summary(workspace: &Path, loop_id: &str) -> Result<String, Me
     let suffix_len = 8 + loop_id.len(); // " (loop " + loop_id + ")"
     let max_summary_len = 72 - prefix_len - suffix_len;
 
-    // Truncate if needed
-    let summary = if summary.len() > max_summary_len {
-        format!("{}...", &summary[..max_summary_len.saturating_sub(3)])
-    } else {
-        summary
-    };
+    let summary = truncate_merge_summary(&summary, max_summary_len);
 
     Ok(summary)
+}
+
+fn truncate_merge_summary(summary: &str, max_summary_len: usize) -> String {
+    if summary.len() > max_summary_len {
+        let prefix_limit = max_summary_len.saturating_sub(3);
+        let boundary = crate::text::floor_char_boundary(summary, prefix_limit);
+        format!("{}...", &summary[..boundary])
+    } else {
+        summary.to_string()
+    }
 }
 
 /// Extract summary from a git log --oneline line (removes commit hash prefix).
@@ -1047,5 +1052,13 @@ mod tests {
 
         assert!(ralph_dir.exists());
         assert!(queue_file.exists());
+    }
+
+    #[test]
+    fn test_truncate_merge_summary_utf8_boundary_safe() {
+        // prefix_limit=58 lands inside "中" (3-byte UTF-8 char), which previously panicked.
+        let summary = format!("{}中文提交", "a".repeat(57));
+        let truncated = truncate_merge_summary(&summary, 61);
+        assert_eq!(truncated, format!("{}...", "a".repeat(57)));
     }
 }


### PR DESCRIPTION
## Summary
- fix UTF-8 string boundary panics caused by byte slicing (`&s[..N]`) in prompt/summary preview paths
- replace unsafe truncation with UTF-8-safe helpers in CLI/core runtime paths
- add regression tests for mixed ASCII + CJK boundary cases to prevent reintroduction

## Files
- `crates/ralph-cli/src/main.rs`
- `crates/ralph-cli/src/loop_runner.rs`
- `crates/ralph-cli/src/hats.rs`
- `crates/ralph-cli/src/memory.rs`
- `crates/ralph-core/src/loop_context.rs`
- `crates/ralph-core/src/handoff.rs`
- `crates/ralph-core/src/event_reader.rs`
- `crates/ralph-core/src/merge_queue.rs`

## Validation
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test -p ralph-core smoke_runner`
- manual repro:
  - before: `ralph run --dry-run -p "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa中文复现"` panicked with `not a char boundary`
  - after: same command succeeds and prints prompt preview
