### PR TITLE
fix: ACP orphaned processes, garbled TUI, and missing tool details

### DIFF
--- a/crates/ralph-adapters/src/acp_executor.rs
+++ b/crates/ralph-adapters/src/acp_executor.rs
@@ -8,15 +8,17 @@
 //! to the caller via an unbounded channel for handler dispatch.
 
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use agent_client_protocol::{
-    Agent, ClientSideConnection, ContentBlock, InitializeRequest, NewSessionRequest, PromptRequest,
-    ProtocolVersion, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    SelectedPermissionOutcome, SessionNotification, SessionUpdate, StopReason, TextContent,
-    ToolCallStatus,
+    Agent, CancelNotification, ClientSideConnection, ContentBlock, InitializeRequest,
+    NewSessionRequest, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    SessionNotification, SessionUpdate, StopReason, TextContent, ToolCallStatus,
 };
 use anyhow::{Context, Result};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{debug, warn};
@@ -80,10 +82,25 @@ impl agent_client_protocol::Client for RalphAcpClient {
                 }
             }
             SessionUpdate::ToolCall(tc) => {
+                // ACP sends two ToolCall notifications per tool:
+                // 1. Initial: no raw_input, no locations (just "tool started")
+                // 2. Update: has raw_input with actual parameters and a descriptive title
+                // Skip the first one to avoid showing bare "[Tool] ls" with no details.
+                if tc.raw_input.is_none() && tc.locations.is_empty() {
+                    return Ok(());
+                }
+
+                let input = tc.raw_input.clone().unwrap_or_else(|| {
+                    if let Some(loc) = tc.locations.first() {
+                        serde_json::json!({"path": loc.path.display().to_string()})
+                    } else {
+                        serde_json::Value::Null
+                    }
+                });
                 let _ = self.tx.send(AcpEvent::ToolCall {
                     name: tc.title.clone(),
                     id: tc.tool_call_id.to_string(),
-                    input: tc.raw_input.unwrap_or(serde_json::Value::Null),
+                    input,
                 });
             }
             SessionUpdate::ToolCallUpdate(update) => {
@@ -136,6 +153,29 @@ impl agent_client_protocol::Client for RalphAcpClient {
     }
 }
 
+/// Drop guard that terminates the ACP child process.
+///
+/// When the `execute` future is cancelled (e.g., by `tokio::select!` on
+/// interrupt), destructors still run. This ensures the child process tree
+/// is cleaned up even if the normal cleanup code is never reached.
+/// Sends SIGTERM first for graceful shutdown, then SIGKILL.
+struct ChildKillGuard(Arc<Mutex<Option<u32>>>);
+
+impl Drop for ChildKillGuard {
+    fn drop(&mut self) {
+        if let Ok(guard) = self.0.lock()
+            && let Some(pid) = *guard
+        {
+            // Kill the entire process group (negative PID) so grandchildren
+            // (e.g. MCP servers) are also terminated — not just the direct child.
+            let pgid = nix::unistd::Pid::from_raw(-(pid as i32));
+            let _ = nix::sys::signal::kill(pgid, nix::sys::signal::Signal::SIGTERM);
+            std::thread::sleep(Duration::from_millis(100));
+            let _ = nix::sys::signal::kill(pgid, nix::sys::signal::Signal::SIGKILL);
+        }
+    }
+}
+
 /// Executor for ACP-based backends (kiro-acp).
 pub struct AcpExecutor {
     backend: CliBackend,
@@ -167,9 +207,15 @@ impl AcpExecutor {
         let workspace_root = self.workspace_root.clone();
         let prompt_owned = prompt.to_string();
 
+        // Shared child PID for cleanup. Wrapped in a drop guard so the child
+        // is killed even when this future is cancelled by tokio::select!.
+        let child_pid = Arc::new(Mutex::new(None::<u32>));
+        let child_pid_inner = Arc::clone(&child_pid);
+        let _kill_guard = ChildKillGuard(Arc::clone(&child_pid));
+
         // Run ACP lifecycle on a blocking thread with its own runtime
         // (ClientSideConnection / Client trait is !Send)
-        tokio::task::spawn_blocking(move || {
+        let join_handle = tokio::task::spawn_blocking(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -177,7 +223,7 @@ impl AcpExecutor {
             let local = tokio::task::LocalSet::new();
             local.block_on(
                 &rt,
-                run_acp_lifecycle(backend, workspace_root, prompt_owned, tx),
+                run_acp_lifecycle(backend, workspace_root, prompt_owned, tx, child_pid_inner),
             );
         });
 
@@ -209,6 +255,17 @@ impl AcpExecutor {
                 }
             }
         }
+
+        // Ensure the entire process tree is killed even if the blocking task is still running.
+        if let Ok(guard) = child_pid.lock()
+            && let Some(pid) = *guard
+        {
+            let pgid = nix::unistd::Pid::from_raw(-(pid as i32));
+            let _ = nix::sys::signal::kill(pgid, nix::sys::signal::Signal::SIGKILL);
+        }
+
+        // Wait for the blocking task to finish so it doesn't leak.
+        let _ = join_handle.await;
 
         let duration_ms = start.elapsed().as_millis() as u64;
         let (success, is_error) = if let Some(reason) = stop_reason {
@@ -259,8 +316,11 @@ async fn run_acp_lifecycle(
     workspace_root: PathBuf,
     prompt: String,
     tx: mpsc::UnboundedSender<AcpEvent>,
+    child_pid: Arc<Mutex<Option<u32>>>,
 ) {
-    if let Err(e) = run_acp_lifecycle_inner(&backend, &workspace_root, &prompt, &tx).await {
+    if let Err(e) =
+        run_acp_lifecycle_inner(&backend, &workspace_root, &prompt, &tx, &child_pid).await
+    {
         let _ = tx.send(AcpEvent::Failed(e.to_string()));
     }
 }
@@ -270,16 +330,28 @@ async fn run_acp_lifecycle_inner(
     workspace_root: &PathBuf,
     prompt: &str,
     tx: &mpsc::UnboundedSender<AcpEvent>,
+    child_pid: &Arc<Mutex<Option<u32>>>,
 ) -> Result<()> {
-    // Spawn child process
-    let mut child = tokio::process::Command::new(&backend.command)
-        .args(&backend.args)
+    // Spawn child process in its own process group so we can kill the
+    // entire tree (including MCP servers) with a single group signal.
+    let mut cmd = tokio::process::Command::new(&backend.command);
+    cmd.args(&backend.args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
-        .kill_on_drop(true)
-        .spawn()
-        .context("Failed to spawn ACP process")?;
+        .kill_on_drop(true);
+
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    let mut child = cmd.spawn().context("Failed to spawn ACP process")?;
+
+    // Record PID so the caller can kill the process if needed.
+    if let Some(pid) = child.id()
+        && let Ok(mut guard) = child_pid.lock()
+    {
+        *guard = Some(pid);
+    }
 
     let child_stdin = child.stdin.take().context("No stdin")?;
     let child_stdout = child.stdout.take().context("No stdout")?;
@@ -318,6 +390,7 @@ async fn run_acp_lifecycle_inner(
     debug!("ACP session created: {}", session.session_id);
 
     // Send prompt
+    let session_id = session.session_id.clone();
     let response = conn
         .prompt(PromptRequest::new(
             session.session_id,
@@ -328,8 +401,16 @@ async fn run_acp_lifecycle_inner(
 
     let _ = tx.send(AcpEvent::Done(response.stop_reason));
 
-    // Kill child
-    let _ = child.kill().await;
+    // Graceful shutdown: cancel the session so kiro-cli can clean up MCP servers
+    let _ = conn.cancel(CancelNotification::new(session_id)).await;
+
+    // Give the process a moment to exit cleanly, then force-kill
+    match tokio::time::timeout(Duration::from_secs(2), child.wait()).await {
+        Ok(_) => {}
+        Err(_) => {
+            let _ = child.kill().await;
+        }
+    }
 
     Ok(())
 }

--- a/crates/ralph-adapters/src/stream_handler.rs
+++ b/crates/ralph-adapters/src/stream_handler.rs
@@ -574,16 +574,24 @@ impl StreamHandler for TuiStreamHandler {
 /// Returns `None` for unknown tools or if the expected field is missing.
 fn format_tool_summary(name: &str, input: &serde_json::Value) -> Option<String> {
     match name {
-        "Read" | "Edit" | "Write" => input.get("file_path")?.as_str().map(|s| s.to_string()),
-        "Bash" => {
+        "Read" | "Edit" | "Write" | "read" | "write" => input
+            .get("file_path")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        "Bash" | "shell" => {
             let cmd = input.get("command")?.as_str()?;
             Some(truncate(cmd, 60))
         }
-        "Grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
-        "Glob" => input.get("pattern")?.as_str().map(|s| s.to_string()),
+        "Grep" | "grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
+        "Glob" | "glob" | "ls" => input
+            .get("pattern")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
         "Task" => input.get("description")?.as_str().map(|s| s.to_string()),
-        "WebFetch" => input.get("url")?.as_str().map(|s| s.to_string()),
-        "WebSearch" => input.get("query")?.as_str().map(|s| s.to_string()),
+        "WebFetch" | "web_fetch" => input.get("url")?.as_str().map(|s| s.to_string()),
+        "WebSearch" | "web_search" => input.get("query")?.as_str().map(|s| s.to_string()),
         "LSP" => {
             let op = input.get("operation")?.as_str()?;
             let file = input.get("filePath")?.as_str()?;
@@ -591,7 +599,18 @@ fn format_tool_summary(name: &str, input: &serde_json::Value) -> Option<String> 
         }
         "NotebookEdit" => input.get("notebook_path")?.as_str().map(|s| s.to_string()),
         "TodoWrite" => Some("updating todo list".to_string()),
-        _ => None,
+        _ => {
+            // Generic fallback: try common keys
+            input
+                .get("path")
+                .or_else(|| input.get("file_path"))
+                .or_else(|| input.get("command"))
+                .or_else(|| input.get("pattern"))
+                .or_else(|| input.get("url"))
+                .or_else(|| input.get("query"))
+                .and_then(|v| v.as_str())
+                .map(|s| truncate(s, 60))
+        }
     }
 }
 
@@ -842,6 +861,42 @@ mod tests {
         assert_eq!(
             format_tool_summary("UnknownTool", &json!({"some_field": "value"})),
             None
+        );
+    }
+
+    #[test]
+    fn test_format_tool_summary_unknown_tool_with_common_key_uses_fallback() {
+        assert_eq!(
+            format_tool_summary("UnknownTool", &json!({"path": "/tmp/foo"})),
+            Some("/tmp/foo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_format_tool_summary_acp_lowercase_tools() {
+        assert_eq!(
+            format_tool_summary("read", &json!({"path": "src/main.rs"})),
+            Some("src/main.rs".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("shell", &json!({"command": "ls -la"})),
+            Some("ls -la".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("ls", &json!({"path": "/tmp"})),
+            Some("/tmp".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("grep", &json!({"pattern": "TODO"})),
+            Some("TODO".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("glob", &json!({"pattern": "**/*.rs"})),
+            Some("**/*.rs".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("write", &json!({"path": "out.txt"})),
+            Some("out.txt".to_string())
         );
     }
 

--- a/crates/ralph-adapters/tests/acp_process_cleanup.rs
+++ b/crates/ralph-adapters/tests/acp_process_cleanup.rs
@@ -1,0 +1,241 @@
+//! Integration tests: verifies ACP child processes are cleaned up between hat transitions.
+//!
+//! Uses a mock script that spawns a child process (simulating an MCP server)
+//! and writes PIDs to a file. After each AcpExecutor::execute() call, we verify
+//! that all spawned processes are dead — no orphans.
+//!
+//! Run with: cargo test -p ralph-adapters --test acp_process_cleanup
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use ralph_adapters::{
+    AcpExecutor, CliBackend, OutputFormat, PromptMode, SessionResult, StreamHandler,
+};
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Minimal handler that just collects text.
+#[derive(Default)]
+struct NullHandler;
+
+impl StreamHandler for NullHandler {
+    fn on_text(&mut self, _: &str) {}
+    fn on_tool_call(&mut self, _: &str, _: &str, _: &serde_json::Value) {}
+    fn on_tool_result(&mut self, _: &str, _: &str) {}
+    fn on_error(&mut self, _: &str) {}
+    fn on_complete(&mut self, _: &SessionResult) {}
+}
+
+fn pid_alive(pid: u32) -> bool {
+    // kill(pid, 0) checks if process exists without sending a signal
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok()
+}
+
+/// Create a mock script that behaves like `kiro-cli acp` but spawns a
+/// long-lived child process (simulating an MCP server) and records PIDs.
+///
+/// The script:
+/// 1. Spawns a `sleep 300` child (simulates MCP server)
+/// 2. Writes both PIDs to a known file
+/// 3. Reads one line from stdin (the ACP initialize request)
+/// 4. Exits immediately (simulating a quick session)
+///
+/// The key question: does the sleep child get cleaned up?
+fn create_mock_acp_script(dir: &Path) -> String {
+    let script_path = dir.join("mock-kiro-acp.sh");
+    let pid_file = dir.join("pids.txt");
+
+    let script = format!(
+        r#"#!/bin/bash
+# Spawn a child that simulates an MCP server (long-lived).
+# Redirect its stdio so it doesn't inherit the test's file descriptors
+# (which would keep cargo test's pipe open and prevent exit).
+sleep 300 </dev/null >/dev/null 2>&1 &
+CHILD_PID=$!
+
+# Record PIDs so the test can check them
+echo "$$:$CHILD_PID" >> {pid_file}
+"#,
+        pid_file = pid_file.display()
+    );
+
+    fs::write(&script_path, &script).unwrap();
+    fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+    script_path.to_string_lossy().to_string()
+}
+
+fn parse_pids(dir: &Path) -> Vec<(u32, u32)> {
+    let pid_file = dir.join("pids.txt");
+    if !pid_file.exists() {
+        return vec![];
+    }
+    fs::read_to_string(&pid_file)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            let parts: Vec<&str> = line.split(':').collect();
+            (
+                parts[0].parse::<u32>().unwrap(),
+                parts[1].parse::<u32>().unwrap(),
+            )
+        })
+        .collect()
+}
+
+/// After AcpExecutor::execute() returns, the direct child process should be dead.
+#[tokio::test]
+async fn acp_kills_child_process_on_completion() {
+    let temp_dir = TempDir::new().unwrap();
+    let script = create_mock_acp_script(temp_dir.path());
+
+    let backend = CliBackend {
+        command: script,
+        args: vec![],
+        prompt_mode: PromptMode::Stdin,
+        prompt_flag: None,
+        output_format: OutputFormat::Acp,
+        env_vars: vec![],
+    };
+
+    let executor = AcpExecutor::new(backend, temp_dir.path().to_path_buf());
+    let mut handler = NullHandler;
+
+    // This will fail at ACP protocol level (mock doesn't speak JSON-RPC),
+    // but the process lifecycle (spawn + cleanup) still executes.
+    let _ = timeout(TEST_TIMEOUT, executor.execute("test prompt", &mut handler))
+        .await
+        .expect("execute() hung — deadlock in mock script?");
+
+    // Give processes a moment to be reaped
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let pids = parse_pids(temp_dir.path());
+    assert!(!pids.is_empty(), "Mock script should have recorded PIDs");
+
+    for (parent_pid, _child_pid) in &pids {
+        assert!(
+            !pid_alive(*parent_pid),
+            "Parent process {} should be dead after execute() returns",
+            parent_pid
+        );
+    }
+}
+
+/// The grandchild process (simulated MCP server) should also be dead after cleanup.
+/// This is the actual orphan leak — the direct child dies but its children survive.
+#[tokio::test]
+async fn acp_kills_grandchild_processes_no_orphans() {
+    let temp_dir = TempDir::new().unwrap();
+    let script = create_mock_acp_script(temp_dir.path());
+
+    let backend = CliBackend {
+        command: script,
+        args: vec![],
+        prompt_mode: PromptMode::Stdin,
+        prompt_flag: None,
+        output_format: OutputFormat::Acp,
+        env_vars: vec![],
+    };
+
+    let executor = AcpExecutor::new(backend, temp_dir.path().to_path_buf());
+    let mut handler = NullHandler;
+
+    let _ = timeout(TEST_TIMEOUT, executor.execute("test prompt", &mut handler))
+        .await
+        .expect("execute() hung — deadlock in mock script?");
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let pids = parse_pids(temp_dir.path());
+    assert!(!pids.is_empty(), "Mock script should have recorded PIDs");
+
+    for (_parent_pid, child_pid) in &pids {
+        assert!(
+            !pid_alive(*child_pid),
+            "Grandchild process {} (simulated MCP server) should be dead — \
+             this is an orphan leak! The ACP executor must kill the entire \
+             process tree, not just the direct child.",
+            child_pid
+        );
+    }
+}
+
+/// Simulate two consecutive hat transitions. After each, all processes from
+/// the previous execution should be fully cleaned up.
+#[tokio::test]
+async fn acp_no_orphans_across_hat_transitions() {
+    let temp_dir = TempDir::new().unwrap();
+    let script = create_mock_acp_script(temp_dir.path());
+
+    let backend = CliBackend {
+        command: script,
+        args: vec![],
+        prompt_mode: PromptMode::Stdin,
+        prompt_flag: None,
+        output_format: OutputFormat::Acp,
+        env_vars: vec![],
+    };
+
+    // Hat 1: "planning" hat
+    let executor1 = AcpExecutor::new(backend.clone(), temp_dir.path().to_path_buf());
+    let mut handler = NullHandler;
+    let _ = timeout(
+        TEST_TIMEOUT,
+        executor1.execute("plan the feature", &mut handler),
+    )
+    .await
+    .expect("execute() hung — deadlock in mock script?");
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let pids_after_hat1 = parse_pids(temp_dir.path());
+    assert_eq!(pids_after_hat1.len(), 1, "Should have 1 execution recorded");
+
+    // Verify hat 1 processes are dead before hat 2 starts
+    let (p1, c1) = pids_after_hat1[0];
+    assert!(!pid_alive(p1), "Hat 1 parent should be dead before hat 2");
+    assert!(
+        !pid_alive(c1),
+        "Hat 1 grandchild (MCP server) should be dead before hat 2 — orphan leak!"
+    );
+
+    // Hat 2: "builder" hat
+    let executor2 = AcpExecutor::new(backend.clone(), temp_dir.path().to_path_buf());
+    let _ = timeout(
+        TEST_TIMEOUT,
+        executor2.execute("build the feature", &mut handler),
+    )
+    .await
+    .expect("execute() hung — deadlock in mock script?");
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let pids_after_hat2 = parse_pids(temp_dir.path());
+    assert_eq!(
+        pids_after_hat2.len(),
+        2,
+        "Should have 2 executions recorded"
+    );
+
+    // ALL processes from both hats should be dead
+    for (i, (parent, child)) in pids_after_hat2.iter().enumerate() {
+        assert!(
+            !pid_alive(*parent),
+            "Hat {} parent process {} still alive",
+            i + 1,
+            parent
+        );
+        assert!(
+            !pid_alive(*child),
+            "Hat {} grandchild process {} still alive — orphan leak!",
+            i + 1,
+            child
+        );
+    }
+}

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -1206,6 +1206,10 @@ pub async fn run_loop_impl(
                     &prompt,
                     verbosity,
                     tui_lines_for_pty,
+                    rpc_stdout_for_pty,
+                    iteration,
+                    display_hat.as_str(),
+                    &backend_name_for_timeout,
                 )
                 .await
             } else if use_pty {
@@ -1520,11 +1524,23 @@ async fn execute_acp(
     prompt: &str,
     verbosity: Verbosity,
     tui_lines: Option<Arc<std::sync::Mutex<Vec<ratatui::text::Line<'static>>>>>,
+    rpc_stdout: Option<Arc<std::sync::Mutex<std::io::Stdout>>>,
+    iteration: u32,
+    hat: &str,
+    backend_name: &str,
 ) -> Result<ExecutionOutcome> {
     let executor = AcpExecutor::new(backend.clone(), config.core.workspace_root.clone());
 
     let pty_result = if let Some(lines) = tui_lines {
         let mut handler = TuiStreamHandler::with_lines(verbosity == Verbosity::Verbose, lines);
+        executor.execute(prompt, &mut handler).await?
+    } else if let Some(stdout_writer) = rpc_stdout {
+        let mut handler = JsonRpcStreamHandler::new(
+            stdout_writer,
+            iteration,
+            Some(hat.to_string()),
+            Some(backend_name.to_string()),
+        );
         executor.execute(prompt, &mut handler).await?
     } else {
         match verbosity {

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -1821,7 +1821,7 @@ async fn run_subprocess_tui(
         .args(&child_args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit()) // Pass stderr through for debugging
+        .stderr(Stdio::null()) // Suppress — stderr corrupts the parent TUI
         .spawn()
         .context("Failed to spawn ralph subprocess for TUI")?;
 

--- a/crates/ralph-tui/src/rpc_source.rs
+++ b/crates/ralph-tui/src/rpc_source.rs
@@ -46,6 +46,9 @@ pub async fn run_rpc_event_reader<R>(
     R: AsyncRead + Unpin,
 {
     let mut lines = BufReader::new(reader).lines();
+    // Accumulates raw text deltas so markdown is rendered from the full
+    // buffer rather than per-chunk (mirrors TuiStreamHandler behaviour).
+    let mut text_accumulator = TextAccumulator::new();
 
     loop {
         tokio::select! {
@@ -70,7 +73,7 @@ pub async fn run_rpc_event_reader<R>(
 
                         match serde_json::from_str::<RpcEvent>(line) {
                             Ok(event) => {
-                                apply_rpc_event(&event, &state);
+                                apply_rpc_event(&event, &state, &mut text_accumulator);
                             }
                             Err(e) => {
                                 debug!(error = %e, line = %line, "Failed to parse RPC event");
@@ -97,8 +100,76 @@ pub async fn run_rpc_event_reader<R>(
     }
 }
 
+/// Accumulates text deltas and non-text blocks in chronological order,
+/// mirroring the `TuiStreamHandler` content-block approach so that
+/// markdown is rendered from the full accumulated text rather than
+/// per-chunk.
+struct TextAccumulator {
+    /// Chronological content blocks for the current iteration.
+    blocks: Vec<ContentBlock>,
+    /// Current unfrozen text buffer.
+    current_text: String,
+}
+
+enum ContentBlock {
+    Text(String),
+    NonText(Line<'static>),
+}
+
+impl TextAccumulator {
+    fn new() -> Self {
+        Self {
+            blocks: Vec::new(),
+            current_text: String::new(),
+        }
+    }
+
+    /// Append a text delta and re-render all lines into the buffer.
+    fn push_text(&mut self, delta: &str, lines_handle: &Arc<Mutex<Vec<Line<'static>>>>) {
+        self.current_text.push_str(delta);
+        self.rebuild_lines(lines_handle);
+    }
+
+    /// Freeze current text, add a non-text line, and re-render.
+    fn push_non_text(
+        &mut self,
+        line: Line<'static>,
+        lines_handle: &Arc<Mutex<Vec<Line<'static>>>>,
+    ) {
+        if !self.current_text.is_empty() {
+            self.blocks
+                .push(ContentBlock::Text(std::mem::take(&mut self.current_text)));
+        }
+        self.blocks.push(ContentBlock::NonText(line));
+        self.rebuild_lines(lines_handle);
+    }
+
+    /// Reset for a new iteration.
+    fn reset(&mut self) {
+        self.blocks.clear();
+        self.current_text.clear();
+    }
+
+    /// Re-render all accumulated content into the shared lines buffer.
+    fn rebuild_lines(&self, lines_handle: &Arc<Mutex<Vec<Line<'static>>>>) {
+        let mut all_lines = Vec::new();
+        for block in &self.blocks {
+            match block {
+                ContentBlock::Text(t) => all_lines.extend(text_to_lines(t)),
+                ContentBlock::NonText(l) => all_lines.push(l.clone()),
+            }
+        }
+        if !self.current_text.is_empty() {
+            all_lines.extend(text_to_lines(&self.current_text));
+        }
+        if let Ok(mut buf) = lines_handle.lock() {
+            *buf = all_lines;
+        }
+    }
+}
+
 /// Applies an RPC event to the TUI state.
-fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
+fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>, acc: &mut TextAccumulator) {
     let Ok(mut s) = state.lock() else {
         return;
     };
@@ -123,6 +194,9 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
         } => {
             s.max_iterations = *max_iterations;
             s.pending_backend = Some(backend.clone());
+
+            // Reset accumulator for the new iteration
+            acc.reset();
 
             // Start a new iteration buffer with metadata
             s.start_new_iteration_with_metadata(Some(hat_display.clone()), Some(backend.clone()));
@@ -153,12 +227,8 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
         }
 
         RpcEvent::TextDelta { delta, .. } => {
-            // Parse markdown text and append to latest iteration buffer
-            let lines = text_to_lines(delta);
-            if let Some(handle) = s.latest_iteration_lines_handle()
-                && let Ok(mut buffer_lines) = handle.lock()
-            {
-                buffer_lines.extend(lines);
+            if let Some(handle) = s.latest_iteration_lines_handle() {
+                acc.push_text(delta, &handle);
             }
 
             s.last_event = Some("text_delta".to_string());
@@ -168,14 +238,17 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
         RpcEvent::ToolCallStart {
             tool_name, input, ..
         } => {
-            // Format tool call header
+            // ACP titles can be descriptive ("Reading /path/to/file") or bare ("read").
+            // If the title already contains context (has a space), use it as-is.
+            // Otherwise try to extract a summary from the input JSON.
             let mut spans = vec![Span::styled(
                 format!("\u{2699} [{}]", tool_name),
                 Style::default().fg(Color::Blue),
             )];
 
-            // Add summary if available
-            if let Some(summary) = format_tool_summary(tool_name, input) {
+            if !tool_name.contains(' ')
+                && let Some(summary) = format_tool_summary(tool_name, input)
+            {
                 spans.push(Span::styled(
                     format!(" {}", summary),
                     Style::default().fg(Color::DarkGray),
@@ -184,10 +257,8 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
 
             let line = Line::from(spans);
 
-            if let Some(handle) = s.latest_iteration_lines_handle()
-                && let Ok(mut buffer_lines) = handle.lock()
-            {
-                buffer_lines.push(line);
+            if let Some(handle) = s.latest_iteration_lines_handle() {
+                acc.push_non_text(line, &handle);
             }
 
             s.last_event = Some("tool_call_start".to_string());
@@ -197,22 +268,27 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
         RpcEvent::ToolCallEnd {
             output, is_error, ..
         } => {
+            let display = format_tool_result(output);
+            if display.is_empty() {
+                s.last_event = Some("tool_call_end".to_string());
+                s.last_event_at = Some(Instant::now());
+                return;
+            }
+
             let (prefix, color) = if *is_error {
                 ("\u{2717} ", Color::Red)
             } else {
                 ("\u{2713} ", Color::DarkGray)
             };
 
-            let truncated = truncate(output, 200);
+            let truncated = truncate(&display, 200);
             let line = Line::from(Span::styled(
                 format!(" {}{}", prefix, truncated),
                 Style::default().fg(color),
             ));
 
-            if let Some(handle) = s.latest_iteration_lines_handle()
-                && let Ok(mut buffer_lines) = handle.lock()
-            {
-                buffer_lines.push(line);
+            if let Some(handle) = s.latest_iteration_lines_handle() {
+                acc.push_non_text(line, &handle);
             }
 
             s.last_event = Some("tool_call_end".to_string());
@@ -303,21 +379,28 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>) {
 
 /// Extracts the most relevant field from tool input for display.
 fn format_tool_summary(name: &str, input: &Value) -> Option<String> {
+    // Try the primary key for the tool name first, then common fallbacks.
+    // ACP tools use lowercase names (read, write, shell, ls, glob, grep)
+    // while Claude uses PascalCase (Read, Write, Bash, Glob, Grep).
     match name {
-        "Read" | "Edit" | "Write" => input
+        "Read" | "Edit" | "Write" | "read" | "write" => input
             .get("path")
             .or_else(|| input.get("file_path"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
-        "Bash" => {
+        "Bash" | "shell" => {
             let cmd = input.get("command")?.as_str()?;
             Some(truncate(cmd, 60))
         }
-        "Grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
-        "Glob" => input.get("pattern")?.as_str().map(|s| s.to_string()),
+        "Grep" | "grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
+        "Glob" | "glob" | "ls" => input
+            .get("pattern")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
         "Task" => input.get("description")?.as_str().map(|s| s.to_string()),
-        "WebFetch" => input.get("url")?.as_str().map(|s| s.to_string()),
-        "WebSearch" => input.get("query")?.as_str().map(|s| s.to_string()),
+        "WebFetch" | "web_fetch" => input.get("url")?.as_str().map(|s| s.to_string()),
+        "WebSearch" | "web_search" => input.get("query")?.as_str().map(|s| s.to_string()),
         "LSP" => {
             let op = input.get("operation")?.as_str()?;
             let file = input.get("filePath")?.as_str()?;
@@ -325,8 +408,89 @@ fn format_tool_summary(name: &str, input: &Value) -> Option<String> {
         }
         "NotebookEdit" => input.get("notebook_path")?.as_str().map(|s| s.to_string()),
         "TodoWrite" => Some("updating todo list".to_string()),
-        _ => None,
+        _ => {
+            // Generic fallback: try common keys
+            input
+                .get("path")
+                .or_else(|| input.get("file_path"))
+                .or_else(|| input.get("command"))
+                .or_else(|| input.get("pattern"))
+                .or_else(|| input.get("url"))
+                .or_else(|| input.get("query"))
+                .and_then(|v| v.as_str())
+                .map(|s| truncate(s, 60))
+        }
     }
+}
+
+/// Extracts human-readable content from ACP tool result JSON envelopes.
+///
+/// ACP tool results arrive as `{"items":[{"Text":"..."} | {"Json":{...}}]}`.
+fn format_tool_result(output: &str) -> String {
+    let Ok(val) = serde_json::from_str::<Value>(output) else {
+        return output.to_string();
+    };
+    let Some(items) = val.get("items").and_then(|v| v.as_array()) else {
+        return output.to_string();
+    };
+    let Some(item) = items.first() else {
+        return String::new();
+    };
+
+    if let Some(text) = item.get("Text").and_then(|v| v.as_str()) {
+        return text.to_string();
+    }
+
+    if let Some(json) = item.get("Json") {
+        // Shell: {exit_status, stdout, stderr}
+        if let Some(stdout) = json.get("stdout").and_then(|v| v.as_str()) {
+            let stderr = json.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
+            let exit = json
+                .get("exit_status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let failed = !exit.contains("status: 0");
+            return if failed && !stderr.is_empty() {
+                stderr.to_string()
+            } else if !stdout.is_empty() {
+                stdout.to_string()
+            } else {
+                stderr.to_string()
+            };
+        }
+        // Glob/ls: {filePaths, totalFiles}
+        if let Some(paths) = json.get("filePaths").and_then(|v| v.as_array()) {
+            let total = json
+                .get("totalFiles")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(paths.len() as u64);
+            let names: Vec<&str> = paths
+                .iter()
+                .filter_map(|p| p.as_str())
+                .map(|p| p.rsplit('/').next().unwrap_or(p))
+                .collect();
+            return format!("{} files: {}", total, names.join(", "));
+        }
+        // Grep: {numFiles, numMatches, results}
+        if let Some(results) = json.get("results").and_then(|v| v.as_array()) {
+            let num_matches = json.get("numMatches").and_then(|v| v.as_u64()).unwrap_or(0);
+            let first_match = results.first().and_then(|r| {
+                let file = r.get("file").and_then(|v| v.as_str()).unwrap_or("");
+                let basename = file.rsplit('/').next().unwrap_or(file);
+                let matches = r.get("matches").and_then(|v| v.as_array())?;
+                let first = matches.first().and_then(|m| m.as_str())?;
+                Some(format!("{}: {}", basename, first.trim()))
+            });
+            return match first_match {
+                Some(m) => format!("{} matches: {}", num_matches, m),
+                None => format!("{} matches", num_matches),
+            };
+        }
+
+        return json.to_string();
+    }
+
+    output.to_string()
 }
 
 #[cfg(test)]
@@ -339,9 +503,14 @@ mod tests {
         Arc::new(Mutex::new(TuiState::new()))
     }
 
+    fn make_acc() -> TextAccumulator {
+        TextAccumulator::new()
+    }
+
     #[test]
     fn test_loop_started_sets_timer() {
         let state = make_state();
+        let mut acc = make_acc();
         {
             let mut s = state.lock().unwrap();
             s.loop_started = None;
@@ -353,7 +522,7 @@ mod tests {
             backend: "claude".to_string(),
             started_at: 0,
         };
-        apply_rpc_event(&event, &state);
+        apply_rpc_event(&event, &state, &mut acc);
 
         let s = state.lock().unwrap();
         assert!(s.loop_started.is_some());
@@ -363,6 +532,7 @@ mod tests {
     #[test]
     fn test_iteration_start_creates_buffer() {
         let state = make_state();
+        let mut acc = make_acc();
 
         let event = RpcEvent::IterationStart {
             iteration: 1,
@@ -372,7 +542,7 @@ mod tests {
             backend: "claude".to_string(),
             started_at: 0,
         };
-        apply_rpc_event(&event, &state);
+        apply_rpc_event(&event, &state, &mut acc);
 
         let s = state.lock().unwrap();
         assert_eq!(s.total_iterations(), 1);
@@ -382,6 +552,7 @@ mod tests {
     #[test]
     fn test_text_delta_appends_content() {
         let state = make_state();
+        let mut acc = make_acc();
 
         // Start an iteration first
         let start_event = RpcEvent::IterationStart {
@@ -392,14 +563,14 @@ mod tests {
             backend: "claude".to_string(),
             started_at: 0,
         };
-        apply_rpc_event(&start_event, &state);
+        apply_rpc_event(&start_event, &state, &mut acc);
 
         // Now add text
         let text_event = RpcEvent::TextDelta {
             iteration: 1,
             delta: "Hello world".to_string(),
         };
-        apply_rpc_event(&text_event, &state);
+        apply_rpc_event(&text_event, &state, &mut acc);
 
         let s = state.lock().unwrap();
         let lines = s.iterations[0].lines.lock().unwrap();
@@ -409,6 +580,7 @@ mod tests {
     #[test]
     fn test_tool_call_start_adds_header() {
         let state = make_state();
+        let mut acc = make_acc();
 
         // Start an iteration first
         let start_event = RpcEvent::IterationStart {
@@ -419,7 +591,7 @@ mod tests {
             backend: "claude".to_string(),
             started_at: 0,
         };
-        apply_rpc_event(&start_event, &state);
+        apply_rpc_event(&start_event, &state, &mut acc);
 
         let tool_event = RpcEvent::ToolCallStart {
             iteration: 1,
@@ -427,7 +599,7 @@ mod tests {
             tool_call_id: "tool_1".to_string(),
             input: json!({"command": "ls -la"}),
         };
-        apply_rpc_event(&tool_event, &state);
+        apply_rpc_event(&tool_event, &state, &mut acc);
 
         let s = state.lock().unwrap();
         let lines = s.iterations[0].lines.lock().unwrap();
@@ -437,6 +609,7 @@ mod tests {
     #[test]
     fn test_loop_terminated_marks_complete() {
         let state = make_state();
+        let mut acc = make_acc();
 
         let event = RpcEvent::LoopTerminated {
             reason: TerminationReason::Completed,
@@ -445,7 +618,7 @@ mod tests {
             total_cost_usd: 0.25,
             terminated_at: 0,
         };
-        apply_rpc_event(&event, &state);
+        apply_rpc_event(&event, &state, &mut acc);
 
         let s = state.lock().unwrap();
         assert!(s.loop_completed);
@@ -455,6 +628,7 @@ mod tests {
     #[test]
     fn test_task_counts_updated() {
         let state = make_state();
+        let mut acc = make_acc();
 
         let event = RpcEvent::TaskCountsUpdated {
             total: 10,
@@ -462,7 +636,7 @@ mod tests {
             closed: 7,
             ready: 2,
         };
-        apply_rpc_event(&event, &state);
+        apply_rpc_event(&event, &state, &mut acc);
 
         let s = state.lock().unwrap();
         assert_eq!(s.task_counts.total, 10);
@@ -488,6 +662,24 @@ mod tests {
             Some("ls".to_string())
         );
         assert_eq!(format_tool_summary("Unknown", &json!({})), None);
+
+        // ACP tool names (lowercase)
+        assert_eq!(
+            format_tool_summary("read", &json!({"path": "/foo/bar.rs"})),
+            Some("/foo/bar.rs".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("shell", &json!({"command": "cargo test"})),
+            Some("cargo test".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("ls", &json!({"path": "/src"})),
+            Some("/src".to_string())
+        );
+        assert_eq!(
+            format_tool_summary("grep", &json!({"pattern": "TODO"})),
+            Some("TODO".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #204

## Summary

Three categories of fixes for the kiro-acp backend:

### Orphaned processes
- Spawn ACP child in its own process group via `process_group(0)`
- Kill entire process group (negative PID) on cleanup instead of just the direct child, preventing grandchild leaks (e.g. MCP servers)
- Add `ChildKillGuard` drop guard for cleanup on future cancellation
- Graceful shutdown: cancel ACP session + SIGTERM before SIGKILL

### Garbled TUI / subprocess output
- Suppress child stderr to prevent TUI corruption
- Wire ACP executor to `JsonRpcStreamHandler` in RPC mode

### Missing tool details in output
- Skip initial empty ACP `ToolCall` notifications (no `raw_input`) so only the informative follow-up with parameters and descriptive title shows
- Add lowercase ACP tool names (`read`, `shell`, `ls`, `glob`, `grep`) to `format_tool_summary` in both console and TUI handlers
- Add generic fallback for unknown tool names using common input keys
- Use ACP locations as fallback when `raw_input` is missing

### Tests
- Add integration tests for orphan cleanup across hat transitions

## Root Causes

1. **Orphans**: All kill signals targeted the individual child PID, not the process group. Grandchildren (MCP servers) never received a signal.
2. **Bare tool names**: ACP sends two `ToolCall` events per tool — an initial empty notification, then a follow-up with actual data. The first produced `[Tool] ls` with no details. Additionally, `format_tool_summary` only matched PascalCase Claude names, not lowercase ACP names.