### PR TITLE
feat(loops): refactor scratchpad configuration to support per-hat

### DIFF
--- a/crates/ralph-cli/src/doctor.rs
+++ b/crates/ralph-cli/src/doctor.rs
@@ -614,6 +614,7 @@ mod tests {
             backend,
             default_publishes: None,
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -1630,9 +1630,6 @@ pub async fn run_loop_impl(
             );
         }
 
-        // Log full prompt to diagnostics (RALPH_DIAGNOSTICS=1)
-        event_loop.log_prompt(iteration, display_hat.as_str(), &prompt);
-
         // In verbose mode, print the full prompt before execution
         if verbosity == Verbosity::Verbose {
             eprintln!("\n{}", "=".repeat(80));

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -201,18 +201,31 @@ pub async fn run_loop_impl(
 
         debug!("Created events file for this run: {}", relative_events_path);
 
-        // Clear scratchpad for fresh objective start
+        // Clear scratchpads for fresh objective start
         // Stale content from previous runs can confuse the agent about current task state
-        // Use the config's scratchpad path resolved against the workspace, not the
-        // hardcoded LoopContext default, so custom paths are properly cleared
-        let scratchpad_path = ctx.workspace().join(&config.core.scratchpad);
-        if scratchpad_path.exists() {
-            fs::remove_file(&scratchpad_path)
-                .with_context(|| format!("Failed to clear scratchpad: {:?}", scratchpad_path))?;
-            debug!(
-                "Cleared scratchpad for fresh objective: {:?}",
-                scratchpad_path
-            );
+        // Clear global scratchpad and all per-hat scratchpad overrides
+        let mut scratchpad_paths: Vec<PathBuf> =
+            vec![ctx.workspace().join(&config.core.scratchpad.path)];
+        for hat in config.hats.values() {
+            if let Some(ref sc) = hat.scratchpad
+                && sc.enabled
+            {
+                let hat_path = ctx.workspace().join(&sc.path);
+                if !scratchpad_paths.contains(&hat_path) {
+                    scratchpad_paths.push(hat_path);
+                }
+            }
+        }
+        for scratchpad_path in &scratchpad_paths {
+            if scratchpad_path.exists() {
+                fs::remove_file(scratchpad_path).with_context(|| {
+                    format!("Failed to clear scratchpad: {:?}", scratchpad_path)
+                })?;
+                debug!(
+                    "Cleared scratchpad for fresh objective: {:?}",
+                    scratchpad_path
+                );
+            }
         }
     }
 
@@ -945,7 +958,7 @@ pub async fn run_loop_impl(
         handle_termination(
             &reason,
             event_loop.state(),
-            &config.core.scratchpad,
+            &config.core.scratchpad.path,
             &loop_history,
             &loop_context,
             auto_merge,
@@ -1016,7 +1029,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -1139,7 +1152,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -1224,7 +1237,7 @@ pub async fn run_loop_impl(
                 handle_termination(
                     &reason,
                     event_loop.state(),
-                    &config.core.scratchpad,
+                    &config.core.scratchpad.path,
                     &loop_history,
                     &loop_context,
                     auto_merge,
@@ -1298,7 +1311,7 @@ pub async fn run_loop_impl(
                         handle_termination(
                             &reason,
                             event_loop.state(),
-                            &config.core.scratchpad,
+                            &config.core.scratchpad.path,
                             &loop_history,
                             &loop_context,
                             auto_merge,
@@ -1360,7 +1373,7 @@ pub async fn run_loop_impl(
                     handle_termination(
                         &reason,
                         event_loop.state(),
-                        &config.core.scratchpad,
+                        &config.core.scratchpad.path,
                         &loop_history,
                         &loop_context,
                         auto_merge,
@@ -1423,7 +1436,7 @@ pub async fn run_loop_impl(
                 handle_termination(
                     &reason,
                     event_loop.state(),
-                    &config.core.scratchpad,
+                    &config.core.scratchpad.path,
                     &loop_history,
                     &loop_context,
                     auto_merge,
@@ -1521,7 +1534,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -1616,6 +1629,9 @@ pub async fn run_loop_impl(
                 use_colors,
             );
         }
+
+        // Log full prompt to diagnostics (RALPH_DIAGNOSTICS=1)
+        event_loop.log_prompt(iteration, display_hat.as_str(), &prompt);
 
         // In verbose mode, print the full prompt before execution
         if verbosity == Verbosity::Verbose {
@@ -1830,7 +1846,7 @@ pub async fn run_loop_impl(
                 )
                 .await?;
 
-                handle_termination(&reason, event_loop.state(), &config.core.scratchpad, &loop_history, &loop_context, auto_merge, &prompt_content);
+                handle_termination(&reason, event_loop.state(), &config.core.scratchpad.path, &loop_history, &loop_context, auto_merge, &prompt_content);
                 // Signal TUI to exit immediately on interrupt
                 let _ = terminated_tx.send(true);
                 return Ok(reason);
@@ -1876,7 +1892,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -1980,7 +1996,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -2078,7 +2094,7 @@ pub async fn run_loop_impl(
                 handle_termination(
                     &reason,
                     event_loop.state(),
-                    &config.core.scratchpad,
+                    &config.core.scratchpad.path,
                     &loop_history,
                     &loop_context,
                     auto_merge,
@@ -2173,7 +2189,7 @@ pub async fn run_loop_impl(
                 handle_termination(
                     &reason,
                     event_loop.state(),
-                    &config.core.scratchpad,
+                    &config.core.scratchpad.path,
                     &loop_history,
                     &loop_context,
                     auto_merge,
@@ -2270,7 +2286,7 @@ pub async fn run_loop_impl(
                 handle_termination(
                     &reason,
                     event_loop.state(),
-                    &config.core.scratchpad,
+                    &config.core.scratchpad.path,
                     &loop_history,
                     &loop_context,
                     auto_merge,
@@ -2357,7 +2373,7 @@ pub async fn run_loop_impl(
                 handle_termination(
                     &reason,
                     event_loop.state(),
-                    &config.core.scratchpad,
+                    &config.core.scratchpad.path,
                     &loop_history,
                     &loop_context,
                     auto_merge,
@@ -2442,7 +2458,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -2498,7 +2514,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -2559,7 +2575,7 @@ pub async fn run_loop_impl(
             handle_termination(
                 &reason,
                 event_loop.state(),
-                &config.core.scratchpad,
+                &config.core.scratchpad.path,
                 &loop_history,
                 &loop_context,
                 auto_merge,
@@ -9909,6 +9925,7 @@ hats:
                 timeout: Some(timeout_secs),
                 concurrency: 1,
                 aggregate: None,
+                scratchpad: None,
             },
             events: vec![event],
             total: 1,

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -402,7 +402,7 @@ pub(crate) fn apply_config_overrides(
         if let ConfigSource::Override { key, value } = source {
             match key.as_str() {
                 "core.scratchpad" => {
-                    config.core.scratchpad = value.clone();
+                    config.core.scratchpad.path = value.clone();
                 }
                 "core.specs_dir" => {
                     config.core.specs_dir = value.clone();
@@ -425,7 +425,7 @@ pub(crate) fn apply_config_overrides(
 
 /// Ensures the scratchpad's parent directory exists, creating it if needed.
 pub(crate) fn ensure_scratchpad_directory(config: &RalphConfig) -> anyhow::Result<()> {
-    let scratchpad_path = config.core.resolve_path(&config.core.scratchpad);
+    let scratchpad_path = config.core.resolve_path(&config.core.scratchpad.path);
     if let Some(parent) = scratchpad_path.parent()
         && !parent.exists()
     {
@@ -1395,17 +1395,17 @@ async fn run_command(
     // Handle --continue mode: check scratchpad exists before proceeding
     let resume = args.continue_mode;
     if resume {
-        let scratchpad_path = std::path::Path::new(&config.core.scratchpad);
+        let scratchpad_path = std::path::Path::new(&config.core.scratchpad.path);
         if !scratchpad_path.exists() {
             anyhow::bail!(
                 "Cannot continue: scratchpad not found at '{}'. \
                  Start a fresh run with `ralph run`.",
-                config.core.scratchpad
+                config.core.scratchpad.path
             );
         }
         info!(
             "Found existing scratchpad at '{}', continuing from previous state",
-            config.core.scratchpad
+            config.core.scratchpad.path
         );
     }
 
@@ -1510,7 +1510,10 @@ async fn run_command(
         );
         println!("  Max iterations: {}", config.event_loop.max_iterations);
         println!("  Max runtime: {}s", config.event_loop.max_runtime_seconds);
-        println!("  Scratchpad: {}", config.core.scratchpad);
+        println!(
+            "  Scratchpad: {} (enabled: {})",
+            config.core.scratchpad.path, config.core.scratchpad.enabled
+        );
         println!("  Specs dir: {}", config.core.specs_dir);
         println!("  Backend: {}", config.cli.backend);
         println!("  Verbose: {}", config.verbose);
@@ -1685,11 +1688,11 @@ async fn run_command(
     if !loop_context.is_primary() {
         config.core.workspace_root = loop_context.workspace().to_path_buf();
         // Also update scratchpad path to use worktree location
-        config.core.scratchpad = loop_context.scratchpad_path().to_string_lossy().to_string();
+        config.core.scratchpad.path = loop_context.scratchpad_path().to_string_lossy().to_string();
         debug!(
             "Running in worktree: workspace={}, scratchpad={}",
             config.core.workspace_root.display(),
-            config.core.scratchpad
+            config.core.scratchpad.path
         );
     }
 
@@ -2087,18 +2090,18 @@ async fn resume_command(
     let mut config = preflight::load_config_for_preflight(config_sources, hats_source).await?;
 
     // Check that scratchpad exists (required for resume)
-    let scratchpad_path = std::path::Path::new(&config.core.scratchpad);
+    let scratchpad_path = std::path::Path::new(&config.core.scratchpad.path);
     if !scratchpad_path.exists() {
         anyhow::bail!(
             "Cannot continue: scratchpad not found at '{}'. \
              Start a fresh run with `ralph run`.",
-            config.core.scratchpad
+            config.core.scratchpad.path
         );
     }
 
     info!(
         "Found existing scratchpad at '{}', continuing from previous state",
-        config.core.scratchpad
+        config.core.scratchpad.path
     );
 
     // Apply CLI overrides
@@ -2332,11 +2335,11 @@ fn clean_command(
     let config = load_config_with_overrides(config_sources)?;
 
     // Extract the .agent directory path from scratchpad path
-    let scratchpad_path = Path::new(&config.core.scratchpad);
+    let scratchpad_path = Path::new(&config.core.scratchpad.path);
     let agent_dir = scratchpad_path.parent().ok_or_else(|| {
         anyhow::anyhow!(
             "Could not determine parent directory from scratchpad path: {}",
-            config.core.scratchpad
+            config.core.scratchpad.path
         )
     })?;
 
@@ -3167,7 +3170,7 @@ mod tests {
             value: ".custom/scratch.md".to_string(),
         }];
         apply_config_overrides(&mut config, &sources).unwrap();
-        assert_eq!(config.core.scratchpad, ".custom/scratch.md");
+        assert_eq!(config.core.scratchpad.path, ".custom/scratch.md");
     }
 
     #[test]
@@ -3195,7 +3198,7 @@ mod tests {
             },
         ];
         apply_config_overrides(&mut config, &sources).unwrap();
-        assert_eq!(config.core.scratchpad, ".custom/scratch.md");
+        assert_eq!(config.core.scratchpad.path, ".custom/scratch.md");
         assert_eq!(config.core.specs_dir, "./my-specs/");
     }
 
@@ -3203,7 +3206,7 @@ mod tests {
     fn test_apply_config_overrides_unknown_field() {
         // Unknown core.* fields should warn but not error
         let mut config = RalphConfig::default();
-        let original_scratchpad = config.core.scratchpad.clone();
+        let original_scratchpad = config.core.scratchpad.path.clone();
         let sources = vec![ConfigSource::Override {
             key: "core.unknown_field".to_string(),
             value: "some_value".to_string(),
@@ -3211,7 +3214,7 @@ mod tests {
         // Should not error
         apply_config_overrides(&mut config, &sources).unwrap();
         // Original values should be unchanged
-        assert_eq!(config.core.scratchpad, original_scratchpad);
+        assert_eq!(config.core.scratchpad.path, original_scratchpad);
     }
 
     #[test]
@@ -3235,7 +3238,7 @@ mod tests {
         let mut config = RalphConfig::default();
         config.core.workspace_root = temp_dir.path().to_path_buf();
 
-        config.core.scratchpad = "a/b/c/scratchpad.md".to_string();
+        config.core.scratchpad.path = "a/b/c/scratchpad.md".to_string();
 
         let result = ensure_scratchpad_directory(&config);
         assert!(result.is_ok());
@@ -3254,7 +3257,7 @@ mod tests {
         // Pre-create the directory
         let subdir = temp_dir.path().join("existing");
         std::fs::create_dir_all(&subdir).unwrap();
-        config.core.scratchpad = "existing/scratchpad.md".to_string();
+        config.core.scratchpad.path = "existing/scratchpad.md".to_string();
 
         // Should succeed without error (no-op)
         let result = ensure_scratchpad_directory(&config);
@@ -3407,7 +3410,7 @@ core:
         .unwrap();
 
         let mut config = RalphConfig::from_file(&config_path).unwrap();
-        assert_eq!(config.core.scratchpad, ".agent/scratchpad.md");
+        assert_eq!(config.core.scratchpad.path, ".agent/scratchpad.md");
 
         // Apply override
         let overrides = vec![ConfigSource::Override {
@@ -3416,7 +3419,7 @@ core:
         }];
         apply_config_overrides(&mut config, &overrides).unwrap();
 
-        assert_eq!(config.core.scratchpad, ".custom/scratch.md");
+        assert_eq!(config.core.scratchpad.path, ".custom/scratch.md");
         assert_eq!(config.core.specs_dir, "./specs/"); // Unchanged
     }
 
@@ -3605,7 +3608,7 @@ core:
 
         let config = load_config_with_overrides(&sources).unwrap();
 
-        assert_eq!(config.core.scratchpad, ".custom/scratch.md");
+        assert_eq!(config.core.scratchpad.path, ".custom/scratch.md");
         let expected_root = std::fs::canonicalize(temp_dir.path())
             .unwrap_or_else(|_| temp_dir.path().to_path_buf());
         let actual_root = std::fs::canonicalize(&config.core.workspace_root)
@@ -3642,7 +3645,7 @@ core:
 
         let config = load_config_with_overrides(&sources).unwrap();
 
-        assert!(!config.core.scratchpad.is_empty());
+        assert!(!config.core.scratchpad.path.is_empty());
         let expected_root = std::fs::canonicalize(temp_dir.path())
             .unwrap_or_else(|_| temp_dir.path().to_path_buf());
         let actual_root = std::fs::canonicalize(&config.core.workspace_root)

--- a/crates/ralph-cli/tests/integration_events_isolation.rs
+++ b/crates/ralph-cli/tests/integration_events_isolation.rs
@@ -665,6 +665,83 @@ features:
     Ok(())
 }
 
+#[test]
+fn test_fresh_run_clears_per_hat_scratchpads() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let temp_path = temp_dir.path();
+
+    // Config with global + per-hat scratchpad overrides
+    let config = r#"
+event_loop:
+  prompt_file: "PROMPT.md"
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 1
+  max_runtime_seconds: 5
+
+cli:
+  backend: "custom"
+  command: "true"
+
+core:
+  scratchpad:
+    path: ".ralph/agent/scratchpad.md"
+
+hats:
+  planner:
+    name: "Planner"
+    description: "Plans work"
+    triggers: ["plan.start"]
+    scratchpad:
+      path: ".ralph/agent/planner.md"
+  builder:
+    name: "Builder"
+    description: "Builds things"
+    triggers: ["build.start"]
+    scratchpad: ".ralph/agent/builder.md"
+
+features:
+  preflight:
+    enabled: false
+"#;
+    fs::write(temp_path.join("ralph.yml"), config)?;
+    fs::write(temp_path.join("PROMPT.md"), "Test task")?;
+
+    // Create stale scratchpads at all three paths
+    let global_scratchpad = temp_path.join(".ralph/agent/scratchpad.md");
+    let planner_scratchpad = temp_path.join(".ralph/agent/planner.md");
+    let builder_scratchpad = temp_path.join(".ralph/agent/builder.md");
+
+    fs::create_dir_all(temp_path.join(".ralph/agent"))?;
+    fs::write(&global_scratchpad, "# Stale global\n- [ ] Old task\n")?;
+    fs::write(&planner_scratchpad, "# Stale planner\n- [ ] Plan old\n")?;
+    fs::write(&builder_scratchpad, "# Stale builder\n- [ ] Build old\n")?;
+
+    // Run ralph fresh (exit code doesn't matter — max_iterations=1 exits non-zero,
+    // but scratchpad cleanup happens before the loop starts)
+    let _output = Command::new(ralph_bin())
+        .arg("run")
+        .arg("--config")
+        .arg(temp_path.join("ralph.yml"))
+        .current_dir(temp_path)
+        .output()?;
+
+    // All scratchpads should have been cleared
+    assert!(
+        !global_scratchpad.exists(),
+        "Fresh run should clear the global scratchpad"
+    );
+    assert!(
+        !planner_scratchpad.exists(),
+        "Fresh run should clear the planner hat scratchpad"
+    );
+    assert!(
+        !builder_scratchpad.exists(),
+        "Fresh run should clear the builder hat scratchpad"
+    );
+
+    Ok(())
+}
+
 // =============================================================================
 // Directory Structure Tests
 // =============================================================================

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -4,10 +4,147 @@
 //! Users can switch from Python v1.x to Rust v2.0 with zero config changes.
 
 use ralph_proto::Topic;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tracing::debug;
+
+/// Scratchpad configuration with enabled flag and path.
+///
+/// Supports both plain string (legacy) and structured object in YAML:
+/// ```yaml
+/// # Legacy (plain string) — treated as { enabled: true, path: "..." }
+/// core:
+///   scratchpad: ".ralph/agent/scratchpad.md"
+///
+/// # Structured object
+/// core:
+///   scratchpad:
+///     enabled: true
+///     path: .ralph/agent/scratchpad.md
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScratchpadConfig {
+    #[serde(default = "scratchpad_enabled_default")]
+    pub enabled: bool,
+
+    #[serde(default = "default_scratchpad_path")]
+    pub path: String,
+}
+
+fn scratchpad_enabled_default() -> bool {
+    true
+}
+
+fn default_scratchpad_path() -> String {
+    ".ralph/agent/scratchpad.md".to_string()
+}
+
+impl Default for ScratchpadConfig {
+    fn default() -> Self {
+        Self {
+            enabled: scratchpad_enabled_default(),
+            path: default_scratchpad_path(),
+        }
+    }
+}
+
+impl ScratchpadConfig {
+    /// Resolves the effective scratchpad config for a hat run.
+    ///
+    /// Resolution order: hat override → global core config → defaults.
+    pub fn resolve(
+        hat_config: Option<&ScratchpadConfig>,
+        global: &ScratchpadConfig,
+    ) -> ScratchpadConfig {
+        match hat_config {
+            Some(override_config) => override_config.clone(),
+            None => global.clone(),
+        }
+    }
+}
+
+/// Custom deserializer that accepts both a plain string and a structured object.
+///
+/// - Plain string → `ScratchpadConfig { enabled: true, path: <string> }`
+/// - Map → normal `ScratchpadConfig` deserialization
+fn deserialize_scratchpad_config<'de, D>(deserializer: D) -> Result<ScratchpadConfig, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    struct ScratchpadConfigVisitor;
+
+    impl<'de> de::Visitor<'de> for ScratchpadConfigVisitor {
+        type Value = ScratchpadConfig;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or a scratchpad config object")
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<ScratchpadConfig, E> {
+            Ok(ScratchpadConfig {
+                enabled: true,
+                path: value.to_string(),
+            })
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, map: M) -> Result<ScratchpadConfig, M::Error> {
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
+        }
+    }
+
+    deserializer.deserialize_any(ScratchpadConfigVisitor)
+}
+
+/// Custom deserializer for optional scratchpad config on hats.
+///
+/// Handles: absent (None), plain string, or structured object.
+fn deserialize_optional_scratchpad_config<'de, D>(
+    deserializer: D,
+) -> Result<Option<ScratchpadConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    struct OptionalScratchpadConfigVisitor;
+
+    impl<'de> de::Visitor<'de> for OptionalScratchpadConfigVisitor {
+        type Value = Option<ScratchpadConfig>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("null, a string, or a scratchpad config object")
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Option<ScratchpadConfig>, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Option<ScratchpadConfig>, E> {
+            Ok(None)
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<Option<ScratchpadConfig>, E> {
+            Ok(Some(ScratchpadConfig {
+                enabled: true,
+                path: value.to_string(),
+            }))
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(
+            self,
+            map: M,
+        ) -> Result<Option<ScratchpadConfig>, M::Error> {
+            let config: ScratchpadConfig =
+                Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))?;
+            Ok(Some(config))
+        }
+    }
+
+    deserializer.deserialize_any(OptionalScratchpadConfigVisitor)
+}
 
 /// Top-level configuration for Ralph Orchestrator.
 ///
@@ -854,9 +991,10 @@ impl Default for EventLoopConfig {
 /// Per spec: "Core behaviors (always injected, can customize paths)"
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CoreConfig {
-    /// Path to the scratchpad file (shared state between hats).
-    #[serde(default = "default_scratchpad")]
-    pub scratchpad: String,
+    /// Scratchpad configuration (path and enabled flag).
+    /// Accepts both plain string (legacy) and structured object.
+    #[serde(default, deserialize_with = "deserialize_scratchpad_config")]
+    pub scratchpad: ScratchpadConfig,
 
     /// Path to the specs directory (source of truth for requirements).
     #[serde(default = "default_specs_dir")]
@@ -878,10 +1016,6 @@ pub struct CoreConfig {
     pub workspace_root: std::path::PathBuf,
 }
 
-fn default_scratchpad() -> String {
-    ".ralph/agent/scratchpad.md".to_string()
-}
-
 fn default_specs_dir() -> String {
     ".ralph/specs/".to_string()
 }
@@ -900,7 +1034,7 @@ fn default_guardrails() -> Vec<String> {
 impl Default for CoreConfig {
     fn default() -> Self {
         Self {
-            scratchpad: default_scratchpad(),
+            scratchpad: ScratchpadConfig::default(),
             specs_dir: default_specs_dir(),
             guardrails: default_guardrails(),
             workspace_root: std::env::var("RALPH_WORKSPACE_ROOT")
@@ -1731,6 +1865,11 @@ pub struct HatConfig {
     /// instead of activating the hat again.
     pub max_activations: Option<u32>,
 
+    /// Per-hat scratchpad override. If None, inherits from core.scratchpad.
+    /// Accepts both a plain string shorthand and a structured object.
+    #[serde(default, deserialize_with = "deserialize_optional_scratchpad_config")]
+    pub scratchpad: Option<ScratchpadConfig>,
+
     /// Tools the hat is not allowed to use.
     ///
     /// Injected as a TOOL RESTRICTIONS section in the prompt (soft enforcement).
@@ -2391,7 +2530,9 @@ hats:
     #[test]
     fn test_core_config_defaults() {
         let config = RalphConfig::default();
-        assert_eq!(config.core.scratchpad, ".ralph/agent/scratchpad.md");
+        assert_eq!(config.core.scratchpad, ScratchpadConfig::default());
+        assert_eq!(config.core.scratchpad.path, ".ralph/agent/scratchpad.md");
+        assert!(config.core.scratchpad.enabled);
         assert_eq!(config.core.specs_dir, ".ralph/specs/");
         // Default guardrails per spec
         assert_eq!(config.core.guardrails.len(), 6);
@@ -2411,7 +2552,8 @@ core:
   specs_dir: "./specifications/"
 "#;
         let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(config.core.scratchpad, ".workspace/plan.md");
+        assert_eq!(config.core.scratchpad.path, ".workspace/plan.md");
+        assert!(config.core.scratchpad.enabled);
         assert_eq!(config.core.specs_dir, "./specifications/");
         // Guardrails should use defaults when not specified
         assert_eq!(config.core.guardrails.len(), 6);
@@ -3506,6 +3648,271 @@ hats:
         let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
         let hat = config.hats.get("simple").unwrap();
         assert!(hat.extra_instructions.is_empty());
+    }
+
+    // === Per-Hat Scratchpad Configuration Tests ===
+
+    /// AC1: Legacy plain-string config
+    #[test]
+    fn test_scratchpad_legacy_plain_string() {
+        let yaml = r#"
+core:
+  scratchpad: ".workspace/plan.md"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.core.scratchpad,
+            ScratchpadConfig {
+                enabled: true,
+                path: ".workspace/plan.md".to_string()
+            }
+        );
+    }
+
+    /// AC2: Structured config with enabled/path
+    #[test]
+    fn test_scratchpad_structured_config() {
+        let yaml = r#"
+core:
+  scratchpad:
+    enabled: true
+    path: ".ralph/agent/scratchpad.md"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            config.core.scratchpad,
+            ScratchpadConfig {
+                enabled: true,
+                path: ".ralph/agent/scratchpad.md".to_string()
+            }
+        );
+    }
+
+    /// AC2 variant: Structured config with enabled: false
+    #[test]
+    fn test_scratchpad_structured_disabled() {
+        let yaml = r"
+core:
+  scratchpad:
+    enabled: false
+";
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!config.core.scratchpad.enabled);
+        assert_eq!(config.core.scratchpad.path, ".ralph/agent/scratchpad.md");
+    }
+
+    /// AC5/AC7: Default config unchanged
+    #[test]
+    fn test_scratchpad_default_config() {
+        let config = RalphConfig::default();
+        assert_eq!(
+            config.core.scratchpad,
+            ScratchpadConfig {
+                enabled: true,
+                path: ".ralph/agent/scratchpad.md".to_string()
+            }
+        );
+    }
+
+    /// AC8: Hat with plain-string scratchpad shorthand
+    #[test]
+    fn test_hat_scratchpad_plain_string() {
+        let yaml = r#"
+hats:
+  planner:
+    name: "Planner"
+    triggers: ["plan.start"]
+    scratchpad: ".ralph/agent/planner.md"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let hat = config.hats.get("planner").unwrap();
+        assert_eq!(
+            hat.scratchpad,
+            Some(ScratchpadConfig {
+                enabled: true,
+                path: ".ralph/agent/planner.md".to_string()
+            })
+        );
+    }
+
+    /// AC3 (config part): Hat disables scratchpad
+    #[test]
+    fn test_hat_scratchpad_disabled() {
+        let yaml = r#"
+hats:
+  validator:
+    name: "Validator"
+    triggers: ["validate.start"]
+    scratchpad:
+      enabled: false
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let hat = config.hats.get("validator").unwrap();
+        assert_eq!(
+            hat.scratchpad,
+            Some(ScratchpadConfig {
+                enabled: false,
+                path: ".ralph/agent/scratchpad.md".to_string()
+            })
+        );
+    }
+
+    /// AC4 (config part): Hat with custom path
+    #[test]
+    fn test_hat_scratchpad_custom_path() {
+        let yaml = r#"
+hats:
+  builder:
+    name: "Builder"
+    triggers: ["build.start"]
+    scratchpad:
+      path: ".ralph/agent/builder.md"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let hat = config.hats.get("builder").unwrap();
+        assert_eq!(
+            hat.scratchpad,
+            Some(ScratchpadConfig {
+                enabled: true,
+                path: ".ralph/agent/builder.md".to_string()
+            })
+        );
+    }
+
+    /// AC5 (config part): Hat inherits global (no scratchpad key)
+    #[test]
+    fn test_hat_scratchpad_inherits_global() {
+        let yaml = r#"
+hats:
+  reviewer:
+    name: "Reviewer"
+    triggers: ["review.start"]
+    instructions: "Review the code."
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let hat = config.hats.get("reviewer").unwrap();
+        assert!(
+            hat.scratchpad.is_none(),
+            "No scratchpad key means None (inherit global)"
+        );
+    }
+
+    /// Resolution function test
+    #[test]
+    fn test_scratchpad_resolve_hat_override() {
+        let global = ScratchpadConfig {
+            enabled: true,
+            path: ".ralph/agent/scratchpad.md".to_string(),
+        };
+        let hat_override = ScratchpadConfig {
+            enabled: true,
+            path: ".ralph/agent/planner.md".to_string(),
+        };
+        let resolved = ScratchpadConfig::resolve(Some(&hat_override), &global);
+        assert_eq!(resolved, hat_override);
+    }
+
+    #[test]
+    fn test_scratchpad_resolve_global_fallback() {
+        let global = ScratchpadConfig {
+            enabled: true,
+            path: ".ralph/agent/scratchpad.md".to_string(),
+        };
+        let resolved = ScratchpadConfig::resolve(None, &global);
+        assert_eq!(resolved, global);
+    }
+
+    /// AC9 (config part): Multiple hats with different configs
+    #[test]
+    fn test_multiple_hats_different_scratchpad_configs() {
+        let yaml = r#"
+core:
+  scratchpad:
+    enabled: true
+    path: ".ralph/agent/scratchpad.md"
+hats:
+  planner:
+    name: "Planner"
+    triggers: ["plan.start"]
+    scratchpad:
+      path: ".ralph/agent/planner.md"
+  builder:
+    name: "Builder"
+    triggers: ["build.start"]
+  validator:
+    name: "Validator"
+    triggers: ["validate.start"]
+    scratchpad:
+      enabled: false
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+
+        // Planner has custom path
+        let planner = config.hats.get("planner").unwrap();
+        let planner_resolved =
+            ScratchpadConfig::resolve(planner.scratchpad.as_ref(), &config.core.scratchpad);
+        assert_eq!(planner_resolved.path, ".ralph/agent/planner.md");
+        assert!(planner_resolved.enabled);
+
+        // Builder inherits global
+        let builder = config.hats.get("builder").unwrap();
+        let builder_resolved =
+            ScratchpadConfig::resolve(builder.scratchpad.as_ref(), &config.core.scratchpad);
+        assert_eq!(builder_resolved.path, ".ralph/agent/scratchpad.md");
+        assert!(builder_resolved.enabled);
+
+        // Validator is disabled
+        let validator = config.hats.get("validator").unwrap();
+        let validator_resolved =
+            ScratchpadConfig::resolve(validator.scratchpad.as_ref(), &config.core.scratchpad);
+        assert!(!validator_resolved.enabled);
+    }
+
+    /// Edge case: core.scratchpad missing entirely
+    #[test]
+    fn test_scratchpad_missing_defaults() {
+        let yaml = r#"
+core:
+  specs_dir: "./specs/"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.core.scratchpad, ScratchpadConfig::default());
+    }
+
+    /// Edge case: hat scratchpad with enabled but no path
+    #[test]
+    fn test_hat_scratchpad_enabled_no_path() {
+        let yaml = r#"
+hats:
+  worker:
+    name: "Worker"
+    triggers: ["work.start"]
+    scratchpad:
+      enabled: true
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let hat = config.hats.get("worker").unwrap();
+        let sc = hat.scratchpad.as_ref().unwrap();
+        assert!(sc.enabled);
+        assert_eq!(sc.path, ".ralph/agent/scratchpad.md");
+    }
+
+    /// Edge case: hat scratchpad with path but no enabled
+    #[test]
+    fn test_hat_scratchpad_path_no_enabled() {
+        let yaml = r#"
+hats:
+  worker:
+    name: "Worker"
+    triggers: ["work.start"]
+    scratchpad:
+      path: ".ralph/agent/worker.md"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let hat = config.hats.get("worker").unwrap();
+        let sc = hat.scratchpad.as_ref().unwrap();
+        assert!(sc.enabled);
+        assert_eq!(sc.path, ".ralph/agent/worker.md");
     }
 
     // ── Wave config tests (Step 2: HatConfig extensions) ──

--- a/crates/ralph-core/src/diagnostics/integration_tests.rs
+++ b/crates/ralph-core/src/diagnostics/integration_tests.rs
@@ -226,7 +226,7 @@ mod tests {
 
         // Configure event loop to use temp directory scratchpad
         let mut config = RalphConfig::default();
-        config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+        config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
 
         let diagnostics = DiagnosticsCollector::with_enabled(temp_dir.path(), true).unwrap();
         let mut event_loop = EventLoop::with_diagnostics(config, diagnostics);

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 
 pub use loop_state::LoopState;
 
-use crate::config::{HatBackend, InjectMode, RalphConfig};
+use crate::config::{HatBackend, InjectMode, RalphConfig, ScratchpadConfig};
 use crate::event_parser::{EventParser, MutationEvidence, MutationStatus};
 use crate::event_reader::EventReader;
 use crate::hat_registry::HatRegistry;
@@ -196,10 +196,19 @@ impl EventLoop {
 
     /// Creates a new event loop with explicit loop context and diagnostics.
     pub fn with_context_and_diagnostics(
-        config: RalphConfig,
+        mut config: RalphConfig,
         context: LoopContext,
         diagnostics: crate::diagnostics::DiagnosticsCollector,
     ) -> Self {
+        // Solo mode safety guard: force scratchpad enabled when no hats defined
+        if config.hats.is_empty() && !config.core.scratchpad.enabled {
+            warn!(
+                "core.scratchpad.enabled is false but no hats are defined. \
+                 Scratchpad is the only continuity mechanism in solo mode — forcing enabled."
+            );
+            config.core.scratchpad.enabled = true;
+        }
+
         let registry = HatRegistry::from_config(&config);
         let instruction_builder =
             InstructionBuilder::with_events(config.core.clone(), config.events.clone());
@@ -298,9 +307,18 @@ impl EventLoop {
 
     /// Creates a new event loop with explicit diagnostics collector (for testing).
     pub fn with_diagnostics(
-        config: RalphConfig,
+        mut config: RalphConfig,
         diagnostics: crate::diagnostics::DiagnosticsCollector,
     ) -> Self {
+        // Solo mode safety guard: force scratchpad enabled when no hats defined
+        if config.hats.is_empty() && !config.core.scratchpad.enabled {
+            warn!(
+                "core.scratchpad.enabled is false but no hats are defined. \
+                 Scratchpad is the only continuity mechanism in solo mode — forcing enabled."
+            );
+            config.core.scratchpad.enabled = true;
+        }
+
         let registry = HatRegistry::from_config(&config);
         let instruction_builder =
             InstructionBuilder::with_events(config.core.clone(), config.events.clone());
@@ -418,19 +436,28 @@ impl EventLoop {
             .unwrap_or_else(|| PathBuf::from(".ralph/agent/tasks.jsonl"))
     }
 
-    /// Returns the scratchpad path based on config and loop context.
+    /// Returns the scratchpad path based on loop context and active scratchpad config.
     ///
-    /// If the config specifies a custom (non-default) scratchpad path, that
-    /// always wins. Otherwise, the loop context path is used for worktree
-    /// isolation, falling back to the config default.
+    /// When a per-hat scratchpad override is active (path differs from global default),
+    /// the custom path is resolved relative to the loop context workspace for worktree
+    /// isolation. When using the default/global path, loop context's standard resolution
+    /// applies.
     fn scratchpad_path(&self) -> PathBuf {
-        if self.config.core.scratchpad != ".ralph/agent/scratchpad.md" {
-            return PathBuf::from(&self.config.core.scratchpad);
+        let active_path = &self.ralph.active_scratchpad().path;
+
+        match self.loop_context.as_ref() {
+            Some(ctx) => ctx.workspace().join(active_path),
+            None => PathBuf::from(active_path),
         }
+    }
+
+    /// Returns the global scratchpad path (ignoring per-hat overrides).
+    /// Used for guidance persistence which is cross-hat state.
+    fn global_scratchpad_path(&self) -> PathBuf {
         self.loop_context
             .as_ref()
             .map(|ctx| ctx.scratchpad_path())
-            .unwrap_or_else(|| PathBuf::from(&self.config.core.scratchpad))
+            .unwrap_or_else(|| PathBuf::from(&self.config.core.scratchpad.path))
     }
 
     /// Returns the current loop state.
@@ -914,6 +941,11 @@ impl EventLoop {
                     .collect::<Vec<_>>()
                     .join("\n");
 
+                // Solo mode: set scratchpad and iteration before guidance persistence
+                self.ralph
+                    .set_active_scratchpad(self.config.core.scratchpad.clone());
+                self.ralph.set_iteration(self.state.iteration);
+
                 // Persist and inject human guidance into prompt if present
                 self.update_robot_guidance(guidance_events);
                 self.apply_robot_guidance();
@@ -969,18 +1001,35 @@ impl EventLoop {
                     .into_iter()
                     .partition(|e| e.topic.as_str() == "human.guidance");
 
-                // Persist and inject human guidance before building prompt (must happen before
-                // immutable borrows from determine_active_hats)
-                self.update_robot_guidance(guidance_events);
-                self.apply_robot_guidance();
-
                 // Ignore kickoff/recovery noise when a real downstream event is pending.
                 let effective_regular_events = self.effective_regular_events(&regular_events);
 
-                // Determine which hats are active based on the effective event set
+                // Determine which hats are active based on regular events
                 let active_hat_ids = self.determine_active_hat_ids(&regular_events);
                 self.record_hat_activations(&active_hat_ids);
                 self.state.last_active_hat_ids = active_hat_ids.clone();
+
+                // Resolve scratchpad config for the active hat (or global default).
+                // Must happen BEFORE guidance persistence so guidance is written
+                // to the correct hat's scratchpad file.
+                let resolved_scratchpad = if let Some(hat_id) = active_hat_ids.first() {
+                    let hat_scratchpad = self
+                        .registry
+                        .get_config(hat_id)
+                        .and_then(|c| c.scratchpad.as_ref());
+                    ScratchpadConfig::resolve(hat_scratchpad, &self.config.core.scratchpad)
+                } else {
+                    // Ralph coordinating — use global
+                    self.config.core.scratchpad.clone()
+                };
+                self.ralph.set_active_scratchpad(resolved_scratchpad);
+                self.ralph.set_iteration(self.state.iteration);
+
+                // Persist and inject human guidance after scratchpad resolution
+                // (must also happen before immutable borrows from determine_active_hats)
+                self.update_robot_guidance(guidance_events);
+                self.apply_robot_guidance();
+
                 let active_hats = self.determine_active_hats(&regular_events);
 
                 // Format events for context
@@ -1063,10 +1112,23 @@ impl EventLoop {
     ///
     /// Each guidance message is written as a timestamped markdown entry so it
     /// appears alongside the agent's own thinking and survives process restarts.
+    ///
+    /// When scratchpad is disabled for the current hat, persists to the global
+    /// scratchpad path (guidance is cross-hat state). If global is also disabled,
+    /// skips persistence.
     fn persist_guidance_to_scratchpad(&self, guidance_events: &[Event]) {
         use std::io::Write;
 
-        let scratchpad_path = self.scratchpad_path();
+        // When hat scratchpad is disabled, fall back to global scratchpad
+        let scratchpad_path = if self.ralph.active_scratchpad().enabled {
+            self.scratchpad_path()
+        } else {
+            if !self.config.core.scratchpad.enabled {
+                debug!("Both hat and global scratchpad disabled, skipping guidance persistence");
+                return;
+            }
+            self.global_scratchpad_path()
+        };
         let resolved_path = if scratchpad_path.is_relative() {
             self.config.core.workspace_root.join(&scratchpad_path)
         } else {
@@ -1312,6 +1374,11 @@ impl EventLoop {
     /// Auto-injecting saves one tool call per iteration.
     /// When the file exceeds the budget, the TAIL is kept (most recent entries).
     fn prepend_scratchpad(&self, prompt: String) -> String {
+        // Skip injection when scratchpad is disabled for the current hat
+        if !self.ralph.active_scratchpad().enabled {
+            return prompt;
+        }
+
         let scratchpad_path = self.scratchpad_path();
 
         let resolved_path = if scratchpad_path.is_relative() {
@@ -1379,7 +1446,8 @@ impl EventLoop {
 
         let mut final_prompt = format!(
             "<scratchpad path=\"{}\">\n{}\n</scratchpad>\n\n",
-            self.config.core.scratchpad, content
+            self.ralph.active_scratchpad().path,
+            content
         );
         final_prompt.push_str(&prompt);
         final_prompt
@@ -1867,10 +1935,15 @@ impl EventLoop {
     /// Verifies all tasks in scratchpad are complete or cancelled.
     ///
     /// Returns:
-    /// - `Ok(true)` if all tasks are `[x]` or `[~]`
+    /// - `Ok(true)` if all tasks are `[x]` or `[~]`, or if scratchpad is disabled
     /// - `Ok(false)` if any tasks are `[ ]` (pending)
     /// - `Err(...)` if scratchpad doesn't exist or can't be read
     fn verify_scratchpad_complete(&self) -> Result<bool, std::io::Error> {
+        // Nothing to verify when scratchpad is disabled
+        if !self.ralph.active_scratchpad().enabled {
+            return Ok(true);
+        }
+
         let scratchpad_path = self.scratchpad_path();
 
         if !scratchpad_path.exists() {

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -316,7 +316,7 @@ fn test_completion_promise_detection() {
 
     // Configure event loop to use temp directory scratchpad
     let mut config = RalphConfig::default();
-    config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+    config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
     let mut event_loop = EventLoop::new(config);
     event_loop.initialize("Test");
 
@@ -353,7 +353,7 @@ fn test_completion_promise_with_open_tasks_in_scratchpad_still_terminates() {
 
     // Configure event loop to use temp directory scratchpad
     let mut config = RalphConfig::default();
-    config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+    config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
     let mut event_loop = EventLoop::new(config);
     event_loop.initialize("Test");
 
@@ -963,7 +963,7 @@ hats:
     publishes: ["build.done"]
 "#;
     let mut config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
-    config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+    config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
     let mut event_loop = EventLoop::new(config);
     event_loop.initialize("Test task");
 
@@ -1048,6 +1048,7 @@ fn test_default_publishes_injects_when_no_events() {
             backend: None,
             default_publishes: Some("task.done".to_string()),
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,
@@ -1105,6 +1106,7 @@ fn test_default_publishes_not_injected_when_events_written() {
             backend: None,
             default_publishes: Some("task.done".to_string()),
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,
@@ -1304,6 +1306,7 @@ fn test_default_publishes_skipped_when_non_orphan_event_written() {
             backend: None,
             default_publishes: Some("task.done".to_string()),
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,
@@ -1374,6 +1377,7 @@ fn test_default_publishes_not_injected_when_not_configured() {
             backend: None,
             default_publishes: None, // No default configured
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,
@@ -3122,7 +3126,7 @@ fn test_persistent_mode_suppresses_loop_complete() {
     fs::write(&scratchpad_path, "## Tasks\n- [x] All done\n").unwrap();
 
     let mut config = RalphConfig::default();
-    config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+    config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
     config.event_loop.persistent = true;
     let mut event_loop = EventLoop::new(config);
     event_loop.initialize("Test");
@@ -3163,7 +3167,7 @@ fn test_non_persistent_mode_terminates_on_loop_complete() {
     fs::write(&scratchpad_path, "## Tasks\n- [x] All done\n").unwrap();
 
     let mut config = RalphConfig::default();
-    config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+    config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
     // persistent defaults to false, but be explicit
     config.event_loop.persistent = false;
     let mut event_loop = EventLoop::new(config);
@@ -3642,15 +3646,15 @@ fn test_custom_scratchpad_overrides_loop_context() {
     let temp_dir = tempfile::tempdir().unwrap();
     let loop_context = LoopContext::primary(temp_dir.path().to_path_buf());
     let mut config = RalphConfig::default();
-    config.core.scratchpad = ".ralph/debug/global.md".to_string();
+    config.core.scratchpad.path = ".ralph/debug/global.md".to_string();
 
     let event_loop = EventLoop::with_context(config, loop_context);
 
-    // Custom scratchpad path should take precedence over loop context
+    // Custom scratchpad path should be resolved relative to loop context workspace
     assert_eq!(
         event_loop.scratchpad_path(),
-        PathBuf::from(".ralph/debug/global.md"),
-        "Custom scratchpad in config should override loop context default"
+        temp_dir.path().join(".ralph/debug/global.md"),
+        "Custom scratchpad in config should be resolved relative to workspace"
     );
 }
 
@@ -3659,7 +3663,7 @@ fn test_paths_fallback_to_config_when_no_context() {
     let temp_dir = tempfile::tempdir().unwrap();
     let scratchpad_path = temp_dir.path().join("scratchpad.md");
     let mut config = RalphConfig::default();
-    config.core.scratchpad = scratchpad_path.to_string_lossy().to_string();
+    config.core.scratchpad.path = scratchpad_path.to_string_lossy().to_string();
 
     let event_loop = EventLoop::new(config);
 
@@ -4073,6 +4077,7 @@ fn test_default_publishes_satisfies_required_events_for_completion() {
             backend_args: None,
             default_publishes: Some("plan.draft".to_string()),
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,
@@ -4130,6 +4135,7 @@ fn test_default_publishes_completion_promise_triggers_termination() {
             backend_args: None,
             default_publishes: Some("LOOP_COMPLETE".to_string()),
             max_activations: None,
+            scratchpad: None,
             disallowed_tools: vec![],
             timeout: None,
             concurrency: 1,

--- a/crates/ralph-core/src/hatless_ralph.rs
+++ b/crates/ralph-core/src/hatless_ralph.rs
@@ -2,7 +2,7 @@
 //!
 //! Ralph is always present, cannot be configured away, and acts as a universal fallback.
 
-use crate::config::CoreConfig;
+use crate::config::{CoreConfig, ScratchpadConfig};
 use crate::hat_registry::HatRegistry;
 use ralph_proto::{HatId, Topic};
 use std::collections::HashMap;
@@ -27,6 +27,12 @@ pub struct HatlessRalph {
     /// Collected robot guidance messages for injection into prompts.
     /// Set by EventLoop before build_prompt(), cleared after injection.
     robot_guidance: Vec<String>,
+    /// Resolved scratchpad config for the currently active hat.
+    /// Set by EventLoop before build_prompt() via set_active_scratchpad().
+    active_scratchpad: ScratchpadConfig,
+    /// Current iteration number, set by EventLoop before build_prompt().
+    /// Used to determine if this is the first iteration (fresh start).
+    iteration: u32,
 }
 
 /// Hat topology for multi-hat mode prompt generation.
@@ -232,6 +238,7 @@ impl HatlessRalph {
             Some(HatTopology::from_registry(registry))
         };
 
+        let active_scratchpad = core.scratchpad.clone();
         Self {
             completion_promise: completion_promise.into(),
             core,
@@ -241,7 +248,30 @@ impl HatlessRalph {
             objective: None,
             skill_index: String::new(),
             robot_guidance: Vec::new(),
+            active_scratchpad,
+            iteration: 0,
         }
+    }
+
+    /// Sets the resolved scratchpad config for the currently active hat.
+    ///
+    /// Called by EventLoop before build_prompt() to set the per-hat scratchpad
+    /// configuration, resolved via hat override → global core config → defaults.
+    pub fn set_active_scratchpad(&mut self, config: ScratchpadConfig) {
+        self.active_scratchpad = config;
+    }
+
+    /// Returns a reference to the active scratchpad config.
+    pub fn active_scratchpad(&self) -> &ScratchpadConfig {
+        &self.active_scratchpad
+    }
+
+    /// Sets the current iteration number.
+    ///
+    /// Called by EventLoop before build_prompt() to allow iteration-aware
+    /// decisions like fresh-start detection.
+    pub fn set_iteration(&mut self, iteration: u32) {
+        self.iteration = iteration;
     }
 
     /// Sets whether memories mode is enabled.
@@ -393,19 +423,30 @@ You MUST NOT get distracted by workflow mechanics — they serve this goal.
         true
     }
 
-    /// Checks if this is a fresh start (starting_event set, no scratchpad).
+    /// Checks if this is a fresh start (first iteration with a starting_event).
     ///
     /// Used to enable fast path delegation that skips the PLAN step
     /// when immediate delegation to specialized hats is appropriate.
+    /// Only triggers on the first iteration to avoid repeated re-publication.
     fn is_fresh_start(&self) -> bool {
         // Fast path only applies when starting_event is configured
         if self.starting_event.is_none() {
             return false;
         }
 
-        // Check if scratchpad exists
-        let path = Path::new(&self.core.scratchpad);
-        !path.exists()
+        // Only the first iteration can be a fresh start
+        if self.iteration > 0 {
+            return false;
+        }
+
+        // When scratchpad is enabled, check if it already exists
+        // (existing scratchpad means resumed session, not fresh)
+        if self.active_scratchpad.enabled {
+            return !Path::new(&self.active_scratchpad.path).exists();
+        }
+
+        // First iteration + scratchpad disabled = fresh start
+        true
     }
 
     fn core_prompt(&self) -> String {
@@ -431,7 +472,8 @@ You MUST NOT get distracted by workflow mechanics — they serve this goal.
             .join("\n");
 
         let mut prompt = if self.memories_enabled {
-            r"
+            if self.active_scratchpad.enabled {
+                r"
 ### 0a. ORIENTATION
 You are Ralph. You are running in a loop. You have fresh context each iteration.
 You MUST complete only one atomic task for the overall objective. Leave work for future iterations.
@@ -441,18 +483,32 @@ You MUST complete only one atomic task for the overall objective. Leave work for
 2. Review your `<ready-tasks>` (auto-injected above) to see what work exists
 3. If tasks exist, pick one. If not, create them from your plan.
 "
+                .to_string()
+            } else {
+                r"
+### 0a. ORIENTATION
+You are Ralph. You are running in a loop. You have fresh context each iteration.
+You MUST complete only one atomic task for the overall objective. Leave work for future iterations.
+
+**First thing every iteration:**
+1. Review your `<ready-tasks>` (auto-injected above) to see what work exists
+2. If tasks exist, pick one. If not, create them from your plan.
+"
+                .to_string()
+            }
         } else {
             r"
 ### 0a. ORIENTATION
 You are Ralph. You are running in a loop. You have fresh context each iteration.
 You MUST complete only one atomic task for the overall objective. Leave work for future iterations.
 "
-        }
-        .to_string();
+            .to_string()
+        };
 
-        // SCRATCHPAD section - ALWAYS present
-        prompt.push_str(&format!(
-            r"### 0b. SCRATCHPAD
+        // SCRATCHPAD section - only when enabled
+        if self.active_scratchpad.enabled {
+            prompt.push_str(&format!(
+                r"### 0b. SCRATCHPAD
 `{scratchpad}` is your thinking journal for THIS objective.
 Its content is auto-injected in `<scratchpad>` tags at the top of your context each iteration.
 
@@ -468,16 +524,18 @@ Its content is auto-injected in `<scratchpad>` tags at the top of your context e
 - Checklists or todo lists (use `ralph tools task ensure` when a stable key exists, otherwise `ralph tools task add`)
 
 ",
-            scratchpad = self.core.scratchpad,
-        ));
+                scratchpad = self.active_scratchpad.path,
+            ));
+        }
 
         // TASKS section removed — now injected via skills auto-injection pipeline
         // (see EventLoop::inject_memories_and_tools_skill)
         // TASK BREAKDOWN guidance moved into ralph-tools.md
 
         // Add state management guidance (tasks/memories descriptions now live in their respective skills)
-        prompt.push_str(&format!(
-            "### STATE MANAGEMENT\n\n\
+        if self.active_scratchpad.enabled {
+            prompt.push_str(&format!(
+                "### STATE MANAGEMENT\n\n\
 **Scratchpad** (`{scratchpad}`) — Your thinking:\n\
 - Current understanding and reasoning\n\
 - Analysis notes, decisions, plan narrative\n\
@@ -493,8 +551,29 @@ Do not spend turns on shell or tool-availability diagnosis unless the task is ex
 Do NOT infer failure from empty or terse stdout alone. Verify the intended side effect in the task/event state or in the files and artifacts the command should have changed.\n\
 Keep temporary artifacts where later steps can still inspect them, such as a repo-local `logs/` directory or `/var/tmp` when needed.\n\
 \n",
-            scratchpad = self.core.scratchpad,
-        ));
+                scratchpad = self.active_scratchpad.path,
+            ));
+        } else {
+            prompt.push_str(
+                "### STATE MANAGEMENT\n\n\
+**Tasks** (`ralph tools task`) — What needs to be done:\n\
+- Work items, their status, priorities, and dependencies\n\
+- Source of truth for progress across iterations\n\
+- Auto-injected in `<ready-tasks>` tags at the top of your context\n\
+\n\
+**Memories** (`.ralph/agent/memories.md`) — Persistent learning:\n\
+- Codebase patterns and conventions\n\
+- Architectural decisions and rationale\n\
+- Recurring problem solutions\n\
+\n\
+**Context Files** (`.ralph/agent/*.md`) — Research artifacts:\n\
+- Analysis and temporary notes\n\
+- Read when relevant\n\
+\n\
+**Rule:** Work items go in tasks. Learnings go in memories.\n\
+\n",
+            );
+        }
 
         // List available context files in .ralph/agent/
         if let Ok(entries) = std::fs::read_dir(".ralph/agent") {
@@ -540,6 +619,9 @@ Keep temporary artifacts where later steps can still inspect them, such as a rep
     }
 
     fn workflow_section(&self) -> String {
+        let scratchpad_enabled = self.active_scratchpad.enabled;
+        let scratchpad = &self.active_scratchpad.path;
+
         // Different workflow for solo mode vs multi-hat mode
         if self.hat_topology.is_some() {
             // Check for fast path: starting_event set AND no scratchpad
@@ -560,9 +642,10 @@ You MUST NOT plan or analyze — delegate now.
 
             // Multi-hat mode: Ralph coordinates and delegates
             if self.memories_enabled {
-                // Memories mode: reference both scratchpad AND tasks CLI
-                format!(
-                    r"## WORKFLOW
+                if scratchpad_enabled {
+                    // Memories mode: reference both scratchpad AND tasks CLI
+                    format!(
+                        r"## WORKFLOW
 
 ### 1. PLAN
 You MUST update `{scratchpad}` with your understanding and plan.
@@ -577,9 +660,20 @@ Plain-language summaries do NOT hand off work.
 You MUST NOT do implementation work — delegation is your only job.
 
 ",
-                    scratchpad = self.core.scratchpad
-                )
-            } else {
+                    )
+                } else {
+                    // Memories mode, scratchpad disabled
+                    "## WORKFLOW\n\n\
+### 1. PLAN\n\
+You MUST create tasks with `ralph tools task add` for each work item (check `<ready-tasks>` first to avoid duplicates).\n\
+\n\
+### 2. DELEGATE\n\
+You MUST publish exactly ONE event to hand off to specialized hats.\n\
+You MUST NOT do implementation work — delegation is your only job.\n\
+\n"
+                    .to_string()
+                }
+            } else if scratchpad_enabled {
                 // Scratchpad-only mode (legacy)
                 format!(
                     r"## WORKFLOW
@@ -593,15 +687,23 @@ Plain-language summaries do NOT hand off work.
 You MUST NOT do implementation work — delegation is your only job.
 
 ",
-                    scratchpad = self.core.scratchpad
                 )
+            } else {
+                // Legacy mode, scratchpad disabled (unusual)
+                "## WORKFLOW\n\n\
+### 1. DELEGATE\n\
+You MUST publish exactly ONE event to hand off to specialized hats.\n\
+You MUST NOT do implementation work — delegation is your only job.\n\
+\n"
+                .to_string()
             }
         } else {
             // Solo mode: Ralph does everything
             if self.memories_enabled {
-                // Memories mode: reference both scratchpad AND tasks CLI
-                format!(
-                    r"## WORKFLOW
+                if scratchpad_enabled {
+                    // Memories mode: reference both scratchpad AND tasks CLI
+                    format!(
+                        r"## WORKFLOW
 
 ### 1. Study the prompt.
 You MUST study, explore, and research what needs to be done.
@@ -633,9 +735,32 @@ You MUST update scratchpad with what you learned (tasks track what remains).
 You MUST exit after completing ONE task.
 
 ",
-                    scratchpad = self.core.scratchpad
-                )
-            } else {
+                    )
+                } else {
+                    // Memories mode, scratchpad disabled
+                    "## WORKFLOW\n\n\
+### 1. Study the prompt.\n\
+You MUST study, explore, and research what needs to be done.\n\
+\n\
+### 2. PLAN\n\
+You MUST create tasks with `ralph tools task add` for each work item (check `<ready-tasks>` first to avoid duplicates).\n\
+\n\
+### 3. IMPLEMENT\n\
+You MUST pick exactly ONE task from `<ready-tasks>` to implement.\n\
+\n\
+### 4. VERIFY & COMMIT\n\
+You MUST run tests and verify the implementation works.\n\
+You MUST commit after verification passes - one commit per task.\n\
+You SHOULD run `git diff --cached` to review staged changes before committing.\n\
+You MUST close the task with `ralph tools task close <id>` AFTER commit.\n\
+You SHOULD save learnings to memories with `ralph tools memory add`.\n\
+\n\
+### 5. EXIT\n\
+You MUST exit after completing ONE task.\n\
+\n"
+                    .to_string()
+                }
+            } else if scratchpad_enabled {
                 // Scratchpad-only mode (legacy)
                 format!(
                     r"## WORKFLOW
@@ -663,8 +788,27 @@ You MUST mark the task `[x]` in scratchpad when complete.
 You MUST continue until all tasks are `[x]` or `[~]`.
 
 ",
-                    scratchpad = self.core.scratchpad
                 )
+            } else {
+                // Legacy mode, scratchpad disabled (unusual)
+                "## WORKFLOW\n\n\
+### 1. Study the prompt.\n\
+You MUST study, explore, and research what needs to be done.\n\
+You MAY use parallel subagents (up to 10) for searches.\n\
+\n\
+### 2. IMPLEMENT\n\
+You MUST pick exactly ONE task to implement.\n\
+You MUST NOT use more than 1 subagent for build/tests.\n\
+\n\
+### 3. COMMIT\n\
+You MUST commit after completing each atomic unit of work.\n\
+You MUST capture the why, not just the what.\n\
+You SHOULD run `git diff` before committing to review changes.\n\
+\n\
+### 4. REPEAT\n\
+You MUST continue.\n\
+\n"
+                .to_string()
             }
         }
     }
@@ -903,11 +1047,14 @@ You MUST continue until all tasks are `[x]` or `[~]`.
     }
 
     fn event_writing_section(&self) -> String {
-        // Always use scratchpad for detailed output (scratchpad is always present)
-        let detailed_output_hint = format!(
-            "You SHOULD write detailed output to `{}` and emit only a brief event.",
-            self.core.scratchpad
-        );
+        let detailed_output_hint = if self.active_scratchpad.enabled {
+            format!(
+                "\nYou SHOULD write detailed output to `{}` and emit only a brief event.\n",
+                self.active_scratchpad.path
+            )
+        } else {
+            String::new()
+        };
 
         format!(
             r#"## EVENT WRITING
@@ -921,9 +1068,7 @@ ralph emit "review.done" --json '{{"status": "approved", "issues": 0}}'
 ```
 
 You MUST NOT use echo/cat to write events because shell escaping breaks JSON.
-
 {detailed_output_hint}
-
 **Constraints:**
 - You MUST stop working after publishing an event because a new iteration will start with fresh context
 - You MUST NOT continue with additional work after publishing because the next iteration handles it with the appropriate hat persona
@@ -2636,6 +2781,202 @@ hats:
         assert!(
             !prompt.contains("## ROBOT GUIDANCE"),
             "Should NOT include ROBOT GUIDANCE when no guidance set"
+        );
+    }
+
+    // === Per-Hat Scratchpad Prompt Tests ===
+
+    /// AC3: Hat disables scratchpad — all scratchpad sections suppressed
+    #[test]
+    fn test_scratchpad_disabled_suppresses_all_sections() {
+        use crate::config::ScratchpadConfig;
+
+        let config = RalphConfig::default();
+        let registry = HatRegistry::new();
+        let mut ralph = HatlessRalph::new("LOOP_COMPLETE", config.core.clone(), &registry, None)
+            .with_memories_enabled(true);
+        ralph.set_active_scratchpad(ScratchpadConfig {
+            enabled: false,
+            path: ".ralph/agent/scratchpad.md".to_string(),
+        });
+
+        let prompt = ralph.build_prompt("", &[]);
+
+        // 0a. ORIENTATION should NOT contain scratchpad reference
+        assert!(
+            !prompt.contains("Review your `<scratchpad>`"),
+            "Disabled scratchpad: ORIENTATION should not reference scratchpad"
+        );
+        // 0b. SCRATCHPAD section should not exist
+        assert!(
+            !prompt.contains("### 0b. SCRATCHPAD"),
+            "Disabled scratchpad: SCRATCHPAD section should be suppressed"
+        );
+        // STATE MANAGEMENT should not reference "Scratchpad"
+        assert!(
+            !prompt.contains("**Scratchpad**"),
+            "Disabled scratchpad: STATE MANAGEMENT should not reference Scratchpad"
+        );
+        assert!(
+            !prompt.contains("Thinking goes in scratchpad"),
+            "Disabled scratchpad: Rule should not reference scratchpad"
+        );
+        // WORKFLOW should not reference scratchpad
+        assert!(
+            !prompt.contains("update scratchpad"),
+            "Disabled scratchpad: WORKFLOW should not reference scratchpad"
+        );
+        // EVENT WRITING should not have detailed output hint
+        assert!(
+            !prompt.contains("write detailed output to"),
+            "Disabled scratchpad: EVENT WRITING should not reference scratchpad"
+        );
+    }
+
+    /// AC4: Hat with custom path — all scratchpad instruction references use custom path
+    #[test]
+    fn test_scratchpad_custom_path_in_prompt() {
+        use crate::config::ScratchpadConfig;
+
+        let config = RalphConfig::default();
+        let registry = HatRegistry::new();
+        let mut ralph = HatlessRalph::new("LOOP_COMPLETE", config.core.clone(), &registry, None)
+            .with_memories_enabled(true);
+        ralph.set_active_scratchpad(ScratchpadConfig {
+            enabled: true,
+            path: ".ralph/agent/planner.md".to_string(),
+        });
+
+        let prompt = ralph.build_prompt("", &[]);
+
+        // SCRATCHPAD section should reference custom path
+        assert!(
+            prompt.contains("`.ralph/agent/planner.md` is your thinking journal"),
+            "Custom path should appear in SCRATCHPAD section"
+        );
+        // STATE MANAGEMENT should reference custom path
+        assert!(
+            prompt.contains("**Scratchpad** (`.ralph/agent/planner.md`)"),
+            "STATE MANAGEMENT should reference custom path"
+        );
+        // WORKFLOW should reference custom path
+        assert!(
+            prompt.contains("`.ralph/agent/planner.md`") && prompt.contains("PLAN"),
+            "WORKFLOW should reference custom path"
+        );
+        // EVENT WRITING should use custom path
+        assert!(
+            prompt.contains("write detailed output to `.ralph/agent/planner.md`"),
+            "EVENT WRITING should use custom scratchpad path"
+        );
+    }
+
+    /// AC5: Hat inherits global — default path used
+    #[test]
+    fn test_scratchpad_inherits_global_path() {
+        let config = RalphConfig::default();
+        let registry = HatRegistry::new();
+        let ralph = HatlessRalph::new("LOOP_COMPLETE", config.core.clone(), &registry, None);
+
+        let prompt = ralph.build_prompt("", &[]);
+
+        assert!(
+            prompt.contains("`.ralph/agent/scratchpad.md`"),
+            "Default global path should be used"
+        );
+        assert!(
+            prompt.contains("### 0b. SCRATCHPAD"),
+            "SCRATCHPAD section should be present"
+        );
+    }
+
+    /// AC11: Disabled scratchpad + first iteration triggers fresh start
+    #[test]
+    fn test_disabled_scratchpad_is_fresh_start() {
+        use crate::config::ScratchpadConfig;
+
+        let yaml = r#"
+hats:
+  tdd_writer:
+    name: "TDD Writer"
+    triggers: ["tdd.start"]
+    publishes: ["test.written"]
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let registry = HatRegistry::from_config(&config);
+        let mut ralph = HatlessRalph::new(
+            "LOOP_COMPLETE",
+            config.core.clone(),
+            &registry,
+            Some("tdd.start".to_string()),
+        );
+        ralph.set_active_scratchpad(ScratchpadConfig {
+            enabled: false,
+            path: ".ralph/agent/scratchpad.md".to_string(),
+        });
+
+        // First iteration (iteration=0): should trigger fast path
+        ralph.set_iteration(0);
+        let prompt = ralph.build_prompt("", &[]);
+        assert!(
+            prompt.contains("FAST PATH"),
+            "First iteration with disabled scratchpad should trigger fast path"
+        );
+
+        // Second iteration (iteration=1): should NOT trigger fast path
+        ralph.set_iteration(1);
+        let prompt = ralph.build_prompt("", &[]);
+        assert!(
+            !prompt.contains("FAST PATH"),
+            "Second iteration should NOT trigger fast path even with disabled scratchpad"
+        );
+    }
+
+    /// AC9: Multiple hats with different configs produce correct prompts
+    #[test]
+    fn test_multiple_hats_different_scratchpad_prompts() {
+        use crate::config::ScratchpadConfig;
+
+        let config = RalphConfig::default();
+        let registry = HatRegistry::new();
+
+        // Planner with custom path
+        let mut ralph_planner =
+            HatlessRalph::new("LOOP_COMPLETE", config.core.clone(), &registry, None)
+                .with_memories_enabled(true);
+        ralph_planner.set_active_scratchpad(ScratchpadConfig {
+            enabled: true,
+            path: ".ralph/agent/planner.md".to_string(),
+        });
+        let planner_prompt = ralph_planner.build_prompt("", &[]);
+        assert!(
+            planner_prompt.contains("`.ralph/agent/planner.md`"),
+            "Planner should use custom path"
+        );
+
+        // Builder inherits global
+        let mut ralph_builder =
+            HatlessRalph::new("LOOP_COMPLETE", config.core.clone(), &registry, None)
+                .with_memories_enabled(true);
+        ralph_builder.set_active_scratchpad(config.core.scratchpad.clone());
+        let builder_prompt = ralph_builder.build_prompt("", &[]);
+        assert!(
+            builder_prompt.contains("`.ralph/agent/scratchpad.md`"),
+            "Builder should use global path"
+        );
+
+        // Validator disabled
+        let mut ralph_validator =
+            HatlessRalph::new("LOOP_COMPLETE", config.core.clone(), &registry, None)
+                .with_memories_enabled(true);
+        ralph_validator.set_active_scratchpad(ScratchpadConfig {
+            enabled: false,
+            path: ".ralph/agent/scratchpad.md".to_string(),
+        });
+        let validator_prompt = ralph_validator.build_prompt("", &[]);
+        assert!(
+            !validator_prompt.contains("### 0b. SCRATCHPAD"),
+            "Validator should have no scratchpad sections"
         );
     }
 }

--- a/crates/ralph-core/src/instructions.rs
+++ b/crates/ralph-core/src/instructions.rs
@@ -223,6 +223,7 @@ You MUST handle these events:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ScratchpadConfig;
 
     fn default_builder() -> InstructionBuilder {
         InstructionBuilder::new(CoreConfig::default())
@@ -285,7 +286,10 @@ mod tests {
     #[test]
     fn test_custom_guardrails_injected() {
         let custom_core = CoreConfig {
-            scratchpad: ".workspace/plan.md".to_string(),
+            scratchpad: ScratchpadConfig {
+                enabled: true,
+                path: ".workspace/plan.md".to_string(),
+            },
             specs_dir: "./specifications/".to_string(),
             guardrails: vec!["Custom rule one".to_string(), "Custom rule two".to_string()],
             workspace_root: std::path::PathBuf::from("."),

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -62,8 +62,8 @@ pub mod worktree;
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
     CliConfig, ConfigError, CoreConfig, EventLoopConfig, EventMetadata, FeaturesConfig, HatBackend,
-    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, SkillOverride,
-    SkillsConfig,
+    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, ScratchpadConfig,
+    SkillOverride, SkillsConfig,
 };
 // Re-export loop_name types (also available via FeaturesConfig.loop_naming)
 pub use diagnostics::DiagnosticsCollector;

--- a/crates/ralph-core/src/preflight.rs
+++ b/crates/ralph-core/src/preflight.rs
@@ -469,7 +469,7 @@ impl PreflightCheck for PathsExistCheck {
     async fn run(&self, config: &RalphConfig) -> CheckResult {
         let mut created = Vec::new();
 
-        let scratchpad_path = config.core.resolve_path(&config.core.scratchpad);
+        let scratchpad_path = config.core.resolve_path(&config.core.scratchpad.path);
         if let Some(parent) = scratchpad_path.parent()
             && let Err(err) = ensure_directory(parent, &mut created)
         {
@@ -1286,7 +1286,7 @@ mod tests {
 
         let mut config = RalphConfig::default();
         config.core.workspace_root = root.clone();
-        config.core.scratchpad = "nested/scratchpad.md".to_string();
+        config.core.scratchpad.path = "nested/scratchpad.md".to_string();
         config.core.specs_dir = "nested/specs".to_string();
 
         let check = PathsExistCheck;

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -196,10 +196,10 @@ Loaded from `ralph.yml`:
 struct Config {
     cli: CliConfig,
     event_loop: EventLoopConfig,
-    core: CoreConfig,       // includes scratchpad: ScratchpadConfig
+    core: CoreConfig,
     memories: MemoryConfig,
     tasks: TaskConfig,
-    hats: HashMap<String, HatConfig>,  // each HatConfig has scratchpad: Option<ScratchpadConfig>
+    hats: HashMap<String, HatConfig>,
 }
 ```
 

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -173,7 +173,7 @@ All persistent state lives in `.agent/`:
 ├── memories.md         # Persistent learning
 ├── tasks.jsonl         # Runtime work tracking
 ├── event_history.jsonl # Event audit log
-└── scratchpad.md       # Legacy state (deprecated)
+└── scratchpad.md       # Iteration state (per-hat scratchpads may also exist)
 ```
 
 ### Event Bus
@@ -196,10 +196,10 @@ Loaded from `ralph.yml`:
 struct Config {
     cli: CliConfig,
     event_loop: EventLoopConfig,
-    core: CoreConfig,
+    core: CoreConfig,       // includes scratchpad: ScratchpadConfig
     memories: MemoryConfig,
     tasks: TaskConfig,
-    hats: HashMap<String, HatConfig>,
+    hats: HashMap<String, HatConfig>,  // each HatConfig has scratchpad: Option<ScratchpadConfig>
 }
 ```
 

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -67,7 +67,7 @@ Ralph uses files for all persistent state:
 | `.agent/memories.md` | Cross-session learning |
 | `.agent/tasks.jsonl` | Runtime work tracking |
 | `.agent/event_history.jsonl` | Event audit log |
-| `.agent/scratchpad.md` | Legacy state (deprecated) |
+| `.agent/scratchpad.md` | Iteration state (per-hat scratchpads may also exist) |
 
 ## Quick Reference
 

--- a/docs/concepts/memories-and-tasks.md
+++ b/docs/concepts/memories-and-tasks.md
@@ -163,6 +163,8 @@ tasks:
 
 In this mode, `.agent/scratchpad.md` is used for all state.
 
+In hat-based configurations, scratchpad is configurable per-hat. Each hat can set a custom scratchpad path, disable scratchpad entirely, or inherit the global `core.scratchpad` setting. See [Per-Hat Scratchpads](../guide/configuration.md#with-per-hat-scratchpads) for details.
+
 ## File Formats
 
 ### memories.md

--- a/docs/getting-started/first-task.md
+++ b/docs/getting-started/first-task.md
@@ -198,7 +198,7 @@ ralph run --continue
 
 After completion, check `.agent/` for:
 
-- `scratchpad.md` - Shared memory (legacy mode)
+- `scratchpad.md` - Iteration state (per-hat scratchpads may also exist)
 - `memories.md` - Persistent learning
 - `tasks.jsonl` - Task tracking
 

--- a/docs/guide/agents.md
+++ b/docs/guide/agents.md
@@ -511,11 +511,13 @@ adapters:
 ```
 
 **Agent Scratchpad:**
-All agents maintain context across iterations via `.agent/scratchpad.md`:
+All agents maintain context across iterations via a scratchpad file (`.agent/scratchpad.md` by default):
 - Persists progress from previous iterations
 - Records decisions and context
 - Tracks current blockers or issues
 - Lists remaining work items
+
+In hat-based configurations, each hat can have its own scratchpad via the `scratchpad` config option — set a custom path, disable it entirely, or inherit from `core.scratchpad`. See [Per-Hat Scratchpads](configuration.md#with-per-hat-scratchpads) for details.
 
 ```bash
 # The scratchpad is automatically managed
@@ -703,7 +705,7 @@ Agents write events to the run's events file (`.ralph/events-YYYYMMDD-HHMMSS.jso
 - ❌ **DON'T**: Use YAML formatting in payloads (causes literal newlines)
 - ❌ **DON'T**: Put multi-line content directly in payloads
 
-For detailed output, write to `.agent/scratchpad.md` and emit a brief event.
+For detailed output, write to your scratchpad file and emit a brief event.
 
 ### Example: Builder Hat
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -45,7 +45,7 @@ If `-H/--hats` is provided, it takes precedence over hats in `-c`:
 
 | Field | Description |
 |-------|-------------|
-| `core.scratchpad` | Path to scratchpad file |
+| `core.scratchpad` | Path to scratchpad file (string shorthand for `scratchpad.path`) |
 | `core.specs_dir` | Path to specs directory |
 
 ### Hat Collection Sources (`-H`)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -37,7 +37,7 @@ You can override specific core fields from the command line without creating a s
 
 | Field | Description |
 |-------|-------------|
-| `core.scratchpad` | Path to scratchpad file |
+| `core.scratchpad` | Path to scratchpad file (string shorthand for `scratchpad.path`) |
 | `core.specs_dir` | Path to specs directory |
 
 **Examples:**
@@ -86,8 +86,11 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"                 # Specifications directory
-  guardrails:                           # Rules injected into every prompt
+  scratchpad:                            # Scratchpad configuration
+    enabled: true                        # Enable scratchpad (default: true)
+    path: .ralph/agent/scratchpad.md     # Scratchpad file path
+  specs_dir: "./specs/"                  # Specifications directory
+  guardrails:                            # Rules injected into every prompt
     - "Fresh context each iteration"
     - "Never modify production database"
 
@@ -139,6 +142,8 @@ hats:
     default_publishes: "event.done"     # Default when no explicit
     max_activations: 10                 # Activation limit
     backend: "claude"                   # Backend override
+    scratchpad:                         # Per-hat scratchpad override
+      path: .ralph/agent/my-hat.md     #   (omit to inherit core.scratchpad)
     instructions: |
       Hat-specific instructions...
 ```
@@ -185,12 +190,31 @@ Backend configuration.
 
 ### core
 
-Core behaviors and guardrails.
+Core behaviors, scratchpad, and guardrails.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
+| `scratchpad` | string or object | `{ enabled: true, path: ".ralph/agent/scratchpad.md" }` | Scratchpad configuration (see below) |
+| `scratchpad.enabled` | boolean | `true` | Enable the scratchpad |
+| `scratchpad.path` | string | `".ralph/agent/scratchpad.md"` | Scratchpad file path |
 | `specs_dir` | string | `"./specs/"` | Specifications directory |
 | `guardrails` | list | `[]` | Rules injected into every prompt |
+
+The `scratchpad` field accepts a plain string (shorthand for setting `path` with `enabled: true`) or a structured object with `enabled` and `path`:
+
+```yaml
+# String shorthand — sets path, enabled defaults to true
+core:
+  scratchpad: ".workspace/plan.md"
+
+# Structured object — full control
+core:
+  scratchpad:
+    enabled: true
+    path: .ralph/agent/scratchpad.md
+```
+
+> **Solo mode safety:** If scratchpad is disabled (`enabled: false`) but no hats are defined, Ralph force-enables it with a warning. Scratchpad is the only continuity mechanism in solo mode.
 
 ### memories
 
@@ -295,7 +319,29 @@ Specialized personas for hat-based mode.
 | `default_publishes` | string | No | Default event if none explicit |
 | `max_activations` | integer | No | Limit activations |
 | `backend` | string | No | Backend override |
+| `scratchpad` | string or object | No | Per-hat scratchpad override (inherits `core.scratchpad` if omitted) |
 | `instructions` | string | Yes | Hat-specific prompt |
+
+Each hat can override the global scratchpad with its own `scratchpad` field. Like the core-level setting, it accepts a plain string or a structured object:
+
+```yaml
+hats:
+  planner:
+    scratchpad: .ralph/agent/planner.md       # String shorthand
+    # ...
+  builder:
+    scratchpad:
+      path: .ralph/agent/builder.md           # Structured with custom path
+    # ...
+  validator:
+    scratchpad:
+      enabled: false                          # Disable scratchpad entirely
+    # ...
+  reviewer:                                   # No scratchpad key = inherits global
+    # ...
+```
+
+**Resolution order:** hat override → `core.scratchpad` → defaults.
 
 ## Example Configurations
 
@@ -352,6 +398,48 @@ memories:
 
 tasks:
   enabled: false
+```
+
+### With Per-Hat Scratchpads
+
+```yaml
+cli:
+  backend: "claude"
+
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  starting_event: "task.start"
+
+core:
+  scratchpad:
+    enabled: true
+    path: .ralph/agent/scratchpad.md
+
+hats:
+  planner:
+    name: "Planner"
+    scratchpad:
+      path: .ralph/agent/planner.md
+    triggers: ["task.start"]
+    publishes: ["plan.ready"]
+    instructions: |
+      Create an implementation plan.
+
+  builder:
+    name: "Builder"
+    triggers: ["plan.ready"]
+    publishes: ["build.done"]
+    instructions: |
+      Implement the plan.
+
+  reviewer:
+    name: "Reviewer"
+    scratchpad:
+      enabled: false
+    triggers: ["build.done"]
+    publishes: ["review.done"]
+    instructions: |
+      Review the implementation. No scratchpad needed.
 ```
 
 ### With Custom Guardrails

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -143,7 +143,8 @@ hats:
     max_activations: 10                 # Activation limit
     backend: "claude"                   # Backend override
     scratchpad:                         # Per-hat scratchpad override
-      path: .ralph/agent/my-hat.md     #   (omit to inherit core.scratchpad)
+      enabled: true                     #   Enable scratchpad (default: true)
+      path: .ralph/agent/my-hat.md      #   Scratchpad file path. Inherits from core if omitted.
     instructions: |
       Hat-specific instructions...
 ```


### PR DESCRIPTION
## Summary

Closes https://github.com/mikeyobrien/ralph-orchestrator/issues/174.

Refactors the scratchpad configuration from a plain string path (`core.scratchpad: "..."`) into a structured `ScratchpadConfig` type with `enabled` and `path` fields, and adds per-hat scratchpad overrides so each hat can use a custom scratchpad path, disable scratchpad entirely, or inherit the global setting.

- Introduces `ScratchpadConfig` struct with custom serde deserializers supporting both legacy plain-string and structured object YAML formats (backwards-compatible)
- Adds optional `scratchpad` field to `HatConfig` with resolution order: hat override > `core.scratchpad` > defaults
- Updates prompt generation in `HatlessRalph` to conditionally suppress all scratchpad-related sections (ORIENTATION, SCRATCHPAD, STATE MANAGEMENT, WORKFLOW, EVENT WRITING) when scratchpad is disabled
- Updates `EventLoop` to resolve per-hat scratchpad config before each iteration, skip scratchpad injection/verification when disabled, and fall back to global scratchpad for guidance persistence
- Adds solo-mode safety guard that force-enables scratchpad when no hats are defined (scratchpad is the only continuity mechanism in solo mode)
- Updates documentation for configuration, architecture, agents, and memories-and-tasks guides

## Test plan

- [ ] `cargo test -p ralph-core` passes (includes 20+ new tests for scratchpad config parsing, resolution, prompt generation, and edge cases)
- [ ] `cargo test` passes across all crates
- [ ] Verify legacy `core.scratchpad: "path"` string format still works (backwards-compatible deserialization)
- [ ] Verify structured `core.scratchpad: { enabled: true, path: "..." }` format works
- [ ] Verify hat-level `scratchpad` overrides (plain string, structured, disabled, absent/inherit)
- [ ] Verify prompts omit all scratchpad references when `enabled: false`
- [ ] Verify prompts use custom path when hat specifies one
- [ ] Verify solo mode forces scratchpad enabled when no hats defined
