### PR TITLE
docs: add llms.txt docs map generation (issue #135)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,10 +37,13 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install mkdocs mkdocs-material mkdocs-material-extensions pymdown-extensions mkdocs-minify-plugin
+          pip install mkdocs mkdocs-material mkdocs-material-extensions pymdown-extensions mkdocs-minify-plugin mkdocs-llmstxt==0.5.0
 
       - name: Build documentation
         run: mkdocs build --strict --verbose
+
+      - name: Validate llms.txt structure
+        run: python scripts/validate_llms_txt.py site/llms.txt
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/contributing/style.md
+++ b/docs/contributing/style.md
@@ -31,6 +31,8 @@ Ralph Orchestrator follows Rust community conventions with project-specific addi
 - Use present tense ("adds" not "added")
 - Keep lines under 100 characters
 - Include examples for public APIs
+- Keep `plugins.llmstxt.sections` in `mkdocs.yml` in sync with docs IA changes
+- Validate llms map changes with `mkdocs build --strict` and `python scripts/validate_llms_txt.py site/llms.txt`
 
 ## See Also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,69 @@ nav:
 plugins:
   - search:
       separator: '[\s\u200b\-_,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+  - llmstxt:
+      markdown_description: >
+        Ralph Orchestrator is a hat-based orchestration framework for autonomous AI agents.
+        This llms.txt provides an LLM-friendly map of the most important project documentation.
+      sections:
+        Getting Started:
+          - getting-started/index.md: Start here for first-time setup and orientation.
+          - getting-started/installation.md: Installation methods and prerequisites.
+          - getting-started/quick-start.md: Fast path to running Ralph.
+          - getting-started/first-task.md: First end-to-end task walkthrough.
+        Concepts:
+          - concepts/index.md: Concept overview and mental model.
+          - concepts/ralph-wiggum-technique.md
+          - concepts/tenets.md
+          - concepts/hats-and-events.md
+          - concepts/coordination-patterns.md
+          - concepts/memories-and-tasks.md
+          - concepts/backpressure.md
+        User Guide:
+          - guide/index.md
+          - guide/configuration.md
+          - guide/presets.md
+          - guide/cli-reference.md
+          - guide/backends.md
+          - guide/prompts.md
+          - guide/cost-management.md
+        Advanced:
+          - advanced/index.md
+          - advanced/architecture.md
+          - advanced/custom-hats.md
+          - advanced/event-system.md
+          - advanced/memory-system.md
+          - advanced/task-system.md
+          - advanced/testing.md
+          - advanced/diagnostics.md
+          - advanced/parallel-loops.md
+        API Reference:
+          - api/index.md
+          - api/ralph-proto.md
+          - api/ralph-core.md
+          - api/ralph-adapters.md
+          - api/ralph-tui.md
+          - api/ralph-cli.md
+        Examples:
+          - examples/index.md
+          - examples/simple-task.md
+          - examples/tdd-workflow.md
+          - examples/spec-driven.md
+          - examples/multi-hat.md
+          - examples/debugging.md
+        Contributing:
+          - contributing/index.md
+          - contributing/setup.md
+          - contributing/style.md
+          - contributing/testing.md
+          - contributing/pull-requests.md
+        Reference:
+          - reference/index.md
+          - reference/changelog.md
+          - reference/faq.md
+          - reference/glossary.md
+          - reference/migration-v1.md
+          - reference/troubleshooting.md
   - minify:
       minify_html: true
 

--- a/scripts/validate_llms_txt.py
+++ b/scripts/validate_llms_txt.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Validate generated llms.txt shape for docs CI.
+
+Usage:
+    python scripts/validate_llms_txt.py [path/to/llms.txt]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_SECTIONS = [
+    "Getting Started",
+    "Concepts",
+    "User Guide",
+    "Advanced",
+    "API Reference",
+    "Examples",
+    "Contributing",
+    "Reference",
+]
+
+LINK_PATTERN = re.compile(r"^-\s+\[[^\]]+\]\([^)]+\)")
+H2_PATTERN = re.compile(r"^##\s+(.+?)\s*$")
+
+
+def fail(message: str) -> int:
+    print(f"llms.txt validation failed: {message}", file=sys.stderr)
+    return 1
+
+
+def first_non_empty_line(lines: list[str]) -> str | None:
+    for line in lines:
+        if line.strip():
+            return line.strip()
+    return None
+
+
+def main() -> int:
+    target = Path(sys.argv[1] if len(sys.argv) > 1 else "site/llms.txt")
+
+    if not target.exists():
+        return fail(f"file not found: {target}")
+
+    contents = target.read_text(encoding="utf-8")
+    lines = [line.rstrip() for line in contents.splitlines()]
+
+    if not lines:
+        return fail("file is empty")
+
+    first_line = first_non_empty_line(lines)
+    if first_line is None or not first_line.startswith("# "):
+        return fail("missing H1 title at top of file")
+
+    if not any(line.strip().startswith("> ") for line in lines):
+        return fail("missing summary blockquote")
+
+    section_indices: dict[str, int] = {}
+    ordered_sections: list[str] = []
+    for index, line in enumerate(lines):
+        match = H2_PATTERN.match(line.strip())
+        if match:
+            name = match.group(1)
+            section_indices[name] = index
+            ordered_sections.append(name)
+
+    if not ordered_sections:
+        return fail("no H2 sections found")
+
+    missing_sections = [name for name in REQUIRED_SECTIONS if name not in section_indices]
+    if missing_sections:
+        return fail(f"missing required sections: {', '.join(missing_sections)}")
+
+    ordered_index_lookup = {name: i for i, name in enumerate(ordered_sections)}
+
+    for section in REQUIRED_SECTIONS:
+        start = section_indices[section] + 1
+        order_index = ordered_index_lookup[section]
+        if order_index + 1 < len(ordered_sections):
+            next_section = ordered_sections[order_index + 1]
+            end = section_indices[next_section]
+        else:
+            end = len(lines)
+
+        body = [line.strip() for line in lines[start:end] if line.strip()]
+        if not any(LINK_PATTERN.match(line) for line in body):
+            return fail(f"section '{section}' has no markdown link list entries")
+
+    print(f"llms.txt validation passed: {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add mkdocs-llmstxt plugin configuration in mkdocs.yml to generate /llms.txt with sectioned documentation map
- pin docs CI dependency to mkdocs-llmstxt==0.5.0 in .github/workflows/docs.yml
- add scripts/validate_llms_txt.py and run it in docs CI to enforce llms.txt structure/coverage
- add contributor guidance in docs/contributing/style.md for keeping llmstxt sections in sync with docs IA

## Validation

- python3 -m venv .venv && source .venv/bin/activate && pip install mkdocs mkdocs-material mkdocs-material-extensions pymdown-extensions mkdocs-minify-plugin mkdocs-llmstxt==0.5.0
- mkdocs build --strict --verbose
- python scripts/validate_llms_txt.py site/llms.txt
- cargo test -- --test-threads=1
- cargo test -p ralph-core smoke_runner -- --test-threads=1

Closes #135
