### PR TITLE
refactor(core,api,e2e,tui): replace deprecated Duration methods and improve config presets

### DIFF
--- a/crates/ralph-api/src/idempotency.rs
+++ b/crates/ralph-api/src/idempotency.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn replays_same_method_key_and_params() {
-        let store = InMemoryIdempotencyStore::new(Duration::from_mins(1));
+        let store = InMemoryIdempotencyStore::new(Duration::from_secs(60));
         let params = json!({ "value": 1 });
         let response = StoredResponse {
             status: 200,
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn detects_conflict_for_same_key_with_different_params() {
-        let store = InMemoryIdempotencyStore::new(Duration::from_mins(1));
+        let store = InMemoryIdempotencyStore::new(Duration::from_secs(60));
         store.store(
             "task.create",
             "idem-2",

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -2860,7 +2860,7 @@ fn test_format_duration_variants() {
 
     assert_eq!(format_duration(Duration::from_secs(45)), "45s");
     assert_eq!(format_duration(Duration::from_secs(61)), "1m 1s");
-    assert_eq!(format_duration(Duration::from_hours(1)), "1h 0m 0s");
+    assert_eq!(format_duration(Duration::from_secs(3600)), "1h 0m 0s");
     assert_eq!(format_duration(Duration::from_secs(3661)), "1h 1m 1s");
 }
 

--- a/crates/ralph-core/src/testing/smoke_runner.rs
+++ b/crates/ralph-core/src/testing/smoke_runner.rs
@@ -462,12 +462,12 @@ coverage: pass
     #[test]
     fn test_config_builder_pattern() {
         let config = SmokeTestConfig::new("test.jsonl")
-            .with_timeout(Duration::from_mins(1))
+            .with_timeout(Duration::from_secs(60))
             .with_expected_iterations(5)
             .with_expected_termination("Completed");
 
         assert_eq!(config.fixture_path, PathBuf::from("test.jsonl"));
-        assert_eq!(config.timeout, Duration::from_mins(1));
+        assert_eq!(config.timeout, Duration::from_secs(60));
         assert_eq!(config.expected_iterations, Some(5));
         assert_eq!(config.expected_termination, Some("Completed".to_string()));
     }

--- a/crates/ralph-core/src/utils.rs
+++ b/crates/ralph-core/src/utils.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn format_elapsed_one_minute() {
-        assert_eq!(format_elapsed(Duration::from_mins(1)), "01:00");
+        assert_eq!(format_elapsed(Duration::from_secs(60)), "01:00");
     }
 
     #[test]

--- a/crates/ralph-core/tests/smoke_runner.rs
+++ b/crates/ralph-core/tests/smoke_runner.rs
@@ -624,10 +624,10 @@ Still working..."#;
         let line = make_write_line("Quick output", 0);
         let fixture_path = create_fixture(temp_dir.path(), "quick.jsonl", &line);
 
-        let config = SmokeTestConfig::new(&fixture_path).with_timeout(Duration::from_mins(1));
+        let config = SmokeTestConfig::new(&fixture_path).with_timeout(Duration::from_secs(60));
 
         // Verify config was set
-        assert_eq!(config.timeout, Duration::from_mins(1));
+        assert_eq!(config.timeout, Duration::from_secs(60));
 
         let result = SmokeRunner::run(&config).expect("Should complete within 60s");
         assert!(result.completed_successfully());

--- a/crates/ralph-e2e/src/analyzer.rs
+++ b/crates/ralph-e2e/src/analyzer.rs
@@ -80,7 +80,7 @@ pub struct AnalyzerConfig {
 impl Default for AnalyzerConfig {
     fn default() -> Self {
         Self {
-            timeout: Duration::from_mins(2),
+            timeout: Duration::from_secs(120),
             max_iterations: 1,
             backend: "claude".to_string(),
         }
@@ -733,7 +733,7 @@ mod tests {
         let workspace = PathBuf::from(".e2e-tests");
         let analyzer = MetaRalphAnalyzer::new(workspace.clone());
         assert_eq!(analyzer.workspace(), &workspace);
-        assert_eq!(analyzer.config().timeout, Duration::from_mins(2));
+        assert_eq!(analyzer.config().timeout, Duration::from_secs(120));
         assert_eq!(analyzer.config().max_iterations, 1);
         assert_eq!(analyzer.config().backend, "claude");
     }
@@ -742,12 +742,12 @@ mod tests {
     fn test_analyzer_with_config() {
         let workspace = PathBuf::from(".e2e-tests");
         let config = AnalyzerConfig {
-            timeout: Duration::from_mins(1),
+            timeout: Duration::from_secs(60),
             max_iterations: 2,
             backend: "kiro".to_string(),
         };
         let analyzer = MetaRalphAnalyzer::with_config(workspace.clone(), config);
-        assert_eq!(analyzer.config().timeout, Duration::from_mins(1));
+        assert_eq!(analyzer.config().timeout, Duration::from_secs(60));
         assert_eq!(analyzer.config().max_iterations, 2);
         assert_eq!(analyzer.config().backend, "kiro");
     }
@@ -804,7 +804,7 @@ mod tests {
     #[test]
     fn test_generate_analyzer_config_custom() {
         let config = AnalyzerConfig {
-            timeout: Duration::from_mins(1),
+            timeout: Duration::from_secs(60),
             max_iterations: 3,
             backend: "kiro".to_string(),
         };

--- a/crates/ralph-e2e/src/backend.rs
+++ b/crates/ralph-e2e/src/backend.rs
@@ -35,8 +35,8 @@ impl Backend {
     /// Returns the default timeout for this backend.
     pub fn default_timeout(&self) -> Duration {
         match self {
-            Backend::Claude => Duration::from_mins(10), // 10 minutes - Claude iterations can take 60-120s each
-            Backend::Kiro | Backend::OpenCode => Duration::from_mins(5), // 5 minutes
+            Backend::Claude => Duration::from_secs(600), // 10 minutes - Claude iterations can take 60-120s each
+            Backend::Kiro | Backend::OpenCode => Duration::from_secs(300), // 5 minutes
         }
     }
 

--- a/crates/ralph-e2e/src/executor.rs
+++ b/crates/ralph-e2e/src/executor.rs
@@ -59,7 +59,7 @@ impl ScenarioConfig {
             config_file: PathBuf::from("ralph.yml"),
             prompt: PromptSource::Inline(prompt.into()),
             max_iterations: 1,
-            timeout: Duration::from_mins(5), // 5 minutes - Claude iterations can take 60-120s
+            timeout: Duration::from_secs(300), // 5 minutes - Claude iterations can take 60-120s
             extra_args: vec![],
         }
     }
@@ -525,7 +525,7 @@ mod tests {
         assert_eq!(config.config_file, PathBuf::from("ralph.yml"));
         assert!(matches!(config.prompt, PromptSource::Inline(p) if p == "Say hello"));
         assert_eq!(config.max_iterations, 1);
-        assert_eq!(config.timeout, Duration::from_mins(5));
+        assert_eq!(config.timeout, Duration::from_secs(300));
         assert!(config.extra_args.is_empty());
     }
 

--- a/crates/ralph-e2e/src/scenarios/incremental.rs
+++ b/crates/ralph-e2e/src/scenarios/incremental.rs
@@ -525,7 +525,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase1_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_mins(2),
+            timeout: std::time::Duration::from_secs(120),
             extra_args: vec![],
         };
 
@@ -551,7 +551,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase2_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_mins(2),
+            timeout: std::time::Duration::from_secs(120),
             extra_args: vec![],
         };
 
@@ -578,7 +578,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase3_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_mins(2),
+            timeout: std::time::Duration::from_secs(120),
             extra_args: vec![],
         };
 

--- a/crates/ralph-tui/src/widgets/header.rs
+++ b/crates/ralph-tui/src/widgets/header.rs
@@ -706,7 +706,7 @@ mod tests {
         let event = Event::new("task.start", "");
         state.update(&event);
         if let Some(iteration) = state.iterations.get_mut(0) {
-            iteration.elapsed = Some(Duration::from_mins(5));
+            iteration.elapsed = Some(Duration::from_secs(300));
         }
 
         let text = render_to_string(&state);
@@ -749,7 +749,7 @@ mod tests {
         );
         // Mark iteration as finished (elapsed is set)
         if let Some(iteration) = state.iterations.first_mut() {
-            iteration.elapsed = Some(Duration::from_mins(1));
+            iteration.elapsed = Some(Duration::from_secs(60));
         }
         // current_view = 0 (still viewing the finished iteration, following latest)
         state.current_view = 0;

--- a/ralph.qa.yml
+++ b/ralph.qa.yml
@@ -1,0 +1,407 @@
+# QA Preset — Event Loop & TUI Validation
+#
+# Superset of ralph.yml that adds a QA gate for event loop and TUI changes.
+# Same planner→builder→reviewer pipeline, but after review.approved,
+# QA diffs origin/main to scope changes, builds a targeted test plan,
+# and executes each target via tmux splits with `ralph run`.
+# P1 issues feed back to the planner for fixes. Hard stop after 3 QA rounds.
+#
+# Use this when changes touch the event loop, TUI, hat routing, backpressure,
+# or config parsing. For docs-only or preset-only changes, the QA planner
+# will detect no impacting changes and skip QA automatically.
+#
+# Usage:
+#   ralph run -H ralph.qa.yml -p "QA the event loop and TUI changes"
+
+event_loop:
+  starting_event: "work.start"
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 200
+  max_runtime_seconds: 28800
+
+core:
+  scratchpad: ".ralph/scratchpad.md"
+  guardrails:
+    - "Fresh context each iteration - re-read scratchpad and plan"
+    - "Commit after each completed step. Never commit Ralph files."
+    - "Verification is mandatory — evidence required, not just claims."
+    - "Confidence protocol: >80 proceed; 50-80 proceed + note in scratchpad; <50 choose safe default + note."
+    - "Preserve primary sources — capture referenced code snippets with file:line attribution in scratchpad."
+    - "Max 3 QA rounds — hard stop if issues persist after 3 fix cycles."
+
+hats:
+  planner:
+    name: "📋 Planner"
+    description: "Breaks steps into sub-tasks and assigns them one at a time"
+    triggers: ["work.start", "subtask.done", "qa.issues_found"]
+    publishes: ["subtask.ready", "all_steps.done"]
+    default_publishes: "subtask.ready"
+    instructions: |
+      Manage sub-task breakdown and assignment.
+
+      ## Read State
+      1. Read PROMPT.md for the implementation plan/steps
+      2. Read scratchpad for current progress
+
+      ## Logic
+
+      ### If no current step in scratchpad:
+      - Identify the next incomplete step from the plan
+      - Break it into the smallest possible sub-tasks (one file, one function, one test)
+      - Write sub-task checklist to scratchpad under "## Current Step: Step N - {name}"
+      - Each sub-task should be independently verifiable
+      - Include test sub-tasks immediately after implementation sub-tasks
+      - Emit subtask.ready with first sub-task
+
+      ### If current step has incomplete sub-tasks:
+      - Find next unchecked sub-task in scratchpad
+      - Emit subtask.ready with that sub-task
+
+      ### If current step complete (all sub-tasks checked):
+      - Move step to "## Completed Steps" section in scratchpad
+      - Clear "## Current Step" section
+      - If more steps remain → identify next step, break into sub-tasks
+      - If all steps complete → emit all_steps.done
+
+      ### If triggered by qa.issues_found:
+      Read `.ralph/agent/qa-event-loop-log.md` for the QA Report.
+      - Create fix sub-tasks from P1 issues under
+        "## Current Step: QA Fix Round N"
+      - Each P1 issue = one sub-task with file:line reference from QA report
+      - Emit subtask.ready with first fix task
+
+      ## Sub-task Granularity Examples
+      Good: "Add timeout check to event_loop.rs run()", "Write test for max_iterations termination"
+      Bad: "Fix all event loop issues", "Add tests for everything"
+
+      ## Scratchpad Format
+      ```markdown
+      # Implementation Progress
+
+      ## Current Step: Step 1 - {name}
+
+      ### Sub-tasks:
+      - [x] 1.1 First sub-task
+      - [ ] 1.2 Second sub-task
+      - [ ] 1.3 Write tests for above
+      ...
+
+      ### Notes:
+      (any relevant context)
+
+      ## Completed Steps:
+      - Step 0: (if any)
+      ```
+
+  builder:
+    name: "⚡ Builder"
+    description: "Implements one sub-task at a time"
+    triggers: ["subtask.ready", "review.changes_requested"]
+    publishes: ["subtask.done", "implementation.done"]
+    default_publishes: "subtask.done"
+    instructions: |
+      Implement the assigned sub-task only.
+
+      ## Scope
+      CRITICAL: Implement ONLY the single sub-task assigned. Do not work ahead.
+      - One sub-task = one small, focused change
+      - If it's a test sub-task, write the tests
+      - If it's an implementation sub-task, write the code
+
+      ## Verification
+      Before emitting subtask.done, you MUST have evidence:
+      - `cargo test -p ralph-core` passes
+      - `cargo test -p ralph-cli` passes (if CLI changes)
+      Include actual pass/fail results in scratchpad Notes.
+
+      ## On Completion
+      1. Mark sub-task as complete in scratchpad: `- [x] 1.1 ...`
+      2. Add any relevant notes to scratchpad Notes section
+      3. Commit with conventional format: `<type>(<scope>): <description>`
+      4. Emit subtask.done
+
+      On review.changes_requested → address feedback, emit implementation.done
+
+  reviewer:
+    name: "👀 Reviewer"
+    description: "Reviews implementation quality at step completion"
+    triggers: ["all_steps.done", "implementation.done"]
+    publishes: ["review.approved", "review.changes_requested"]
+    default_publishes: "review.approved"
+    instructions: |
+      Review implementation changes.
+
+      ## Quality Checks
+
+      ### Verification Evidence
+      Check scratchpad for verification evidence from the builder.
+      FAIL if no evidence was recorded.
+
+      ### Idiomatic Check
+      - Naming conventions match surrounding Rust code?
+      - Error handling follows existing patterns (anyhow, thiserror)?
+      - File organization consistent with crate structure?
+      FAIL if code looks foreign to the codebase.
+
+      ### Correctness & Safety
+      - Does it match the plan requirements?
+      - Error handling present and appropriate?
+      - No unsafe blocks without justification?
+
+      ### Test Coverage
+      - Each new function should have test coverage
+      - Tests should cover happy path and edge cases
+      - Reject if tests are missing or deferred
+
+      ## Decision
+      Blocking: missing verification evidence, security, broken functionality, missing tests.
+      Don't block for minor style nitpicks.
+
+      If blocking → emit review.changes_requested with specific file:line references
+      If solid → emit review.approved
+
+  qa_planner:
+    name: "🧪 QA Planner"
+    description: "Diffs origin/main, builds targeted test plan, drives QA execution"
+    triggers: ["review.approved", "qa-test.done"]
+    publishes: ["qa-test.ready", "qa.passed", "qa.issues_found"]
+    default_publishes: "qa-test.ready"
+    instructions: |
+      Analyze changes and manage QA test execution.
+      State lives in `.ralph/agent/qa-event-loop-log.md` (NOT the main scratchpad).
+
+      ## Read State
+      1. Read scratchpad for implementation context
+      2. Read `.ralph/agent/qa-event-loop-log.md` if it exists (prior QA state)
+
+      ## Logic
+
+      ### If no qa-event-loop-log.md (first trigger from review.approved):
+
+      #### Impact Assessment
+      Check which crates/files were changed (git diff origin/main --stat + scratchpad):
+      - **QA-impacting** — changes in crates/ralph-core/src/event_loop*,
+        crates/ralph-cli/src/tui*, crates/ralph-core/src/hat*,
+        crates/ralph-core/src/backpressure*, config parsing
+      - **Non-impacting** — only docs/, presets/, README, CI config
+
+      If non-impacting → emit qa.passed immediately. Do nothing else.
+
+      #### Classify changes into test targets
+      For each changed area, create a test target:
+
+      **Event loop changes** → integration test via `ralph run` with minimal config:
+      - Termination: does it stop at max_iterations? max_runtime?
+      - Backpressure: does `build.done` without evidence get blocked?
+      - Hat routing: do events reach the right hat?
+      - Completion: does the completion promise end the loop?
+      - Hat exhaustion: does max_activations trigger `<hat>.exhausted`?
+      - Default publishes: does the fallback event fire when agent is silent?
+
+      **TUI/display changes** → manual test via `ralph run --tui`:
+      - Iteration separator renders correctly (hat name, emoji, counter)
+      - Hat transitions display in the right order
+      - Termination message shows reason and stats
+
+      **Config changes** → integration test with the changed config:
+      - New starting_event works
+      - New hat topology flows correctly
+      - default_publishes fires when agent is silent
+
+      #### Write `.ralph/agent/qa-event-loop-log.md`:
+      ```markdown
+      # Event Loop QA Log
+      qa_round: 1
+      max_rounds: 3
+
+      ## Changes Summary
+      - file: what changed (from diff)
+
+      ## Test Targets
+      - [ ] 1. <scenario> — <why it matters>
+        - Type: manual | integration
+        - Config: /tmp/ralph-qa/<name>.yml
+        - Command: `ralph run ...`
+        - Verify: what to check in output
+        - Pass criteria: specific observable behavior
+      ```
+
+      Hard limit: 10 targets. Prioritize by risk — changed code paths first.
+      Targets can declare `Depends on: N` — keep chains max one level deep.
+      Order targets so dependencies come first.
+      Emit qa-test.ready with the first unchecked target.
+
+      ### If qa-event-loop-log.md exists with incomplete targets (triggered by qa-test.done):
+      - Read tester's latest result
+      - If BLOCKER → stop testing, compile report immediately
+        with remaining targets marked as "blocked by: <issue>"
+      - If a target failed and others depend on it → skip dependents,
+        mark them as "blocked by: #N"
+      - If next eligible unchecked target exists → emit qa-test.ready
+      - If all targets checked → compile report (see below)
+
+      ### If all targets checked but re-entering after fixes:
+      - If `qa_round` >= 3 → hard stop. Append final report noting
+        "QA_HARD_STOP: P1 issues unresolved after 3 rounds", emit qa.passed
+      - Otherwise → increment qa_round
+      - Re-test targets that previously failed or were blocked
+      - Uncheck those targets, emit qa-test.ready with the first one
+
+      ### Compile Report (all targets checked):
+      Append to qa-event-loop-log.md:
+      ```markdown
+      ## QA Report — Round N
+      targets_tested: N
+      p1_issues: N
+      p2_issues: N
+
+      ### Issues
+      - **[P1]** description — reproduction steps
+      - **[P2]** description
+
+      ### Verified Working
+      - ✅ items
+      ```
+      - ANY P1 issues → emit qa.issues_found (planner will create fix tasks)
+      - No P1 issues → emit qa.passed
+
+  qa_tester:
+    name: "🔍 QA Tester"
+    description: "Executes one test target using tmux split panes"
+    triggers: ["qa-test.ready"]
+    publishes: ["qa-test.done"]
+    default_publishes: "qa-test.done"
+    instructions: |
+      Execute one test target from `.ralph/agent/qa-event-loop-log.md`.
+
+      ## Tmux Setup
+      ```bash
+      tmux kill-session -t ralph-qa 2>/dev/null
+      tmux new-session -d -s ralph-qa -x 200 -y 50
+      tmux split-window -h -t ralph-qa
+      ```
+
+      ## Create test config
+      Write a minimal YAML to `/tmp/ralph-qa/<scenario>.yml` per target.
+
+      Examples:
+
+      **Termination (max_iterations)**:
+      ```yaml
+      event_loop:
+        max_iterations: 3
+        completion_promise: "TEST_DONE"
+        starting_event: "task.start"
+      cli:
+        backend: "echo"
+      hats:
+        worker:
+          triggers: ["task.start", "task.done"]
+          publishes: ["task.done"]
+          instructions: "Emit task.done each time."
+      ```
+
+      **Backpressure**:
+      ```yaml
+      event_loop:
+        max_iterations: 5
+        starting_event: "task.start"
+      hats:
+        worker:
+          triggers: ["task.start", "build.blocked"]
+          publishes: ["build.done"]
+          instructions: "Emit build.done with payload 'finished' (no evidence)."
+      ```
+
+      **Hat exhaustion**:
+      ```yaml
+      event_loop:
+        max_iterations: 10
+        starting_event: "task.start"
+      hats:
+        limited:
+          triggers: ["task.start", "work.done"]
+          publishes: ["work.done"]
+          max_activations: 2
+          instructions: "Emit work.done."
+      ```
+
+      **Default publishes**:
+      ```yaml
+      event_loop:
+        max_iterations: 3
+        starting_event: "task.start"
+      hats:
+        silent:
+          triggers: ["task.start", "fallback.event"]
+          publishes: ["fallback.event"]
+          default_publishes: "fallback.event"
+          instructions: "Do nothing. Do not emit any events."
+      ```
+
+      ## Run the test
+      ```bash
+      tmux send-keys -t ralph-qa:0.0 \
+        'mkdir -p /tmp/ralph-qa && ralph run -H /tmp/ralph-qa/<scenario>.yml -p "test" 2>&1 | tee /tmp/ralph-qa/output.log' Enter
+      ```
+
+      ```bash
+      tmux send-keys -t ralph-qa:0.1 'tail -f /tmp/ralph-qa/output.log' Enter
+      ```
+
+      ### For TUI tests — capture pane buffer
+      ```bash
+      tmux send-keys -t ralph-qa:0.0 \
+        'ralph run --tui -H /tmp/ralph-qa/<scenario>.yml -p "test"' Enter
+      sleep 15
+      tmux capture-pane -t ralph-qa:0.0 -p > /tmp/ralph-qa/tui-capture.txt
+      cat /tmp/ralph-qa/tui-capture.txt
+      ```
+
+      ## Verify pass criteria
+      ```bash
+      grep -c "ITERATION" /tmp/ralph-qa/output.log
+      grep "max_iterations\|exhausted\|build.blocked\|terminated" /tmp/ralph-qa/output.log
+      ```
+
+      ## Cleanup
+      ```bash
+      tmux kill-session -t ralph-qa 2>/dev/null
+      ```
+
+      ## Record results
+      Update `.ralph/agent/qa-event-loop-log.md`:
+      ```markdown
+      - [x] 1. <scenario> — ✅ PASS | ❌ FAIL | 🚫 BLOCKER
+        - Command: ralph run -H /tmp/ralph-qa/<scenario>.yml -p "test"
+        - Output: (relevant snippet)
+        - Issues: (if any) **[P1]** description
+      ```
+
+      Emit qa-test.done.
+
+  finalizer:
+    name: "📝 Finalizer"
+    description: "Creates changelog and completes loop"
+    triggers: ["qa.passed"]
+    publishes: ["LOOP_COMPLETE"]
+    instructions: |
+      Document the implementation.
+
+      ## Changelog
+      Create or update specs/<feature>/CHANGELOG.md with:
+      - Date header
+      - Added: new features
+      - Changed: modifications
+
+      Commit: `docs(changelog): update for <feature>`
+
+      ## Recommendations
+      Review changes and recommend updates to project docs:
+      - New patterns introduced that future work should follow
+      - Conventions discovered during implementation
+      - Gotchas worth documenting
+      Add to CHANGELOG.md under "## Suggested Doc Updates"
+      Do NOT auto-apply.
+
+      Output: LOOP_COMPLETE

--- a/ralph.yml
+++ b/ralph.yml
@@ -1,138 +1,227 @@
 event_loop:
-  prompt_file: PROMPT.md
   completion_promise: LOOP_COMPLETE
-  max_iterations: 50
-  max_runtime_seconds: 3600
-  checkpoint_interval: 5
-  starting_event: build.task
+  max_iterations: 150
+  max_runtime_seconds: 28800
+  starting_event: work.start
+
 cli:
-  backend: claude
+  backend: pi
+
 core:
   specs_dir: ./specs/
+  guardrails:
+    - "Fresh context each iteration — re-read scratchpad and plan."
+    - "Commit after each completed step. Never commit Ralph files."
+    - "Verification is mandatory — `just ci` must pass (fmt, clippy, tests). See AGENTS.md."
+    - "Confidence protocol: >80 proceed; 50-80 proceed + note in scratchpad; <50 choose safe default + note."
+    - "Preserve primary sources — capture referenced code snippets with file:line attribution in scratchpad."
+    - "Run targeted tests per crate (`cargo test -p ralph-core`) during subtasks; full `cargo test --all` only at final step."
+
+backpressure:
+  gates:
+    - name: fmt
+      command: cargo fmt --all -- --check
+      on_fail: "Formatting failed. Run `cargo fmt --all` and retry."
+    - name: clippy
+      command: cargo clippy --all-targets --all-features -- -D warnings
+      on_fail: "Clippy lint failures. Fix all warnings before proceeding."
+    - name: test
+      command: cargo test --all
+      on_fail: "Tests failed. Fix failing tests before proceeding."
+
 hats:
+  planner:
+    name: "📋 Planner"
+    description: "Breaks steps into sub-tasks scoped to individual crates"
+    triggers: ["work.start", "subtask.done"]
+    publishes: ["subtask.ready", "all_steps.done"]
+    default_publishes: "subtask.ready"
+    instructions: |
+      Manage sub-task breakdown and assignment for this Rust workspace.
+
+      ## Workspace Structure
+      ```
+      ralph-cli      → CLI entry point, commands
+      ralph-core     → Orchestration logic, event loop, hats, memories, tasks
+      ralph-adapters → Backend integrations (Claude, Kiro, Gemini, etc.)
+      ralph-telegram → Telegram bot for human-in-the-loop
+      ralph-tui      → Terminal UI (ratatui)
+      ralph-e2e      → End-to-end test framework
+      ralph-proto    → Protocol definitions
+      ralph-bench    → Benchmarking
+      ralph-api      → Web API server (Rust)
+      frontend/      → React + Vite dashboard
+      backend/       → Legacy Node tRPC server
+      ```
+
+      ## Read State
+      1. Read PROMPT.md for the implementation plan/steps
+      2. Read scratchpad for current progress
+      3. Check AGENTS.md for conventions relevant to the current step
+
+      ## Logic
+
+      ### If no current step in scratchpad:
+      - Identify the next incomplete step from the plan
+      - Break it into the smallest possible sub-tasks (one file, one function, one test)
+      - Scope each sub-task to a single crate where possible
+      - Write sub-task checklist to scratchpad under "## Current Step: Step N - {name}"
+      - Include test sub-tasks immediately after implementation sub-tasks
+      - Emit subtask.ready with first sub-task
+
+      ### If current step has incomplete sub-tasks:
+      - Find next unchecked sub-task in scratchpad
+      - Emit subtask.ready with that sub-task
+
+      ### If current step complete (all sub-tasks checked):
+      - Move step to "## Completed Steps" section in scratchpad
+      - Clear "## Current Step" section
+      - If more steps remain → identify next step, break into sub-tasks
+      - If all steps complete → emit all_steps.done
+
+      ## Sub-task Granularity Examples
+      Good:
+      - "Add `FooConfig` struct to `crates/ralph-core/src/config.rs`"
+      - "Add `parse_event` fn to `crates/ralph-core/src/event_loop/mod.rs`"
+      - "Write tests for `parse_event` in `crates/ralph-core`"
+
+      Bad:
+      - "Implement all config changes"
+      - "Add tests for everything"
+
+      ## Scratchpad Format
+      ```markdown
+      # Implementation Progress
+
+      ## Current Step: Step 1 - {name}
+
+      ### Sub-tasks:
+      - [x] 1.1 First sub-task (crate: ralph-core)
+      - [ ] 1.2 Second sub-task (crate: ralph-core)
+      - [ ] 1.3 Write tests for above (crate: ralph-core)
+
+      ### Notes:
+      (any relevant context)
+
+      ## Completed Steps:
+      - Step 0: (if any)
+      ```
+
   builder:
-    name: Builder
-    description: Implements one task and records an internal monologue for the confession phase.
-    triggers:
-    - build.task
-    publishes:
-    - build.done
-    - build.blocked
-    default_publishes: build.done
+    name: "⚡ Builder"
+    description: "Implements one sub-task at a time within the Rust workspace"
+    triggers: ["subtask.ready", "review.changes_requested"]
+    publishes: ["subtask.done", "implementation.done"]
+    default_publishes: "subtask.done"
     instructions: |
-      ## BUILDER PHASE
-      Implement the task. Record your thinking as memories for the confession phase:
-      ```bash
-      ralph tools memory add "shortcut: used X instead of Y because..." -t decision
-      ralph tools memory add "uncertainty: not sure if edge case Z is handled" -t context
-      ralph tools memory add "assumption: assuming API returns sorted results" -t context
-      ```
-      ### Process
-      1. Pick one task from `ralph tools task ready`.
-      2. Implement the change.
-      3. Run verification (tests/lints/builds).
-      4. Record what you did as a memory with evidence.
-      5. Close the task: `ralph tools task close <id>`.
-      6. If any command fails or a skill/dependency is missing, record a fix memory and open a task if not resolved.
-      ### Don't
-      - Do not output the completion promise.
-      - Do not skip verification.
-      - Do not close tasks without running tests.
+      Implement the assigned sub-task only.
 
-      ### Event Format
-      ```bash
-      ralph emit "build.done" "tests: pass, lint: pass. Summary of what was done"
-      ```
+      ## Scope
+      CRITICAL: Implement ONLY the single sub-task assigned. Do not work ahead.
+      - One sub-task = one small, focused change
+      - If it's a test sub-task, write the tests
+      - If it's an implementation sub-task, write the code
+      - Follow patterns in AGENTS.md and neighboring files in the target crate
 
-      If stuck:
-      ```bash
-      ralph emit "build.blocked" "what you tried and why it failed"
-      ```
-  confessor:
-    name: Confessor
-    description: Produces a ConfessionReport; rewarded solely for honesty and finding issues.
-    triggers:
-    - build.done
-    publishes:
-    - confession.clean
-    - confession.issues_found
+      ## Verification
+      Before emitting subtask.done, ALL must pass:
+      1. `cargo fmt --all -- --check` — formatting
+      2. `cargo clippy --all-targets --all-features -- -D warnings` — lints
+      3. `cargo test -p <target-crate>` — targeted tests for the crate you changed
+
+      Include actual pass/fail output in scratchpad Notes. Do not claim "pass" without running.
+      If PROMPT.md specifies additional verification, run those too.
+
+      ## On Completion
+      1. Mark sub-task as complete in scratchpad: `- [x] 1.1 ...`
+      2. Add verification evidence to scratchpad Notes section
+      3. Commit with conventional format: `<type>(<scope>): <description>`
+          - Scope = crate name (e.g., `core`, `cli`, `adapters`, `tui`, `telegram`)
+          - Types: feat, fix, refactor, test, docs, chore
+          - Include spec path in body if applicable: `spec: specs/<feature>/`
+      4. Emit subtask.done
+
+      On review.changes_requested → address feedback, emit implementation.done
+
+  reviewer:
+    name: "👀 Reviewer"
+    description: "Reviews implementation quality against AGENTS.md conventions"
+    triggers: ["all_steps.done", "implementation.done"]
+    publishes: ["review.approved", "review.changes_requested"]
+    default_publishes: "review.approved"
     instructions: |
-      ## CONFESSION PHASE
-      You are an internal auditor. Your ONLY job is to find issues.
-      You are NOT rewarded for saying the work is good.
-      You ARE rewarded for surfacing problems, uncertainties, and shortcuts.
-      ### Read First
-      1. Search for builder's internal monologue: `ralph tools memory search "shortcut OR uncertainty OR assumption"`
-      2. The code/changes produced (git diff, recent commits)
-      3. The original task requirements
-      ### Create ConfessionReport Memory
-      ```bash
-      ralph tools memory add "confession: objective=X, met=Yes/Partial/No, evidence=file:line" -t context
-      ralph tools memory add "confession: uncertainty=<assumption or gap>" -t context
-      ralph tools memory add "confession: shortcut=<what was done>, reason=<why>" -t context
-      ralph tools memory add "confession: verify=<easiest check>, confidence=<0-100>" -t context --tags confession
-      ```
-      ### Then Publish Event
-      Confidence threshold: 80.
-      - If you found ANY issues OR confidence < 80 -> publish `confession.issues_found`.
-      - If genuinely nothing (rare) AND confidence >= 80 -> publish `confession.clean`.
+      Review implementation changes for this Rust workspace.
 
-      ### Event Format
-      ```bash
-      ralph emit "confession.issues_found" "confidence: [0-100], summary: [brief summary], verification: [easiest check]"
-      # Or if clean:
-      ralph emit "confession.clean" "confidence: [0-100], summary: [brief summary]"
-      ```
-  confession_handler:
-    name: Confession Handler
-    description: Verifies one claim and decides whether to continue iterating or finish.
-    triggers:
-    - confession.issues_found
-    - confession.clean
-    publishes:
-    - build.task
-    - escalate.human
+      ## Quality Checks
+
+      ### AGENTS.md Compliance
+      Verify the implementation follows conventions in AGENTS.md.
+      FAIL if code violates documented conventions.
+
+      ### Verification Evidence
+      Check scratchpad for fmt/clippy/test evidence from the builder.
+      FAIL if no evidence was recorded.
+
+      ### Rust Idioms & Codebase Consistency
+      - Error handling uses `thiserror`/`anyhow` per existing patterns?
+      - Naming conventions match surrounding code in the same crate?
+      - Public APIs have doc comments?
+      - File organization consistent with the crate's existing structure?
+      - No `unsafe` code (workspace forbids it)?
+      FAIL if code looks foreign to the codebase.
+
+      ### Test Coverage
+      - New functions/components have test coverage?
+      - Tests cover happy path and edge cases?
+      - Smoke tests updated if event loop behavior changed?
+      FAIL if tests are missing or deferred.
+
+      ### Full Suite Gate
+      Run `cargo test --all` to verify nothing is broken across crates.
+      FAIL if any test fails.
+
+      ## Decision
+      Blocking: AGENTS.md violations, missing verification, security issues, broken tests, missing error handling, missing tests, unsafe code.
+      Non-blocking: minor style nitpicks.
+
+      If blocking → emit review.changes_requested with specific file:line references
+      If solid → emit review.approved
+
+  finalizer:
+    name: "📝 Finalizer"
+    description: "Documents changes and completes loop"
+    triggers: ["review.approved"]
+    publishes: ["LOOP_COMPLETE"]
     instructions: |
-      ## HANDLER PHASE
-      Search for confession memories: `ralph tools memory search "confession" --tags confession`
+      Document the implementation and complete.
 
-      If you were triggered by `confession.issues_found`:
-      1. Run the verification command/check from the confession memory to calibrate trust.
-      2. If the issue is real, the confession is trustworthy.
-         - For minor issues: create a fix task and publish `build.task`:
-           ```bash
-           ralph tools task add "Fix: <specific issue>" -p 1
-           ralph emit "build.task" "fix needed: <summary>"
-           ```
-         - For major issues: publish `escalate.human`.
-      3. If the issue is NOT real, the confession is untrustworthy. Publish `escalate.human`.
-      Do not output the completion promise on this path.
+      ## Changelog
+      Create or update specs/<feature>/CHANGELOG.md with:
+      - Date header
+      - Added: new features
+      - Changed: modifications
+      - Crates affected
 
-      If you were triggered by `confession.clean`:
-      1. Be skeptical. Verify at least one positive claim from the builder's work.
-      2. If your verification passes AND the `confidence` from the event is >= 80:
-         - Ensure all tasks are closed: `ralph tools task list` should show no open tasks.
-         - Commit changes with a descriptive message summarizing the work done.
-         - Output the completion promise.
-      3. If your verification fails OR `confidence` < 80:
-         - Create a fix task and publish `build.task`.
-tasks:
-  enabled: true
-memories:
-  enabled: true
-  inject: auto
-  budget: 2000
-  filter:
-    types: []
-    tags: []
-    recent: 0
+      Commit: `docs(changelog): update for <feature>`
+
+      ## AGENTS.md Recommendations
+      Review changes and recommend AGENTS.md updates:
+      - New patterns introduced that future work should follow
+      - Conventions discovered during implementation
+      - Gotchas or non-obvious decisions
+      Add to CHANGELOG.md under "## Suggested AGENTS.md Updates"
+      Do NOT auto-apply.
+
+      Output: LOOP_COMPLETE
+
 skills:
   enabled: true
   dirs:
-  - .claude/skills
+    - .claude/skills
   overrides:
     ralph-operations:
       auto_inject: true
+
 RObot:
   enabled: false
   timeout_seconds: 120


### PR DESCRIPTION
## Summary

Replace deprecated `Duration::from_mins()` and `Duration::from_hours()` with `Duration::from_secs()` across the codebase, and improve the orchestration config presets.

## Changes

### Duration fixes
- Replace `Duration::from_mins()` with `Duration::from_secs()` in all crates
- Replace `Duration::from_hours()` with `Duration::from_secs()` in test assertions
- Affected crates: `ralph-api`, `ralph-core`, `ralph-e2e`, `ralph-tui`

### Config improvements (`ralph.yml`)
- Switch to planner → builder → reviewer → finalizer hat pipeline
- Add backpressure gates (fmt, clippy, test)
- Add crate-scoped guardrails and sub-task granularity
- Scope sub-tasks to individual crates
- Switch default backend to `pi`

### New QA preset (`ralph.qa.yml`)
- Superset of ralph.yml adding a QA gate for event loop and TUI changes
- QA planner diffs origin/main to scope impacting changes
- QA tester executes targets via tmux split panes
- Hard stop after 3 QA rounds
- Auto-skips QA for non-impacting changes (docs, presets)