### PR TITLE
test: add cascade reproduction test and code task for #187

### DIFF
--- a/.ralph/tasks/fix-default-publishes-cascade.code-task.md
+++ b/.ralph/tasks/fix-default-publishes-cascade.code-task.md
@@ -1,0 +1,117 @@
+---
+status: pending
+created: 2026-02-25
+---
+# Task: Fix default_publishes Cascade on Silent Agent Iterations
+
+## Description
+When an agent writes zero events during an iteration, `default_publishes` unconditionally advances the hat state machine. In a multi-hat chain, consecutive silent iterations cascade through every hat to `LOOP_COMPLETE`, terminating the loop with zero work done. This is especially harmful for parallel worktree loops where agent silence is more likely (fresh context, missing env, API errors).
+
+Fix with two layers:
+1. **Runtime guard**: Track consecutive default injections in `LoopState`. After one default fires without any real agent events in between, block further defaults and terminate with a new `CascadingDefaults` reason.
+2. **Config validation**: Reject any hat where `default_publishes` equals the `completion_promise`. The completion event should always require explicit agent action.
+
+GitHub issue: https://github.com/mikeyobrien/ralph-orchestrator/issues/187
+
+## Background
+`default_publishes` was designed as a convenience fallback — if a hat's agent forgets to emit an event, the orchestrator injects a sensible default so the chain doesn't stall. The problem is it treats silence identically to success. When the agent is truly broken (crashed, confused, API error), each iteration fires `default_publishes` for the active hat, which triggers the next hat, which also fires its default, cascading to loop completion.
+
+The existing pattern for this kind of guard already exists in `LoopState`: `consecutive_failures`, `consecutive_malformed_events`, and `abandoned_task_redispatches` all track degenerate iteration patterns and feed into `check_termination()`. This fix follows the same pattern.
+
+Three independent models (o3, Sonnet 4, Gemini 3.1) analyzed this bug and unanimously recommended Option 4 (consecutive default limiting) as the core fix, with two of three also recommending Option 1 (completion promise guard) as defense-in-depth.
+
+## Reference Documentation
+**Required:**
+- Event loop core: `crates/ralph-core/src/event_loop/mod.rs` — `check_default_publishes()` (~line 1362), `check_termination()` (~line 434), `TerminationReason` enum (~line 38)
+- Loop runner: `crates/ralph-cli/src/loop_runner.rs` — default injection block (~line 1083)
+- Loop state: `crates/ralph-core/src/event_loop/loop_state.rs` — `LoopState` struct
+- Config validation: `crates/ralph-core/src/config.rs` — `validate()` method, `HatConfig` struct (~line 1262)
+
+**Additional References:**
+- Existing default_publishes tests: `crates/ralph-core/src/event_loop/tests.rs` (~line 1026)
+- **New cascade reproduction test**: `crates/ralph-core/src/event_loop/tests.rs` — `test_default_publishes_cascade_on_silent_agent` (documents the bug; assertions must be flipped when fix lands)
+- Existing scenario test: `crates/ralph-core/tests/scenarios/default_publishes.yml`
+
+## Technical Requirements
+
+### Layer 1: Runtime Cascade Guard
+1. Add `consecutive_default_publishes: u32` field to `LoopState` in `loop_state.rs`
+2. In `loop_runner.rs`: reset counter to 0 when `agent_wrote_events` is true
+3. In `loop_runner.rs`: before calling `check_default_publishes`, skip if counter > 0 (one consecutive default allowed, second blocked)
+4. After injecting a default, increment the counter
+5. Add `CascadingDefaults` variant to `TerminationReason` enum with exit code 1 and reason string `"cascading_defaults"`
+6. In `check_termination()`: return `CascadingDefaults` when `consecutive_default_publishes >= 2`
+
+### Layer 2: Config Validation
+7. In `config.rs` `validate()`: for each hat, if `default_publishes` is `Some` and equals `completion_promise`, push a validation error
+8. Error message: `"Hat '{hat_id}' has default_publishes='{topic}' which matches the completion promise. The completion event must be emitted explicitly by the agent, not injected as a default. Remove default_publishes from this hat or change it to a non-completion event."`
+
+### Wiring
+9. Add `CascadingDefaults` to all `TerminationReason` match arms (exit_code, as_str, is_success, loop terminate message, TUI display, history recording)
+10. Update `print_termination` and any TUI rendering that matches on `TerminationReason`
+
+## Dependencies
+- No new crate dependencies
+- Follows existing `consecutive_failures` / `consecutive_malformed_events` patterns in `LoopState`
+
+## Implementation Approach
+1. Add field to `LoopState`, default to 0
+2. Add `CascadingDefaults` to `TerminationReason` and wire all match arms
+3. Add validation check in `config.rs` `validate()`
+4. Modify `loop_runner.rs` default injection block: reset/skip/increment logic
+5. Add check in `check_termination()` for the new counter
+6. Write unit tests
+7. Update existing `default_publishes.yml` scenario or add new one
+8. Run `cargo test` to confirm no regressions
+
+## Acceptance Criteria
+
+1. **Silent cascade is blocked**
+   - Given a hat chain where all hats have `default_publishes` and a silent agent backend
+   - When the loop runs
+   - Then at most one `default_publishes` fires before the loop terminates with `CascadingDefaults`
+
+2. **Single default still works**
+   - Given a hat with `default_publishes` and a silent agent in one iteration
+   - When the agent writes real events in the next iteration
+   - Then the counter resets and defaults work again later
+
+3. **Completion promise rejected in config**
+   - Given a hat config where `default_publishes` equals the `completion_promise`
+   - When `validate()` runs
+   - Then a validation error is returned with an actionable message
+
+4. **Legitimate configs unaffected**
+   - Given existing preset configs (feature, code-assist, etc.) that don't set `default_publishes` to the completion promise
+   - When `validate()` runs
+   - Then no new validation errors are produced
+
+5. **Existing presets updated**
+   - Given `presets/bugfix.yml` and `crates/ralph-cli/presets/bugfix.yml` where the `committer` hat has `default_publishes: "LOOP_COMPLETE"`
+   - When the fix lands
+   - Then those presets have `default_publishes` removed from the committer hat (or changed to a non-completion event)
+
+6. **New termination reason wired correctly**
+   - Given `CascadingDefaults` termination
+   - When the loop exits
+   - Then exit code is 1, reason string is `"cascading_defaults"`, and the terminate event payload reflects this
+
+7. **Existing tests pass**
+   - Given the full test suite
+   - When `cargo test` runs
+   - Then all existing tests pass, including the 4 existing `default_publishes` tests
+
+8. **New unit tests cover the guard**
+   - Given the new code
+   - When tests run
+   - Then there are tests for: cascade blocked after 2 consecutive defaults, counter reset on real events, config rejection of completion-promise defaults, `CascadingDefaults` termination reason properties
+
+9. **Existing cascade reproduction test flipped**
+   - Given `test_default_publishes_cascade_on_silent_agent` which currently documents the bug
+   - When the fix lands
+   - Then flip the assertions to verify: `injected_defaults.len() <= 1` and `!injected_defaults.contains("LOOP_COMPLETE")`
+
+## Metadata
+- **Complexity**: Medium
+- **Labels**: Bug Fix, Event Loop, default_publishes, Parallel Loops, Worktree
+- **Required Skills**: Rust, ralph event loop architecture, LoopState patterns

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -1248,6 +1248,142 @@ fn test_default_publishes_not_injected_when_not_configured() {
     );
 }
 
+/// Integration test: default_publishes cascades through a 3-hat chain when agent is silent.
+///
+/// Reproduces https://github.com/mikeyobrien/ralph-orchestrator/issues/187
+///
+/// Setup: track_builder → security_reviewer → track_reviewer, all with default_publishes.
+/// The agent writes zero events every iteration. Without a fix, defaults cascade:
+///   iteration 1: track_builder silent → inject track.build.done
+///   iteration 2: security_reviewer silent → inject security_review.passed
+///   iteration 3: track_reviewer silent → inject LOOP_COMPLETE → loop completes
+///
+/// This test drives the EventLoop through the same code path as loop_runner.rs
+/// to prove the cascade happens (and will verify the fix blocks it).
+#[test]
+/// Regression test for #187: default_publishes cascades through a 3-hat chain
+/// when the agent is silent, advancing all the way to LOOP_COMPLETE with zero
+/// real work done.
+///
+/// Setup: track_builder → security_reviewer → track_reviewer, each hat's
+/// default_publishes feeds the next hat's trigger. When no agent writes events,
+/// each call to check_default_publishes injects a default that activates the
+/// next hat, which also gets a default, and so on.
+///
+/// This test documents the bug. When the fix lands, flip assertions to:
+///   assert!(injected_defaults.len() <= 1);
+///   assert!(!injected_defaults.contains(&"LOOP_COMPLETE".to_string()));
+fn test_default_publishes_cascade_on_silent_agent() {
+    use std::collections::HashMap;
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    // Build a 3-hat chain where defaults cascade
+    let mut config = RalphConfig::default();
+    config.event_loop.completion_promise = "LOOP_COMPLETE".to_string();
+    config.event_loop.max_iterations = 10;
+    config.event_loop.starting_event = Some("track.build.start".to_string());
+
+    let make_hat =
+        |triggers: Vec<&str>, publishes: Vec<&str>, default: &str| crate::config::HatConfig {
+            name: String::new(),
+            description: None,
+            triggers: triggers.into_iter().map(String::from).collect(),
+            publishes: publishes.into_iter().map(String::from).collect(),
+            instructions: String::new(),
+            extra_instructions: vec![],
+            backend_args: None,
+            backend: None,
+            default_publishes: Some(default.to_string()),
+            max_activations: None,
+        };
+
+    let mut hats = HashMap::new();
+    hats.insert(
+        "track_builder".to_string(),
+        make_hat(
+            vec!["track.build.start"],
+            vec!["track.build.done"],
+            "track.build.done",
+        ),
+    );
+    hats.insert(
+        "security_reviewer".to_string(),
+        make_hat(
+            vec!["track.build.done"],
+            vec!["security_review.passed"],
+            "security_review.passed",
+        ),
+    );
+    hats.insert(
+        "track_reviewer".to_string(),
+        make_hat(
+            vec!["security_review.passed"],
+            vec!["LOOP_COMPLETE"],
+            "LOOP_COMPLETE",
+        ),
+    );
+    config.hats = hats;
+
+    let mut event_loop = EventLoop::new(config);
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Reproduce issue 187");
+
+    // Run iterations: each time the agent is silent, so we inject defaults.
+    // Track which default topics get injected across all iterations.
+    let mut injected_defaults: Vec<String> = Vec::new();
+
+    for iteration in 0..10 {
+        let hat_id = event_loop
+            .next_hat()
+            .cloned()
+            .unwrap_or_else(|| HatId::new("ralph"));
+
+        // build_prompt consumes pending events and sets last_active_hat_ids
+        let _prompt = event_loop.build_prompt(&hat_id);
+
+        // Silent agent: writes nothing, but we must call process_output to
+        // advance the iteration counter (it's how EventLoop tracks progress)
+        event_loop.process_output(&hat_id, "", true);
+
+        // Silent agent: no JSONL events written
+        let result = event_loop.process_events_from_jsonl().unwrap();
+        assert!(!result.had_events, "Agent should be silent");
+
+        // Inject default for the active hat (same as loop_runner gate)
+        let active_hats = event_loop.state().last_active_hat_ids.clone();
+        for active_hat_id in &active_hats {
+            event_loop.check_default_publishes(active_hat_id);
+            if event_loop.has_pending_events() {
+                if let Some(cfg) = event_loop.registry().get_config(active_hat_id)
+                    && let Some(ref default_topic) = cfg.default_publishes
+                {
+                    injected_defaults.push(default_topic.clone());
+                }
+                break;
+            }
+        }
+
+        if event_loop.check_termination().is_some() {
+            break;
+        }
+        assert!(iteration < 9, "Should terminate before 10 iterations");
+    }
+
+    // BUG: all 3 defaults fire in sequence with zero real work
+    assert_eq!(
+        injected_defaults,
+        vec![
+            "track.build.done",
+            "security_review.passed",
+            "LOOP_COMPLETE"
+        ],
+        "Bug #187: silent agent causes full cascade through hat chain"
+    );
+}
+
 #[test]
 fn test_get_hat_backend_with_named_backend() {
     let yaml = r#"


### PR DESCRIPTION
## Summary

Adds a reproduction test and structured code-task for **issue #187**: `default_publishes` cascades to `LOOP_COMPLETE` when agent writes no events in worktree loops, completing the loop with zero work done.

## What's included

### Integration test: `test_default_publishes_cascade_on_silent_agent`

Drives the `EventLoop` through a 3-hat chain (`track_builder` → `security_reviewer` → `track_reviewer`) where:
- All hats have `default_publishes` configured
- Agent writes zero events every iteration (silent backend)
- Verifies all 3 defaults fire, cascading through to `LOOP_COMPLETE`

The test **documents the bug** — assertions will be flipped when the fix lands.

### Code task: `fix-default-publishes-cascade.code-task.md`

Fix design synthesized from 3 independent model analyses (o3, Sonnet 4, Gemini 3.1):

**Layer 1 — Runtime cascade guard:**
- `consecutive_default_publishes: u32` counter in `LoopState`
- Resets on real agent output, increments on default injection
- `CascadingDefaults` termination when threshold (1) exceeded

**Layer 2 — Config validation:**
- Reject `default_publishes == completion_promise` at config load time
- Warn when `default_publishes` is set to `LOOP_COMPLETE` (almost always a mistake)

### Acceptance criteria (9 items)
See the code-task file for the full checklist.

## Testing

- ✅ All 719 tests pass (688 unit + 31 integration/doc), excluding the pre-existing `check_node_rejects_old_version` web.rs flake
- The new test (`test_default_publishes_cascade_on_silent_agent`) exercises the exact bug path

Refs: #187
