### PR TITLE
fix: resolve clippy warnings and add missing ACP struct fields

### DIFF
--- a/crates/ralph-adapters/src/acp_executor.rs
+++ b/crates/ralph-adapters/src/acp_executor.rs
@@ -231,6 +231,10 @@ impl AcpExecutor {
             total_cost_usd: 0.0,
             num_turns: 1,
             is_error,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
         });
 
         Ok(PtyExecutionResult {
@@ -240,6 +244,11 @@ impl AcpExecutor {
             success,
             exit_code: if success { Some(0) } else { Some(1) },
             termination: TerminationType::Natural,
+            total_cost_usd: 0.0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
         })
     }
 }

--- a/crates/ralph-api/src/idempotency.rs
+++ b/crates/ralph-api/src/idempotency.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn replays_same_method_key_and_params() {
-        let store = InMemoryIdempotencyStore::new(Duration::from_secs(60));
+        let store = InMemoryIdempotencyStore::new(Duration::from_mins(1));
         let params = json!({ "value": 1 });
         let response = StoredResponse {
             status: 200,
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn detects_conflict_for_same_key_with_different_params() {
-        let store = InMemoryIdempotencyStore::new(Duration::from_secs(60));
+        let store = InMemoryIdempotencyStore::new(Duration::from_mins(1));
         store.store(
             "task.create",
             "idem-2",

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -1551,6 +1551,11 @@ async fn execute_acp(
         output,
         success: pty_result.success,
         termination: None,
+        total_cost_usd: pty_result.total_cost_usd,
+        input_tokens: pty_result.input_tokens,
+        output_tokens: pty_result.output_tokens,
+        cache_read_tokens: pty_result.cache_read_tokens,
+        cache_write_tokens: pty_result.cache_write_tokens,
     })
 }
 

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -2860,7 +2860,7 @@ fn test_format_duration_variants() {
 
     assert_eq!(format_duration(Duration::from_secs(45)), "45s");
     assert_eq!(format_duration(Duration::from_secs(61)), "1m 1s");
-    assert_eq!(format_duration(Duration::from_secs(3600)), "1h 0m 0s");
+    assert_eq!(format_duration(Duration::from_hours(1)), "1h 0m 0s");
     assert_eq!(format_duration(Duration::from_secs(3661)), "1h 1m 1s");
 }
 

--- a/crates/ralph-core/src/testing/smoke_runner.rs
+++ b/crates/ralph-core/src/testing/smoke_runner.rs
@@ -462,12 +462,12 @@ coverage: pass
     #[test]
     fn test_config_builder_pattern() {
         let config = SmokeTestConfig::new("test.jsonl")
-            .with_timeout(Duration::from_secs(60))
+            .with_timeout(Duration::from_mins(1))
             .with_expected_iterations(5)
             .with_expected_termination("Completed");
 
         assert_eq!(config.fixture_path, PathBuf::from("test.jsonl"));
-        assert_eq!(config.timeout, Duration::from_secs(60));
+        assert_eq!(config.timeout, Duration::from_mins(1));
         assert_eq!(config.expected_iterations, Some(5));
         assert_eq!(config.expected_termination, Some("Completed".to_string()));
     }

--- a/crates/ralph-core/src/utils.rs
+++ b/crates/ralph-core/src/utils.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn format_elapsed_one_minute() {
-        assert_eq!(format_elapsed(Duration::from_secs(60)), "01:00");
+        assert_eq!(format_elapsed(Duration::from_mins(1)), "01:00");
     }
 
     #[test]

--- a/crates/ralph-e2e/src/analyzer.rs
+++ b/crates/ralph-e2e/src/analyzer.rs
@@ -80,7 +80,7 @@ pub struct AnalyzerConfig {
 impl Default for AnalyzerConfig {
     fn default() -> Self {
         Self {
-            timeout: Duration::from_secs(120),
+            timeout: Duration::from_mins(2),
             max_iterations: 1,
             backend: "claude".to_string(),
         }
@@ -733,7 +733,7 @@ mod tests {
         let workspace = PathBuf::from(".e2e-tests");
         let analyzer = MetaRalphAnalyzer::new(workspace.clone());
         assert_eq!(analyzer.workspace(), &workspace);
-        assert_eq!(analyzer.config().timeout, Duration::from_secs(120));
+        assert_eq!(analyzer.config().timeout, Duration::from_mins(2));
         assert_eq!(analyzer.config().max_iterations, 1);
         assert_eq!(analyzer.config().backend, "claude");
     }
@@ -742,12 +742,12 @@ mod tests {
     fn test_analyzer_with_config() {
         let workspace = PathBuf::from(".e2e-tests");
         let config = AnalyzerConfig {
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             max_iterations: 2,
             backend: "kiro".to_string(),
         };
         let analyzer = MetaRalphAnalyzer::with_config(workspace.clone(), config);
-        assert_eq!(analyzer.config().timeout, Duration::from_secs(60));
+        assert_eq!(analyzer.config().timeout, Duration::from_mins(1));
         assert_eq!(analyzer.config().max_iterations, 2);
         assert_eq!(analyzer.config().backend, "kiro");
     }
@@ -804,7 +804,7 @@ mod tests {
     #[test]
     fn test_generate_analyzer_config_custom() {
         let config = AnalyzerConfig {
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             max_iterations: 3,
             backend: "kiro".to_string(),
         };

--- a/crates/ralph-e2e/src/backend.rs
+++ b/crates/ralph-e2e/src/backend.rs
@@ -35,8 +35,8 @@ impl Backend {
     /// Returns the default timeout for this backend.
     pub fn default_timeout(&self) -> Duration {
         match self {
-            Backend::Claude => Duration::from_secs(600), // 10 minutes - Claude iterations can take 60-120s each
-            Backend::Kiro | Backend::OpenCode => Duration::from_secs(300), // 5 minutes
+            Backend::Claude => Duration::from_mins(10), // 10 minutes - Claude iterations can take 60-120s each
+            Backend::Kiro | Backend::OpenCode => Duration::from_mins(5), // 5 minutes
         }
     }
 

--- a/crates/ralph-e2e/src/executor.rs
+++ b/crates/ralph-e2e/src/executor.rs
@@ -59,7 +59,7 @@ impl ScenarioConfig {
             config_file: PathBuf::from("ralph.yml"),
             prompt: PromptSource::Inline(prompt.into()),
             max_iterations: 1,
-            timeout: Duration::from_secs(300), // 5 minutes - Claude iterations can take 60-120s
+            timeout: Duration::from_mins(5), // 5 minutes - Claude iterations can take 60-120s
             extra_args: vec![],
         }
     }
@@ -525,7 +525,7 @@ mod tests {
         assert_eq!(config.config_file, PathBuf::from("ralph.yml"));
         assert!(matches!(config.prompt, PromptSource::Inline(p) if p == "Say hello"));
         assert_eq!(config.max_iterations, 1);
-        assert_eq!(config.timeout, Duration::from_secs(300));
+        assert_eq!(config.timeout, Duration::from_mins(5));
         assert!(config.extra_args.is_empty());
     }
 

--- a/crates/ralph-e2e/src/scenarios/incremental.rs
+++ b/crates/ralph-e2e/src/scenarios/incremental.rs
@@ -525,7 +525,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase1_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_secs(120),
+            timeout: std::time::Duration::from_mins(2),
             extra_args: vec![],
         };
 
@@ -551,7 +551,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase2_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_secs(120),
+            timeout: std::time::Duration::from_mins(2),
             extra_args: vec![],
         };
 
@@ -578,7 +578,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase3_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_secs(120),
+            timeout: std::time::Duration::from_mins(2),
             extra_args: vec![],
         };
 

--- a/crates/ralph-tui/src/widgets/header.rs
+++ b/crates/ralph-tui/src/widgets/header.rs
@@ -706,7 +706,7 @@ mod tests {
         let event = Event::new("task.start", "");
         state.update(&event);
         if let Some(iteration) = state.iterations.get_mut(0) {
-            iteration.elapsed = Some(Duration::from_secs(300));
+            iteration.elapsed = Some(Duration::from_mins(5));
         }
 
         let text = render_to_string(&state);
@@ -749,7 +749,7 @@ mod tests {
         );
         // Mark iteration as finished (elapsed is set)
         if let Some(iteration) = state.iterations.first_mut() {
-            iteration.elapsed = Some(Duration::from_secs(60));
+            iteration.elapsed = Some(Duration::from_mins(1));
         }
         // current_view = 0 (still viewing the finished iteration, following latest)
         state.current_view = 0;


### PR DESCRIPTION
- Fix `duration_suboptimal_units` clippy warnings across all crates (from_secs → from_mins/from_hours)
- Add missing token/cost fields to ACP executor structs (SessionResult, PtyExecutionResult, ExecutionOutcome) added upstream in #200
- All 402 tests pass, zero clippy warnings, formatting clean