### PR TITLE
feat: hat imports design spec

### DIFF
--- a/specs/hat-imports/design.md
+++ b/specs/hat-imports/design.md
@@ -1,0 +1,356 @@
+# Design: Hat Imports — Reusable Hat Definitions via Local File Import
+
+## Overview
+
+Hat imports allow preset authors to define a hat once in a standalone YAML file and reference it from any preset, with optional field-level overrides. This eliminates duplication across presets and enables a shared hat ecosystem.
+
+**Phase 1 scope:** Local file imports only. No URL imports, no transitive imports. Simple, predictable, and delivers the core value.
+
+## Detailed Requirements
+
+### Functional Requirements
+
+1. **Import syntax**: A hat definition in a preset can include an `import:` key pointing to a local file path (relative to the importing file, or absolute).
+
+2. **Imported hat file format**: A standalone YAML file containing a single hat definition — the same fields as `HatConfig` (`name`, `description`, `triggers`, `publishes`, `instructions`, `extra_instructions`, `backend`, `backend_args`, `default_publishes`, `max_activations`, `disallowed_tools`).
+
+3. **Override semantics**: Any field specified alongside `import:` in the consuming preset **fully replaces** the corresponding field from the imported file. Fields not specified locally are inherited from the imported file. No deep merging — field-level replacement only.
+
+4. **No `events:` in imported files**: Imported hat files are pure hat definitions. Event metadata belongs in the consuming preset's top-level `events:` section.
+
+5. **No transitive imports**: An imported hat file cannot itself contain an `import:` key. If one is found, it is rejected with a clear error.
+
+6. **All HatConfig fields are overridable**: No restrictions on which fields can be overridden by the consuming preset.
+
+### Source Compatibility
+
+| Config source | Supports `import:`? | Path resolution base |
+|---------------|---------------------|---------------------|
+| `-c ./ralph.yml` (file) | Yes | Directory containing the file |
+| `-H ./hats.yml` (file) | Yes | Directory containing the file |
+| `-H builtin:feature` (embedded) | No — rejected with clear error | N/A |
+| `-H https://...` (remote) | No — Phase 2 | N/A |
+
+### Error Handling
+
+- Errors include both the importing file and imported file (stack-trace style)
+- File not found, invalid YAML, invalid hat schema, and transitive import rejection all produce distinct, actionable error messages
+- No import-specific validation warnings — existing validation handles structural issues post-resolution
+
+### Non-Requirements (Phase 2+)
+
+- URL imports (requires lockfile, caching, domain allowlist, content validation)
+- Transitive imports (requires cycle detection)
+- Import-aware validation warnings
+- Shared hat directory conventions
+
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    A[load_core_value] --> B[core Value]
+    B --> C["resolve_hat_imports() (NEW)"]
+    D[load_hats_value] --> E[hats Value]
+    E --> F["resolve_hat_imports() (NEW)"]
+    C --> G[merge_hats_overlay]
+    F --> G
+    G --> H["serde_yaml::from_value()"]
+    H --> I["normalize() + validate()"]
+    I --> J[RalphConfig]
+
+    style C fill:#2d6,color:#fff
+    style F fill:#2d6,color:#fff
+```
+
+Import resolution happens at the `serde_yaml::Value` level, between YAML parsing and serde deserialization. Each config source resolves its own imports independently before the overlay merge.
+
+## Components and Interfaces
+
+### 1. Import Resolution Function
+
+**Location**: `crates/ralph-cli/src/preflight.rs` (new function)
+
+```rust
+/// Resolves `import:` keys in a hats mapping.
+///
+/// `hats` is the mapping of hat-id → hat-definition (i.e. the contents of
+/// the `hats:` key, not the full config Value). The caller is responsible
+/// for extracting the hats mapping from whatever config shape it loaded
+/// (full config via `-c` or hats overlay via `-H`).
+///
+/// For each hat that contains an `import:` key:
+/// 1. Resolves the path (relative to `base_dir`, or absolute as-is)
+/// 2. Reads and parses the referenced file as YAML
+/// 3. Validates it contains no `import:` key (no transitive imports)
+/// 4. Validates it contains no `events:` key (not allowed in hat files)
+/// 5. Uses the imported fields as a base, overlays local fields on top
+/// 6. Removes the `import:` key from the result
+///
+/// Returns the modified mapping with all imports resolved.
+fn resolve_hat_imports(hats: &mut Mapping, base_dir: &Path, source_label: &str) -> Result<()>
+```
+
+**Parameters**:
+- `hats`: Mutable reference to the hats mapping (hat-id → hat-definition). The caller extracts this from the parsed Value — from the `hats:` key for `-c` configs, or from the root for `-H` overlays.
+- `base_dir`: Directory of the file being loaded (for resolving relative paths)
+- `source_label`: Human-readable label for error messages (e.g., the file path)
+
+### 2. Hat Field Merge Function
+
+**Location**: `crates/ralph-cli/src/preflight.rs` (new function)
+
+```rust
+/// Merges an imported hat definition with local overrides.
+///
+/// The imported hat provides base values. Any field present in `local_overrides`
+/// replaces the corresponding field from `imported`. The `import:` key is
+/// removed from the result.
+fn merge_imported_hat(imported: Mapping, local_overrides: &Mapping) -> Mapping
+```
+
+**Semantics**: For each key in `local_overrides` (except `import:`), insert it into the imported mapping, replacing any existing value. This is field-level replacement, not deep merge.
+
+### 3. Integration into Load Pipeline
+
+**Modified functions in `preflight.rs`**:
+
+- `load_config_for_preflight()`: After loading core value and before merge, extract the `hats:` mapping from the core value and call `resolve_hat_imports()`. After loading hats value and before merge, extract the root mapping (which is already the hats mapping for `-H` overlays) and call `resolve_hat_imports()`. Each caller knows its own Value shape and passes the uniform hats mapping to the resolution function.
+
+- For `HatsSource::Builtin`: Before calling `resolve_hat_imports()`, check if the hats section contains any `import:` keys. If so, reject with error: "Hat imports are not supported in embedded presets. Use a file-based preset instead."
+
+### 4. Imported Hat File Schema
+
+A standalone hat file is a flat YAML mapping with `HatConfig` fields:
+
+```yaml
+# shared-hats/builder.yml
+name: "Builder"
+description: "TDD builder — one task, one commit"
+triggers: ["build.task"]
+publishes: ["build.done", "build.blocked"]
+default_publishes: "build.done"
+max_activations: 5
+instructions: |
+  ## BUILDER MODE
+  You are the Builder. Implement one task at a time using TDD.
+  ...
+```
+
+**Validation rules for imported files**:
+- Must be a YAML mapping (not a sequence or scalar)
+- Must NOT contain an `import:` key (no transitive imports)
+- Must NOT contain an `events:` key (event metadata belongs in consuming preset)
+- No required fields — the `name` requirement applies to the *resolved* hat (after merge), not the imported file itself. This allows importing a "template" hat and supplying `name` in the consuming preset.
+- Unknown fields are silently ignored (consistent with existing `HatConfig` behavior)
+
+## Data Models
+
+No new Rust types are needed. The imported file is parsed into a `serde_yaml::Value`, validated for disallowed keys, and merged with local overrides at the Value level. The result is a standard hat entry in the YAML tree that serde deserializes into `HatConfig` as usual. Error formatting uses local variables — no dedicated struct.
+
+## Error Handling
+
+### Error Cases
+
+| Error | Message Pattern |
+|-------|----------------|
+| Import file not found | `failed to resolve hat import\n  --> {source}, hat '{id}'\n  --> imports {path}\n\n  cause: file not found` |
+| Import file is invalid YAML | `failed to resolve hat import\n  --> {source}, hat '{id}'\n  --> imports {path}\n\n  cause: {yaml_error}` |
+| Transitive import detected | `failed to resolve hat import\n  --> {source}, hat '{id}'\n  --> imports {path}\n\n  cause: imported hat files cannot contain 'import:' directives (transitive imports are not supported)` |
+| Events in imported file | `failed to resolve hat import\n  --> {source}, hat '{id}'\n  --> imports {path}\n\n  cause: imported hat files cannot contain 'events:' — event metadata belongs in the consuming preset` |
+| Import in embedded preset | `hat imports are not supported in embedded presets — '{hat_id}' contains an 'import:' directive.\n\nhint: use a file-based preset to use hat imports` |
+| Import path is not a string | `failed to resolve hat import\n  --> {source}, hat '{id}'\n\n  cause: 'import' must be a string file path` |
+
+### Error Propagation
+
+All import errors are fatal — they cause `load_config_for_preflight()` to return `Err`. No partial resolution: if any import fails, the entire config load fails.
+
+## Acceptance Criteria
+
+### Basic Import Resolution
+
+```
+Given a preset file with a hat that has `import: ./shared/builder.yml`
+And `./shared/builder.yml` exists with valid hat fields
+When the preset is loaded
+Then the hat definition includes all fields from the imported file
+And the `import:` key is not present in the resolved config
+```
+
+### Field-Level Override
+
+```
+Given a preset file with a hat that has `import: ./shared/builder.yml` and `max_activations: 3`
+And the imported file has `max_activations: 5`
+When the preset is loaded
+Then the hat's `max_activations` is 3 (local override wins)
+And all other fields come from the imported file
+```
+
+### Override Replaces, Does Not Merge
+
+```
+Given a preset file with a hat that has `import: ./shared/builder.yml` and `publishes: ["build.done"]`
+And the imported file has `publishes: ["build.done", "build.blocked"]`
+When the preset is loaded
+Then the hat's `publishes` is `["build.done"]` (full replacement, not merge)
+```
+
+### No Transitive Imports
+
+```
+Given a preset with `import: ./shared/builder.yml`
+And `./shared/builder.yml` contains an `import:` key
+When the preset is loaded
+Then loading fails with error: "imported hat files cannot contain 'import:' directives"
+```
+
+### No Events in Imported Files
+
+```
+Given a preset with `import: ./shared/builder.yml`
+And `./shared/builder.yml` contains an `events:` key
+When the preset is loaded
+Then loading fails with error: "imported hat files cannot contain 'events:'"
+```
+
+### Embedded Preset Rejection
+
+```
+Given an embedded preset (loaded via `-H builtin:name`)
+And the preset contains a hat with an `import:` key
+When the preset is loaded
+Then loading fails with error: "hat imports are not supported in embedded presets"
+```
+
+### Import File Not Found
+
+```
+Given a preset with `import: ./nonexistent.yml`
+When the preset is loaded
+Then loading fails with an error identifying both the preset file and the missing import path
+```
+
+### Relative Path Resolution
+
+```
+Given `presets/my-workflow.yml` with `import: ../shared-hats/builder.yml`
+And `shared-hats/builder.yml` exists
+When `presets/my-workflow.yml` is loaded
+Then the import resolves to `shared-hats/builder.yml` (relative to the importing file)
+```
+
+### Absolute Path Import
+
+```
+Given a preset file with a hat that has `import: /absolute/path/to/builder.yml`
+And `/absolute/path/to/builder.yml` exists with valid hat fields
+When the preset is loaded
+Then the import resolves using the absolute path directly (no base_dir join)
+And the hat definition includes all fields from the imported file
+```
+
+### Import Without `name` (Supplied by Override)
+
+```
+Given a preset file with a hat that has `import: ./shared/template.yml` and `name: "My Builder"`
+And the imported file does NOT contain a `name` field
+When the preset is loaded
+Then the resolved hat has `name: "My Builder"` from the local override
+And validation passes (name requirement is on the resolved hat, not the imported file)
+```
+
+### Multiple Hats with Imports
+
+```
+Given a preset with two hats, each importing from different files
+When the preset is loaded
+Then both imports are resolved independently
+And the resolved config contains both hats with their imported fields
+```
+
+### Mixed Inline and Imported Hats
+
+```
+Given a preset with one imported hat and one fully inline hat
+When the preset is loaded
+Then both hats are present in the resolved config
+And the inline hat is unaffected by import resolution
+```
+
+### Split Config with Imports
+
+```
+Given `-c ralph.yml` with hats containing `import:` directives
+And `-H custom-hats.yml` with hats containing `import:` directives
+When the config is loaded
+Then imports in `-c` resolve relative to `ralph.yml`'s directory
+And imports in `-H` resolve relative to `custom-hats.yml`'s directory
+And the `-H` hats replace `-c` hats as usual (after import resolution)
+```
+
+## Testing Strategy
+
+### Unit Tests (in preflight.rs or a new test module)
+
+1. **resolve_hat_imports()** with a Value containing import keys — verify fields are merged
+2. **merge_imported_hat()** — verify field-level replacement semantics
+3. **Override precedence** — local field replaces imported field
+4. **No-op for hats without import** — hats without `import:` pass through unchanged
+5. **Transitive import rejection** — imported file with `import:` key causes error
+6. **Events rejection** — imported file with `events:` key causes error
+7. **File not found** — missing import file produces descriptive error
+8. **Invalid YAML** — broken import file produces error with both file paths
+9. **Import path not a string** — `import: 42` produces clear error
+10. **Multiple imports in one preset** — each resolved independently
+11. **Absolute path import** — `import: /abs/path.yml` resolves without joining `base_dir`
+12. **Imported file without `name`** — no error when consuming preset supplies `name` override
+
+### Integration Tests (in crates/ralph-cli/tests/)
+
+1. **End-to-end import via CLI** — write preset + hat files to TempDir, run `ralph preflight` or `ralph run --dry-run`, verify resolved config
+2. **Embedded preset with import rejected** — `ralph run -H builtin:feature` with import in a modified builtin (or test via the function directly)
+3. **Split config imports** — `-c` and `-H` both with imports, verify independent resolution
+4. **Error messages** — verify error output includes both source file and import path
+
+### Manual Smoke Test
+
+Create `presets/hats/builder.yml` and a preset that imports it. Run `ralph preflight --check config` to verify resolution.
+
+## Appendices
+
+### A. Technology Choices
+
+- **No new dependencies**: Import resolution uses `std::fs::read_to_string` and `serde_yaml` (both already in use)
+- **No new data structures**: Works entirely with `serde_yaml::Value` / `Mapping` types
+- **No changes to HatConfig**: The `import:` key is consumed at the Value level; `HatConfig` deserialization is unchanged
+
+### B. Research Findings
+
+See `research/` directory for detailed findings on:
+- **Config loading pipeline** — insertion point identified at Value level in `preflight.rs`
+- **YAML import patterns** — surveyed 6 tools; field-level replacement is simplest and most predictable
+- **Embedded preset constraints** — no filesystem context; imports must be disallowed
+- **URL import security** — deferred to Phase 2; local imports avoid all supply chain risks
+- **Circular import detection** — unnecessary when transitive imports are disallowed
+- **Serde unknown fields** — `HatConfig` silently ignores unknown fields, confirming Value-level processing is required
+- **Merge overlay mechanics** — import resolution slots cleanly before `merge_hats_overlay()`
+- **Test patterns** — unit tests in `config.rs`, integration tests with TempDir + Command
+
+### C. Alternative Approaches Considered
+
+1. **Add `import` field to HatConfig struct**: Rejected because serde would need custom deserialization, and the field is a loading concern, not a runtime concern. Processing at the Value level keeps HatConfig clean.
+
+2. **Deep merge instead of field replacement**: Rejected for complexity and unpredictability. Every tool surveyed that uses deep merge has edge cases around list handling. Field replacement is simple and explicit.
+
+3. **Allow events in imported files**: Rejected because event metadata is a preset-level concern (how hats relate to each other), not a single-hat concern. Only 1 of 16 presets uses `events:` at all. Keeps imported files simple and side-effect-free.
+
+4. **URL imports in Phase 1**: Rejected due to security complexity. Imported hat files contain AI agent instructions with tool access — the attack surface includes prompt injection. Local imports deliver the core value without supply chain risk.
+
+5. **Transitive imports in Phase 1**: Rejected for simplicity. Disallowing transitive imports eliminates circular import risk entirely. The primary use case (shared hat files referenced from presets) doesn't need multi-level composition.
+
+### D. Phase 2 Roadmap (Future)
+
+When demand warrants:
+- **URL imports** with lockfile (`.ralph/imports.lock`), content-addressable cache, domain allowlist, vendor directory, `--frozen-imports` for CI
+- **Transitive imports** with stack-based cycle detection and depth limit of 5
+- **`events:` in imported files** scoped to the hat's declared `publishes` events

--- a/specs/hat-imports/requirements.md
+++ b/specs/hat-imports/requirements.md
@@ -1,0 +1,104 @@
+# Requirements — Hat Imports
+
+## Questions & Answers
+
+### Q1: Should Phase 1 be limited to local file imports only (no URL imports)?
+
+Research found that URL imports introduce significant security complexity (lockfiles, caching, domain allowlists, content validation) because imported hats contain AI agent instructions with tool access. Local file imports alone deliver the core value — cross-preset hat reuse — with dramatically simpler implementation. URL imports could follow in a separate Phase 2.
+
+**Answer: (a) Phase 1 = local file imports only. URL imports deferred to Phase 2.**
+
+---
+
+### Q2: Should imported hat files be allowed to contain their own `import:` directives (transitive imports)?
+
+Allowing transitive imports enables deeper composition (e.g., a shared builder imports a base TDD hat), but introduces circular import risk and requires stack-based cycle detection. Disallowing transitive imports in Phase 1 makes circular imports impossible and keeps the implementation simple — imported files must be self-contained hat definitions.
+
+**Answer: (a) No transitive imports. Imported files must be self-contained.**
+
+---
+
+### Q3: How should the imported hat file format handle the `events:` section?
+
+The issue proposes that imported hat files can include an `events:` section with metadata (description, on_trigger, on_publish) that gets merged into the consuming preset's top-level `events:`. This is convenient but means a single hat file produces side effects beyond just the hat definition itself.
+
+**Answer: (b) No `events:` in imported hat files. Hat files are pure hat definitions only.**
+
+Rationale:
+- `events:` is a preset-level concern (how hats relate to each other), not a single-hat concern
+- Only 1 of 16 presets uses `events:` today — it's an undocumented, rarely-used feature
+- Importing a hat should not produce side effects on the preset's top-level `events:` section
+- The consuming preset controls its own event documentation — if you import a builder and want event metadata for `build.done`, add it to your preset's `events:` where it's visible and reviewable
+- Easier to add later than to remove — if demand emerges, we can support it in a future iteration
+
+---
+
+### Q4: Where should shared hat files live by convention?
+
+Import paths are relative to the importing file, so any directory works technically. But a convention helps discoverability. The `presets/` directory currently has one subdirectory (`minimal/`). Some options:
+
+**Answer: (c) No convention. Paths are relative to the importing file. Document this clearly and let users organize as they see fit.**
+
+---
+
+### Q5: Should the `import:` key be rejected if it appears in an embedded (builtin) preset?
+
+Embedded presets are compiled into the binary via `include_str!()` — they have no filesystem context, so relative paths can't be resolved. Options:
+
+**Answer: (a) Reject `import:` in embedded presets with a clear error message.**
+
+---
+
+### Q6: What fields should be overridable when importing a hat?
+
+The issue proposes that any HatConfig field can be specified alongside `import:` to override the imported value (field-level replacement, not merge). Should all fields be overridable, or should some be locked?
+
+**Answer: (a) All HatConfig fields are overridable. Maximum flexibility for consumers.**
+
+---
+
+### Q7: Should `import:` resolution happen before or after the `-H` hat overlay merge?
+
+Ralph supports split config: `-c ralph.yml -H builtin:feature`. The hats from `-H` are merged on top of hats from `-c` via `merge_hats_overlay()`. Import resolution could happen:
+
+**Answer: (a) Before overlay merge. Each source resolves its own imports independently.**
+
+Rationale: Relative path resolution requires knowing which file the `import:` came from. After overlay merge, that context is lost. Resolving before merge keeps each file self-contained and avoids coupling merge logic with import logic.
+
+Additionally, imports work in any **file-based** source regardless of flag:
+
+| Source | Allow `import:`? | Reason |
+|--------|-----------------|--------|
+| `-c ./ralph.yml` (file) | Yes | Has filesystem context |
+| `-H ./my-hats.yml` (file) | Yes | Has filesystem context |
+| `-H builtin:feature` (embedded) | No | No filesystem context (Q5) |
+| `-H https://...` (remote) | No | Phase 1 is local only |
+
+---
+
+### Q8: How should errors be reported when an imported file is invalid?
+
+Failure modes: file not found, invalid YAML, valid YAML but not a valid hat definition, transitive import rejected.
+
+**Answer: (a) Errors point to both the importing file and the imported file, like a stack trace.**
+
+Example:
+```
+error: failed to resolve hat import
+  --> my-workflow.yml, hat 'builder'
+  --> imports ./shared/builder.yml
+
+  cause: expected field 'name' to be a string, found sequence
+```
+
+The importing file is the "call site" and should always be visible. Essential for debugging as shared hat files accumulate.
+
+---
+
+### Q9: Should the `validate()` step produce warnings for common import pitfalls?
+
+For example: an imported hat's `publishes` references events that no other hat in the preset triggers on (orphaned events), or the imported hat duplicates a hat ID already defined inline.
+
+**Answer: (b) Rely on existing validation. No import-specific warnings.**
+
+Rationale: By the time validation runs, imports are already resolved into regular HatConfig entries — validation doesn't need to know whether a hat came from an import or was inline. Existing validation already catches ambiguous trigger routing, missing completion promises, etc. Keeps import resolution (loading concern) and validation (structural concern) cleanly separated.

--- a/specs/hat-imports/research/circular-import-detection.md
+++ b/specs/hat-imports/research/circular-import-detection.md
@@ -1,0 +1,97 @@
+# Research: Circular Import Detection
+
+## The Problem
+
+If `a.yml` imports `b.yml` and `b.yml` imports `a.yml`, naive resolution loops forever.
+
+## How Other Tools Handle It
+
+| Tool | Strategy | Limit |
+|------|----------|-------|
+| Docker Compose | Error on detection | Explicit circular check |
+| GitHub Actions | Depth limit | 10 levels max |
+| Azure Pipelines | Multiple limits | 100 files, 100 nesting, 20MB |
+| Ansible | Role deduplication | Roles processed once per play |
+| Helm | DAG resolution | Implicit via dependency graph |
+
+## Recommended Approach for Ralph
+
+### Strategy: Import Stack with Depth Limit
+
+Maintain a stack of file paths during resolution. Before processing each import:
+
+1. **Canonicalize the path** (resolve symlinks, normalize `../`)
+2. **Check if path is already on the stack** → if yes, error with full cycle trace
+3. **Check depth** → if > 5 levels, error (even without cycles)
+4. **Push path onto stack, resolve imports, pop**
+
+```rust
+fn resolve_imports(
+    value: serde_yaml::Value,
+    base_dir: &Path,
+    import_stack: &mut Vec<PathBuf>,  // tracks the chain
+) -> Result<serde_yaml::Value> {
+    for (hat_id, hat_value) in hats_mapping {
+        if let Some(import_path) = hat_value.get("import") {
+            let canonical = base_dir.join(import_path).canonicalize()?;
+
+            // Circular check
+            if import_stack.contains(&canonical) {
+                let cycle = import_stack.iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(" -> ");
+                bail!("Circular import detected: {} -> {}", cycle, canonical.display());
+            }
+
+            // Depth check
+            if import_stack.len() >= 5 {
+                bail!("Import depth limit exceeded (max 5). Chain: ...");
+            }
+
+            import_stack.push(canonical.clone());
+            let imported = load_and_resolve(canonical, import_stack)?;
+            import_stack.pop();
+
+            // Merge imported fields with local overrides
+            merge_hat(hat_value, imported);
+        }
+    }
+}
+```
+
+### Why Depth 5 Is Sufficient
+
+Hat imports are for reuse, not for building deep abstraction hierarchies. A realistic maximum chain:
+- `my-workflow.yml` → imports `shared-hats/builder.yml` (depth 1)
+- `shared-hats/builder.yml` → imports `base-hats/tdd-base.yml` (depth 2)
+
+Anything deeper than 3-4 levels suggests over-engineering. A limit of 5 provides headroom while catching runaway chains.
+
+### Error Messages
+
+Good error messages are critical:
+
+```
+error: circular hat import detected
+  my-workflow.yml
+    -> shared-hats/builder.yml
+    -> base-hats/common.yml
+    -> shared-hats/builder.yml  <-- cycle
+```
+
+```
+error: hat import depth limit exceeded (max 5)
+  a.yml -> b.yml -> c.yml -> d.yml -> e.yml -> f.yml
+  hint: consider flattening your import hierarchy
+```
+
+## Phase 1 Simplification
+
+If we restrict Phase 1 to single-level imports only (imported files cannot themselves contain `import:`), then:
+- No circular imports are possible
+- No depth tracking needed
+- Dramatically simpler implementation
+- Still solves the core use case (shared hat definitions)
+
+**Recommendation: Phase 1 = no transitive imports. Phase 2 = transitive imports with stack-based cycle detection.**

--- a/specs/hat-imports/research/config-loading-pipeline.md
+++ b/specs/hat-imports/research/config-loading-pipeline.md
@@ -1,0 +1,75 @@
+# Research: Config Loading Pipeline
+
+## The 5-Stage Pipeline
+
+```
+CLI arg (String)
+    |
+ConfigSource::File(PathBuf) / HatsSource::Builtin(String) / HatsSource::Remote(String)
+    |
+File content (String)
+    |
+serde_yaml::Value          <-- BEST INSERTION POINT FOR IMPORTS
+    |
+RalphConfig with HashMap<String, HatConfig>
+    |
+HatRegistry with BTreeMap<HatId, Hat>
+```
+
+## Key Files
+
+| Component | File | Function | Lines |
+|-----------|------|----------|-------|
+| Load config | `preflight.rs` | `load_config_for_preflight()` | 196-230 |
+| Load core YAML | `preflight.rs` | `load_core_value()` | 256-329 |
+| Load hats YAML | `preflight.rs` | `load_hats_value()` | 332-379 |
+| Parse YAML text | `preflight.rs` | `parse_yaml_value()` | 381-382 |
+| **Merge hats** | `preflight.rs` | `merge_hats_overlay()` | 498-531 |
+| Deserialize | `preflight.rs` | (inline in load_config) | 220-221 |
+| Normalize | `config.rs` | `RalphConfig::normalize()` | 272-355 |
+| Validate | `config.rs` | `RalphConfig::validate()` | 366-494 |
+| Create registry | `hat_registry.rs` | `HatRegistry::from_config()` | 24-46 |
+
+## Split Config Architecture
+
+Two separate flags:
+- **`-c/--config`**: Core config (backend, workspace, guardrails). Can be file, URL, or override.
+- **`-H/--hats`**: Hat collection (hat definitions, events, event_loop overrides). Can be `builtin:name`, file, or URL.
+
+## Three Import Resolution Windows
+
+### Window 1: Raw YAML Text (before parse)
+- Location: After `read_to_string()`, before `parse_yaml_value()`
+- Type: `String`
+- Pros: Full text control
+- Cons: YAML structure not yet validated
+
+### Window 2: serde_yaml::Value (RECOMMENDED)
+- Location: After YAML parse, before serde deserialization
+- Type: `serde_yaml::Value` / `serde_yaml::Mapping`
+- Pros: YAML validated; same types as `merge_hats_overlay()`; clean injection point
+- Cons: Need to walk the Value tree
+
+### Window 3: Post-Deserialization
+- Location: After `serde_yaml::from_value()`
+- Type: `RalphConfig` / `HatConfig`
+- Cons: Would need custom Deserialize impl or post-processing; serde already validated
+
+## Recommended Approach
+
+Insert import resolution in `preflight.rs` between `load_hats_value()` and `merge_hats_overlay()`:
+
+```rust
+let hats_value = load_hats_value(source).await?;
+let resolved_value = resolve_imports(hats_value, source_dir)?;  // NEW
+let merged = merge_hats_overlay(core_value, resolved_value)?;
+```
+
+This works with validated YAML structure, integrates with existing overlay merging, and keeps imports processed before deserialization.
+
+## Current State: No Cross-Preset References
+
+- No YAML anchors/aliases across files
+- No `import`, `include`, `extends` keywords in any preset
+- Each preset is fully self-contained
+- YAML anchors are used WITHIN single files (e.g., shared instruction fragments)

--- a/specs/hat-imports/research/embedded-preset-interaction.md
+++ b/specs/hat-imports/research/embedded-preset-interaction.md
@@ -1,0 +1,68 @@
+# Research: Embedded Presets & Import Interactions
+
+## Current Architecture
+
+### Two Directories, Kept in Sync
+| Directory | Purpose |
+|-----------|---------|
+| `presets/` (repo root) | Canonical source, human-editable |
+| `crates/ralph-cli/presets/` | Mirror for `include_str!()` embedding |
+
+Sync via `scripts/sync-embedded-files.sh` before publishing.
+
+### 16 Embedded Presets
+bugfix, code-assist, debug, deploy, docs, feature, fresh-eyes, gap-analysis, hatless-baseline, merge-loop, pdd-to-code-assist, pr-review, refactor, research, review, spec-driven
+
+### 11 Minimal Presets (NOT embedded)
+In `presets/minimal/`: claude, kiro, codex, gemini, amp, builder, code-assist, opencode, smoke, test, preset-evaluator
+
+## Config Source Resolution
+
+```rust
+pub enum ConfigSource {
+    File(PathBuf),           // Local file path
+    Builtin(String),         // Legacy "builtin:name" → REJECTED
+    Remote(String),          // HTTP/HTTPS URL
+    Override { key, value }  // core.field=value
+}
+
+pub enum HatsSource {
+    File(PathBuf),           // Local file path
+    Builtin(String),         // builtin:feature → embedded preset
+    Remote(String),          // HTTP/HTTPS URL
+}
+```
+
+## Key Constraint: Embedded Presets Can't Import Files
+
+An embedded preset compiled into the binary has no filesystem context. If `builtin:feature` contained `import: ./shared-hats/builder.yml`, there's no directory to resolve the relative path against.
+
+**Options:**
+1. **Disallow imports in embedded presets** — simplest, most predictable
+2. **Resolve relative to CWD** — surprising behavior
+3. **Resolve relative to a well-known directory** (e.g., `~/.ralph/hats/`) — adds a new concept
+
+**Recommendation:** Disallow `import:` in embedded presets. Embedded presets are curated, self-contained definitions. If users need imports, they use file-based presets.
+
+## Impact on Import Design
+
+| Source | Can contain `import:`? | Path resolution base |
+|--------|----------------------|---------------------|
+| File-based preset | Yes | Directory containing the preset file |
+| Builtin (embedded) | No | N/A — reject with clear error |
+| Remote URL preset | No (security) | N/A — reject transitive imports |
+| Hat file (via -H) | Yes | Directory containing the hat file |
+
+## Recommended Pattern
+
+```bash
+# Self-contained embedded preset (no imports)
+ralph run -H builtin:feature -p "Add OAuth"
+
+# File-based preset with imports
+ralph run -H ./my-workflow.yml -p "Add OAuth"
+# my-workflow.yml can contain: import: ./shared-hats/builder.yml
+
+# Hat file with imports
+ralph run -c ralph.yml -H ./hats/custom.yml -p "Add OAuth"
+```

--- a/specs/hat-imports/research/merge-overlay-mechanics.md
+++ b/specs/hat-imports/research/merge-overlay-mechanics.md
@@ -1,0 +1,42 @@
+# Research: merge_hats_overlay() Mechanics
+
+## Function Behavior
+
+`merge_hats_overlay(core: Value, hats: Value) -> Result<Value>` in `preflight.rs:498-540`
+
+Three keys are handled with **different merge strategies**:
+
+| Key | Strategy | Behavior |
+|-----|----------|----------|
+| `hats` | **Complete replacement** | `-H` hats entirely replace `-c` hats |
+| `events` | **Complete replacement** | `-H` events entirely replace `-c` events |
+| `event_loop` | **Field-level deep merge** | Individual fields from `-H` override `-c`; non-conflicting fields preserved |
+
+## Important: Hats Are NOT Additively Merged
+
+If `-c` defines `builder` and `-H` defines `reviewer`, the result only has `reviewer`. The hats overlay is a complete specification of which hats to use.
+
+## Helper Functions
+
+- `mapping_get(mapping, key)` — safe YAML mapping lookup
+- `mapping_insert(mapping, key, value)` — safe YAML mapping insert
+- `normalize_hats_source_value()` — validates only allowed top-level keys exist
+- `extract_hat_overlay_from_preset()` — extracts hat keys from a full preset
+
+## Import Resolution Integration Point
+
+Import resolution slots in **before** `merge_hats_overlay()`:
+
+```
+load_core_value()     → core Value (may have hats with import: keys)
+load_hats_value()     → hats Value (may have hats with import: keys)
+                          ↓
+resolve_imports(core)  ← NEW: resolve import: keys in core's hats
+resolve_imports(hats)  ← NEW: resolve import: keys in hats' hats
+                          ↓
+merge_hats_overlay()   → merged Value (all imports already resolved)
+                          ↓
+serde_yaml::from_value() → RalphConfig
+```
+
+Each source resolves its own imports relative to its own file path before merging.

--- a/specs/hat-imports/research/security-url-imports.md
+++ b/specs/hat-imports/research/security-url-imports.md
@@ -1,0 +1,104 @@
+# Research: Security Considerations for URL Imports
+
+## Critical Insight
+
+This is NOT a typical dependency management problem. Importing a hat = importing natural-language instructions that an AI agent follows with tool access (filesystem, git, shell). The attack surface includes prompt injection, not just code injection. OWASP ranks prompt injection as the #1 critical vulnerability for LLM applications.
+
+## 1. Trust Model
+
+**Recommendation: URL imports are Phase 2. Start with local file imports only.**
+
+If/when URL imports are added:
+- Default deny: `allow_remote_imports: true` must be explicit in config
+- Mandatory domain allowlist
+- HTTPS only — reject `http://` unconditionally
+- No transitive imports: fetched files cannot themselves contain `import:`
+
+Precedents: Deno `--allow-net`, Go module proxy, GitHub Actions SHA pinning
+
+## 2. Caching
+
+**Recommendation: Content-addressable local cache.**
+
+```
+~/.ralph/cache/hats/
+  sha256-a1b2c3d4.yml          # content-addressable
+  url-index.json               # URL → { sha256, fetched_at, etag }
+```
+
+- Cache-first by default, re-fetch only with `ralph run --refresh-imports`
+- Individual files capped at 256 KB
+- Total cache capped at 100 MB with LRU eviction
+
+Precedents: npm content-addressable cache, Cargo registry cache, Deno deps cache
+
+## 3. Network Failure Handling
+
+| State | Lockfile exists | Lockfile absent |
+|-------|----------------|-----------------|
+| Network available | Fetch, verify hash matches lockfile | Fetch, create lockfile entry |
+| Network unavailable | Use cache (hash must match) | **Hard error** |
+| Cache miss + no network | **Hard error** | **Hard error** |
+
+No silent degradation. Clear error messages with remediation steps.
+
+## 4. TOCTOU / Integrity
+
+**Recommendation: Mandatory lockfile with SHA-256 hashes.**
+
+```yaml
+# .ralph/imports.lock
+version: 1
+imports:
+  "https://hats.ralph.dev/reviewer/v2.yml":
+    sha256: "a1b2c3d4e5f6..."
+    fetched_at: "2026-02-28T10:30:00Z"
+```
+
+- Trust-on-first-use (TOFU) model
+- Lockfile committed to version control
+- `--frozen-imports` flag for CI (fail if any import needs fetching)
+- `ralph imports update` for explicit refresh with diff display
+
+Precedents: Go go.sum, Deno deno.lock, npm lockfiles, SRI hashes
+
+## 5. Content Validation
+
+Validation pipeline (applied before any import is accepted):
+1. **Size check** — reject > 256 KB
+2. **YAML parse** — reject invalid YAML
+3. **Schema validate** — deserialize into HatConfig; reject unknown fields
+4. **Depth check** — reject nesting > 10 (prevents billion-laughs)
+5. **Field limits** — instructions: max 50K chars, triggers: max 50 entries
+6. **No anchors from remote** — reject YAML anchors/aliases (entity expansion)
+7. **No YAML tags** — reject `!!` tags
+
+## 6. Supply Chain Attack Scenarios
+
+| Attack | Mitigation |
+|--------|-----------|
+| Prompt override in instructions | Human review, vendor directory |
+| Subtle bias injection | `ralph imports audit` shows full content |
+| Time-delayed attack (serve benign then swap) | Hash-pinned lockfile |
+| Domain takeover | Domain monitoring, vendor-first approach |
+| Typosquatting URLs | Domain allowlist |
+
+## 7. Strongest Recommendation: Vendor-First Approach
+
+```bash
+ralph imports vendor  # downloads all imported hats to .ralph/vendor/hats/
+```
+
+- Actual content visible in repo, reviewed in PRs
+- No network access needed at runtime
+- Git history shows exactly when definitions changed
+- AI agent instructions never sourced from URL at runtime
+
+**URL imports as bootstrap convenience; production use should vendor into the repo.**
+
+## Phase Recommendation
+
+- **Phase 1 (this spec):** Local file imports only. No URL support. No caching/lockfile complexity.
+- **Phase 2 (future):** URL imports with full security infrastructure (lockfile, cache, vendor, allowlist).
+
+This significantly reduces scope while delivering the core value: cross-preset hat reuse.

--- a/specs/hat-imports/research/serde-unknown-fields.md
+++ b/specs/hat-imports/research/serde-unknown-fields.md
@@ -1,0 +1,34 @@
+# Research: HatConfig Serde Behavior with Unknown Fields
+
+## Critical Finding
+
+Neither `HatConfig` nor `RalphConfig` uses `#[serde(deny_unknown_fields)]`. Unknown fields are **silently ignored** during deserialization.
+
+## Implications for Import Resolution
+
+1. **We MUST process `import:` at the serde_yaml::Value level** — serde will silently drop the `import:` key during deserialization, so it won't be available after conversion to `HatConfig`.
+
+2. **Processing after deserialization won't work** — `HatConfig` has no `import` field, and adding one would be a leaky abstraction.
+
+3. **No custom Deserialize impls exist** — code relies on `#[derive(Deserialize)]`, giving us full control over the Value-level transformation.
+
+4. **The existing `test_unknown_fields_ignored()` test confirms this behavior** — forward compatibility is intentional.
+
+## Recommended Approach
+
+Process imports at the `serde_yaml::Value` stage:
+
+```rust
+fn resolve_hat_imports(hats_mapping: &mut Mapping, base_dir: &Path) -> Result<()> {
+    for (hat_id, hat_value) in hats_mapping.iter_mut() {
+        if let Some(import_path) = hat_value.get("import") {
+            // 1. Load imported file
+            // 2. Merge imported fields (imported = base, local = override)
+            // 3. Remove the "import" key
+        }
+    }
+    Ok(())
+}
+```
+
+The `import:` key is consumed during resolution and never reaches `HatConfig` deserialization.

--- a/specs/hat-imports/research/test-patterns.md
+++ b/specs/hat-imports/research/test-patterns.md
@@ -1,0 +1,71 @@
+# Research: Existing Test Patterns for Config Loading
+
+## Test Locations
+
+| Type | Location | Count | Purpose |
+|------|----------|-------|---------|
+| Unit (parse) | `config.rs` inline tests | 40+ | YAML parsing, validation, normalization |
+| Integration (CLI) | `crates/ralph-cli/tests/` | 10+ | CLI flag precedence, file loading |
+| Smoke (replay) | `crates/ralph-core/tests/fixtures/` | 6+ | JSONL fixture-based scenario replay |
+
+## Unit Test Pattern (config.rs)
+
+```rust
+#[test]
+fn test_something() {
+    let yaml = r#"
+hats:
+  builder:
+    name: "Builder"
+    triggers: ["build.task"]
+    publishes: ["build.done"]
+    instructions: "Build things"
+"#;
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.hats.len(), 1);
+}
+```
+
+## Integration Test Pattern (CLI tests)
+
+```rust
+fn run_ralph(temp_path: &Path, args: &[&str]) -> Command::Output {
+    Command::new(env!("CARGO_BIN_EXE_ralph"))
+        .args(args)
+        .current_dir(temp_path)
+        .output()
+        .expect("execute ralph")
+}
+
+#[test]
+fn test_something() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    fs::write(temp_dir.path().join("ralph.yml"), yaml_content).unwrap();
+    let output = run_ralph(temp_dir.path(), &["run", "--dry-run", ...]);
+    assert!(output.status.success());
+}
+```
+
+## Test Strategy for Hat Imports
+
+**Unit tests** (in config.rs or a new test module):
+- Parse YAML with `import:` keys at Value level
+- Verify import resolution produces correct merged Value
+- Test override semantics (local field replaces imported field)
+- Test error cases (file not found, invalid YAML, transitive import rejected)
+
+**Integration tests** (in crates/ralph-cli/tests/):
+- Write preset + shared hat files to TempDir
+- Run `ralph run --dry-run -c preset.yml` or `ralph preflight`
+- Verify resolved config has correct hat definitions
+- Test error messages for bad imports
+
+## Remote URL Handling (for context)
+
+Currently uses bare `reqwest::get(url)` with:
+- No custom client config (no timeouts, no retries)
+- HTTP status check (must be 2xx)
+- No caching
+- Fail-fast on any error
+
+This is relevant for Phase 2 URL imports but not Phase 1.

--- a/specs/hat-imports/research/yaml-import-patterns.md
+++ b/specs/hat-imports/research/yaml-import-patterns.md
@@ -1,0 +1,43 @@
+# Research: YAML Import Patterns Across Tools
+
+## Comparison Matrix
+
+| Dimension | Docker Compose | GitHub Actions | Helm | Azure Pipelines | Ansible | ESLint |
+|---|---|---|---|---|---|---|
+| **Mechanism** | `extends`, `include`, `-f` merge | `uses` (atomic call) | Dependencies + values overlay | `template:` (include/extends) | `import_*/include_*` | `extends` array |
+| **Merge granularity** | Field-level (maps merge, lists append, scalars replace) | None (parameterize only) | Field-level (maps merge, lists replace) | None (parameter slots only) | Full replace default | Property-specific |
+| **Override direction** | Extending overrides base | Caller cannot override callee | Parent overrides subchart | Template controls; caller fills params | Higher precedence replaces | Later overrides earlier |
+| **Remote refs** | OCI registries | GitHub repo refs only | Helm repos, OCI, `file://` | Cross-repo via resources | No (use ansible-galaxy) | No |
+| **Circular prevention** | Error on detection | 10-level depth limit | Implicit DAG | 100 files, 100 levels, 20MB cap | Role dedup | JS runtime |
+| **Path resolution** | Relative to file | Repo root | URL/OCI/file:// | Relative to file or repo root | roles/ dir | JS modules |
+
+## Key Trade-offs
+
+### Parameterized Call (GitHub Actions, Azure Pipelines)
+Callee defines slots, caller fills them. No merging, no surprises, but no flexibility to tweak internals. Best for security-sensitive contexts.
+
+### Field-Level Merge (Docker Compose, Helm, Ansible)
+More flexible but more complex. Need to understand which fields merge vs. replace.
+
+### Array-of-Configs Composition (ESLint)
+Flat, explicit, no file-level indirection. Property-specific merge behavior.
+
+## Critical Insight: List/Array Handling
+
+No consensus across tools:
+- Docker Compose: **appends** lists
+- Helm: **replaces** lists entirely
+- Ansible: **replaces** lists
+- ESLint: **replaces** lists
+
+**Recommendation for Ralph: Field-level REPLACEMENT (not merge).** This matches the issue proposal and is the simplest, most predictable semantic. If you specify `publishes:` alongside `import:`, it fully replaces the imported `publishes` list.
+
+## Most Relevant Pattern: Docker Compose `extends`
+
+The closest analogue to Ralph hat imports:
+- Single-entity import (one service) with field-level override
+- Relative path resolution from the importing file
+- Base fields inherited unless overridden
+- Clear override semantics (scalars replace, maps merge, lists append)
+
+Ralph's proposed approach is simpler: **all fields replace** (no deep merge). This is the safest choice.

--- a/specs/hat-imports/rough-idea.md
+++ b/specs/hat-imports/rough-idea.md
@@ -1,0 +1,70 @@
+# Hat Imports — Reusable Hat Definitions via Local/URL Import
+
+Source: https://github.com/mikeyobrien/ralph-orchestrator/issues/209
+
+## Use Case
+
+As preset/hat-collection authors grow their configurations, they end up duplicating entire hat definitions across presets. A "Builder" hat, for example, might appear verbatim in three different workflow presets. When instructions or triggers change, every copy must be updated manually — this is error-prone and scales poorly.
+
+Hat imports would let authors define a hat once in a standalone file and reference it from any preset, with optional field-level overrides.
+
+## Proposed Solution
+
+### Syntax
+
+```yaml
+# In a preset or hat collection file:
+hats:
+  builder:
+    import: ./shared-hats/builder.yml       # local file (relative to this config)
+    publishes: ["build.done", "security.scan"]  # overrides imported publishes
+    max_activations: 3                          # overrides imported value
+    # all other fields come from the imported file
+
+  reviewer:
+    import: https://example.com/hats/reviewer.yml  # URL import
+    # no overrides — use as-is
+```
+
+### Imported hat file format (single hat per file)
+
+```yaml
+# shared-hats/builder.yml
+name: "Builder"
+description: "TDD builder — one task, one commit"
+triggers: ["build.task"]
+publishes: ["build.done", "build.blocked"]
+default_publishes: "build.done"
+instructions: |
+  ## BUILDER MODE
+  ...
+
+# Optional: event metadata that gets merged into consuming preset
+events:
+  build.done:
+    description: "Building completed successfully"
+  build.blocked:
+    description: "Building encountered a blocker"
+```
+
+### Override semantics
+
+- **Field-level replacement** (not merge): if you specify `publishes:` alongside `import:`, it fully replaces the imported `publishes` list
+- Fields not specified locally are inherited from the imported file
+- The `import:` key itself is consumed during resolution and never reaches `HatConfig` deserialization
+
+### Event metadata
+
+- Imported hat files can include an `events:` section
+- Imported events are merged into the preset's top-level `events:`
+- Preset's own `events:` entries take priority over imported ones (override semantics)
+
+## Alternatives Considered
+
+- **YAML anchors / aliases**: only work within a single file, so they don't solve cross-preset reuse.
+- **Copy-paste with conventions**: current approach; doesn't scale.
+- **Preprocessing with external tools** (e.g., ytt, jsonnet): adds toolchain complexity and breaks the "just edit YAML" simplicity.
+
+## Additional Context
+
+This is a foundational building block for a hat ecosystem — community-shared hats, curated hat libraries, and organisation-internal hat registries all depend on a clean import mechanism.


### PR DESCRIPTION
## Summary

- Adds the hat imports design spec to `specs/hat-imports/`, including requirements, design doc, and research findings
- Hat imports allow preset authors to define a hat once in a standalone YAML file and reference it from any preset with optional field-level overrides
- Phase 1 scope: local file imports only, no transitive imports, no deep merge

## Key design decisions

- Import resolution at `serde_yaml::Value` level (no changes to `HatConfig`)
- Caller-extracts-hats pattern — `resolve_hat_imports()` takes a uniform `&mut Mapping`
- Absolute import paths allowed
- `name` requirement applies post-resolution (imported files can omit it if the override supplies it)
- Field-level replacement, not deep merge

## Test plan

- [ ] Review design doc (`specs/hat-imports/design.md`)
- [ ] Review requirements (`specs/hat-imports/requirements.md`)
- [ ] Review research findings (`specs/hat-imports/research/`)
