### PR TITLE
refactor: simplify round 1 — fix flaky tests, remove redundant clones, deduplicate now_ts

### DIFF
--- a/crates/ralph-adapters/tests/acp_process_cleanup.rs
+++ b/crates/ralph-adapters/tests/acp_process_cleanup.rs
@@ -50,7 +50,7 @@ fn create_mock_acp_script(dir: &Path) -> String {
     let pid_file = dir.join("pids.txt");
 
     let script = format!(
-        r#"#!/bin/bash
+        r#"#!/usr/bin/env bash
 # Spawn a child that simulates an MCP server (long-lived).
 # Redirect its stdio so it doesn't inherit the test's file descriptors
 # (which would keep cargo test's pipe open and prevent exit).

--- a/crates/ralph-api/src/collection_domain.rs
+++ b/crates/ralph-api/src/collection_domain.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use tracing::warn;
 
 use crate::errors::ApiError;
+use crate::loop_support::now_ts;
 
 use self::yaml::{export_collection_yaml, graph_from_yaml};
 
@@ -345,5 +346,3 @@ fn collection_not_found_error(collection_id: &str) -> ApiError {
     ApiError::collection_not_found(format!("Collection with id '{collection_id}' not found"))
         .with_details(serde_json::json!({ "collectionId": collection_id }))
 }
-
-use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/collection_domain.rs
+++ b/crates/ralph-api/src/collection_domain.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use chrono::{SecondsFormat, Utc};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::warn;
@@ -346,6 +346,4 @@ fn collection_not_found_error(collection_id: &str) -> ApiError {
         .with_details(serde_json::json!({ "collectionId": collection_id }))
 }
 
-pub(super) fn now_ts() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
-}
+use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/loop_domain.rs
+++ b/crates/ralph-api/src/loop_domain.rs
@@ -437,7 +437,6 @@ impl LoopDomain {
                 "Merge: {}",
                 loop_info
                     .prompt
-                    .clone()
                     .unwrap_or_else(|| params.loop_id.clone())
                     .chars()
                     .take(50)

--- a/crates/ralph-api/src/loop_support.rs
+++ b/crates/ralph-api/src/loop_support.rs
@@ -59,6 +59,6 @@ pub fn is_pid_alive(pid: u32) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-pub fn now_ts() -> String {
+pub(crate) fn now_ts() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
 }

--- a/crates/ralph-api/src/planning_domain.rs
+++ b/crates/ralph-api/src/planning_domain.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::errors::ApiError;
+use crate::loop_support::now_ts;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -588,5 +589,3 @@ fn generate_title(prompt: &str) -> String {
     shortened.push_str("...");
     shortened
 }
-
-use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/planning_domain.rs
+++ b/crates/ralph-api/src/planning_domain.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-use chrono::{SecondsFormat, Utc};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -589,6 +589,4 @@ fn generate_title(prompt: &str) -> String {
     shortened
 }
 
-fn now_ts() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
-}
+use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/protocol.rs
+++ b/crates/ralph-api/src/protocol.rs
@@ -1,6 +1,5 @@
 use std::sync::OnceLock;
 
-use chrono::{SecondsFormat, Utc};
 use jsonschema::{Draft, JSONSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -230,9 +229,7 @@ fn response_meta(served_by: &str) -> ResponseMeta {
     }
 }
 
-fn now_ts() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
-}
+use crate::loop_support::now_ts;
 
 fn request_schema_validator() -> &'static JSONSchema {
     static REQUEST_VALIDATOR: OnceLock<JSONSchema> = OnceLock::new();

--- a/crates/ralph-api/src/protocol.rs
+++ b/crates/ralph-api/src/protocol.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::errors::ApiError;
+use crate::loop_support::now_ts;
 
 pub const API_VERSION: &str = "v1";
 pub const STREAM_NAME: &str = "events.v1";
@@ -228,8 +229,6 @@ fn response_meta(served_by: &str) -> ResponseMeta {
         served_at: now_ts(),
     }
 }
-
-use crate::loop_support::now_ts;
 
 fn request_schema_validator() -> &'static JSONSchema {
     static REQUEST_VALIDATOR: OnceLock<JSONSchema> = OnceLock::new();

--- a/crates/ralph-api/src/runtime.rs
+++ b/crates/ralph-api/src/runtime.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use axum::http::{HeaderMap, StatusCode};
-use chrono::{SecondsFormat, Utc};
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
@@ -95,7 +94,7 @@ impl RpcRuntime {
     pub fn health_payload(&self) -> Value {
         json!({
             "status": "ok",
-            "timestamp": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+            "timestamp": crate::loop_support::now_ts()
         })
     }
 

--- a/crates/ralph-api/src/runtime.rs
+++ b/crates/ralph-api/src/runtime.rs
@@ -295,14 +295,15 @@ impl RpcRuntime {
         })?;
 
         if !is_known_method(&method) {
-            return Err(ApiError::method_not_found(method.clone())
-                .with_context(request_id.clone(), Some(method)));
+            return Err(
+                ApiError::method_not_found(method.clone()).with_context(request_id, Some(method))
+            );
         }
 
         if let Err(errors) = validate_request_schema(&raw) {
             return Err(
                 ApiError::invalid_params("request does not match rpc-v1 schema")
-                    .with_context(request_id.clone(), Some(method.clone()))
+                    .with_context(request_id, Some(method))
                     .with_details(json!({ "errors": errors })),
             );
         }

--- a/crates/ralph-api/src/stream_domain/mod.rs
+++ b/crates/ralph-api/src/stream_domain/mod.rs
@@ -4,7 +4,7 @@ mod rpc_side_effects;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
-use chrono::{SecondsFormat, Utc};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::sync::broadcast;
@@ -459,6 +459,4 @@ fn next_event(
     }
 }
 
-fn now_ts() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
-}
+use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/stream_domain/mod.rs
+++ b/crates/ralph-api/src/stream_domain/mod.rs
@@ -10,6 +10,7 @@ use serde_json::{Value, json};
 use tokio::sync::broadcast;
 
 use crate::errors::ApiError;
+use crate::loop_support::now_ts;
 use crate::protocol::{API_VERSION, STREAM_NAME, STREAM_TOPICS};
 
 use self::filters::{
@@ -458,5 +459,3 @@ fn next_event(
         payload,
     }
 }
-
-use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/task_domain.rs
+++ b/crates/ralph-api/src/task_domain.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use chrono::{SecondsFormat, Utc};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ApiError;
@@ -527,6 +527,4 @@ fn is_terminal_status(status: &str) -> bool {
     matches!(status, "closed" | "failed")
 }
 
-fn now_ts() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
-}
+use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/task_domain.rs
+++ b/crates/ralph-api/src/task_domain.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ApiError;
+use crate::loop_support::now_ts;
 
 mod storage;
 
@@ -526,5 +527,3 @@ fn task_not_found_error(task_id: &str) -> ApiError {
 fn is_terminal_status(status: &str) -> bool {
     matches!(status, "closed" | "failed")
 }
-
-use crate::loop_support::now_ts;

--- a/crates/ralph-api/src/task_domain.rs
+++ b/crates/ralph-api/src/task_domain.rs
@@ -160,7 +160,7 @@ impl TaskDomain {
             )
             .with_details(serde_json::json!({
                 "taskId": params.id,
-                "status": requested_status.clone(),
+                "status": requested_status,
                 "autoExecute": auto_execute,
             })));
         }

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -135,10 +135,7 @@ fn bot_token_set(args: SetTokenArgs, use_colors: bool) -> Result<()> {
     }
 
     let has_config = args.config.is_some();
-    let config_path = args
-        .config
-        .clone()
-        .unwrap_or_else(|| PathBuf::from("ralph.yml"));
+    let config_path = args.config.unwrap_or_else(|| PathBuf::from("ralph.yml"));
 
     let should_write_config = has_config || !keychain_ok;
     if should_write_config {

--- a/crates/ralph-cli/src/loops.rs
+++ b/crates/ralph-cli/src/loops.rs
@@ -1212,14 +1212,14 @@ fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<Strin
 
     // Try exact match in registry
     if let Ok(Some(entry)) = registry.get(id) {
-        return Ok((entry.id.clone(), entry.worktree_path));
+        return Ok((entry.id, entry.worktree_path));
     }
 
     // Try partial match (e.g., "a3f2" matches "ralph-20250124-143052-a3f2")
     if let Ok(entries) = registry.list() {
         for entry in entries {
             if entry.id.ends_with(id) || entry.id.contains(id) {
-                return Ok((entry.id.clone(), entry.worktree_path));
+                return Ok((entry.id, entry.worktree_path));
             }
         }
     }

--- a/crates/ralph-cli/src/loops.rs
+++ b/crates/ralph-cli/src/loops.rs
@@ -538,7 +538,7 @@ fn show_logs(args: LogsArgs) -> Result<()> {
     let base_path = if let Some(ref wt_path) = worktree_path {
         PathBuf::from(wt_path)
     } else {
-        cwd.clone()
+        cwd
     };
 
     let events_path = base_path.join(".ralph/events.jsonl");
@@ -1212,14 +1212,14 @@ fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<Strin
 
     // Try exact match in registry
     if let Ok(Some(entry)) = registry.get(id) {
-        return Ok((entry.id.clone(), entry.worktree_path.clone()));
+        return Ok((entry.id.clone(), entry.worktree_path));
     }
 
     // Try partial match (e.g., "a3f2" matches "ralph-20250124-143052-a3f2")
     if let Ok(entries) = registry.list() {
         for entry in entries {
             if entry.id.ends_with(id) || entry.id.contains(id) {
-                return Ok((entry.id.clone(), entry.worktree_path.clone()));
+                return Ok((entry.id.clone(), entry.worktree_path));
             }
         }
     }
@@ -1233,7 +1233,7 @@ fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<Strin
             .find(|wt| wt.branch.ends_with(&entry.loop_id))
             .map(|wt| wt.path.to_string_lossy().to_string());
 
-        return Ok((entry.loop_id.clone(), wt_path));
+        return Ok((entry.loop_id, wt_path));
     }
 
     // Try partial match in merge queue
@@ -1245,7 +1245,7 @@ fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<Strin
                     .iter()
                     .find(|wt| wt.branch.ends_with(&entry.loop_id))
                     .map(|wt| wt.path.to_string_lossy().to_string());
-                return Ok((entry.loop_id.clone(), wt_path));
+                return Ok((entry.loop_id, wt_path));
             }
         }
     }

--- a/crates/ralph-cli/src/task_cli.rs
+++ b/crates/ralph-cli/src/task_cli.rs
@@ -486,7 +486,7 @@ fn execute_close(args: CloseArgs, root: Option<&PathBuf>, use_colors: bool) -> R
     let path = get_tasks_path(root);
     let mut store = TaskStore::load(&path).context("Failed to load tasks")?;
 
-    let task_id = args.id.clone();
+    let task_id = args.id;
     let title = store
         .close(&task_id)
         .context(format!("Task {} not found", task_id))?
@@ -514,7 +514,7 @@ fn execute_fail(args: FailArgs, root: Option<&PathBuf>, use_colors: bool) -> Res
     let path = get_tasks_path(root);
     let mut store = TaskStore::load(&path).context("Failed to load tasks")?;
 
-    let task_id = args.id.clone();
+    let task_id = args.id;
     let title = store
         .fail(&task_id)
         .context(format!("Task {} not found", task_id))?

--- a/crates/ralph-core/src/hatless_ralph.rs
+++ b/crates/ralph-core/src/hatless_ralph.rs
@@ -712,6 +712,20 @@ You MUST continue until all tasks are `[x]` or `[~]`.
 
     /// Generates a Mermaid flowchart showing event flow between hats.
     fn generate_mermaid_diagram(&self, topology: &HatTopology, ralph_publishes: &[&str]) -> String {
+        // Pre-compute sanitized Mermaid node IDs (strip emojis/special chars)
+        let node_ids: std::collections::HashMap<&str, String> = topology
+            .hats
+            .iter()
+            .map(|h| {
+                let id = h
+                    .name
+                    .chars()
+                    .filter(|c| c.is_alphanumeric())
+                    .collect::<String>();
+                (h.name.as_str(), id)
+            })
+            .collect();
+
         let mut diagram = String::from("```mermaid\nflowchart LR\n");
 
         // Entry point: task.start -> Ralph
@@ -719,18 +733,12 @@ You MUST continue until all tasks are `[x]` or `[~]`.
 
         // Ralph -> hats (via ralph_publishes which are hat triggers)
         for hat in &topology.hats {
+            let node_id = &node_ids[hat.name.as_str()];
             for trigger in &hat.subscribes_to {
                 if ralph_publishes.contains(&trigger.as_str()) {
-                    // Sanitize hat name for Mermaid (remove emojis and special chars for node ID)
-                    let node_id = hat
-                        .name
-                        .chars()
-                        .filter(|c| c.is_alphanumeric())
-                        .collect::<String>();
-                    if node_id == hat.name {
+                    if node_id == &hat.name {
                         diagram.push_str(&format!("    Ralph -->|{}| {}\n", trigger, hat.name));
                     } else {
-                        // If name has special chars, use label syntax
                         diagram.push_str(&format!(
                             "    Ralph -->|{}| {}[{}]\n",
                             trigger, node_id, hat.name
@@ -742,11 +750,7 @@ You MUST continue until all tasks are `[x]` or `[~]`.
 
         // Hats -> Ralph (via hat publishes)
         for hat in &topology.hats {
-            let node_id = hat
-                .name
-                .chars()
-                .filter(|c| c.is_alphanumeric())
-                .collect::<String>();
+            let node_id = &node_ids[hat.name.as_str()];
             for pub_event in &hat.publishes {
                 diagram.push_str(&format!("    {} -->|{}| Ralph\n", node_id, pub_event));
             }
@@ -754,21 +758,13 @@ You MUST continue until all tasks are `[x]` or `[~]`.
 
         // Hat -> Hat connections (when one hat publishes what another triggers on)
         for source_hat in &topology.hats {
-            let source_id = source_hat
-                .name
-                .chars()
-                .filter(|c| c.is_alphanumeric())
-                .collect::<String>();
+            let source_id = &node_ids[source_hat.name.as_str()];
             for pub_event in &source_hat.publishes {
                 for target_hat in &topology.hats {
                     if target_hat.name != source_hat.name
                         && target_hat.subscribes_to.contains(pub_event)
                     {
-                        let target_id = target_hat
-                            .name
-                            .chars()
-                            .filter(|c| c.is_alphanumeric())
-                            .collect::<String>();
+                        let target_id = &node_ids[target_hat.name.as_str()];
                         diagram.push_str(&format!(
                             "    {} -->|{}| {}\n",
                             source_id, pub_event, target_id

--- a/crates/ralph-core/src/hooks/executor.rs
+++ b/crates/ralph-core/src/hooks/executor.rs
@@ -241,13 +241,31 @@ impl HookExecutorContract for HookExecutor {
         command.stdout(Stdio::piped());
         command.stderr(Stdio::piped());
 
-        let mut child = command.spawn().map_err(|source| HookExecutorError::Spawn {
-            phase_event: request.phase_event.clone(),
-            hook_name: request.hook_name.clone(),
-            command: command_display.clone(),
-            cwd: resolved_cwd.display().to_string(),
-            source,
-        })?;
+        // Retry on ETXTBSY: the kernel defers fput() from close(), so exec()
+        // can briefly see a stale write-count on the inode. A single retry
+        // after yielding the thread is sufficient for the task_work to drain.
+        let mut child = None;
+        for attempt in 0..3 {
+            match command.spawn() {
+                Ok(c) => {
+                    child = Some(c);
+                    break;
+                }
+                Err(e) if e.raw_os_error() == Some(26 /* ETXTBSY */) && attempt < 2 => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(source) => {
+                    return Err(HookExecutorError::Spawn {
+                        phase_event: request.phase_event.clone(),
+                        hook_name: request.hook_name.clone(),
+                        command: command_display.clone(),
+                        cwd: resolved_cwd.display().to_string(),
+                        source,
+                    });
+                }
+            }
+        }
+        let mut child = child.expect("spawn loop must break or return");
 
         write_stdin_payload(
             &mut child,
@@ -623,30 +641,37 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
     use std::fs;
-    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use tempfile::{TempDir, tempdir};
 
     fn write_executable_script(temp_dir: &TempDir, file_name: &str, body: &str) -> PathBuf {
         use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
 
         let script_path = temp_dir.path().join(file_name);
         let script = format!("#!/bin/sh\nset -eu\n{body}\n");
 
-        // Explicit open/write/sync/close to avoid ETXTBSY on CI:
-        // the kernel may reject exec() if the write fd isn't fully closed.
+        // Set mode at creation time and sync before close to avoid the
+        // ETXTBSY race (deferred fput between close and exec).
         {
-            let mut file = fs::File::create(&script_path).expect("create script file");
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o755)
+                .open(&script_path)
+                .expect("create script file");
             file.write_all(script.as_bytes())
                 .expect("write script file");
             file.sync_all().expect("sync script file");
         }
 
-        let mut permissions = fs::metadata(&script_path)
-            .expect("read script metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&script_path, permissions).expect("set script permissions");
+        // Force the kernel to process the deferred fput from close() above
+        // by issuing another syscall that touches the same inode.
+        assert!(
+            fs::metadata(&script_path).expect("stat script").len() > 0,
+            "script must not be empty"
+        );
 
         script_path
     }

--- a/crates/ralph-core/src/hooks/executor.rs
+++ b/crates/ralph-core/src/hooks/executor.rs
@@ -668,10 +668,7 @@ mod tests {
 
         // Force the kernel to process the deferred fput from close() above
         // by issuing another syscall that touches the same inode.
-        assert!(
-            fs::metadata(&script_path).expect("stat script").len() > 0,
-            "script must not be empty"
-        );
+        let _ = fs::metadata(&script_path).expect("stat script");
 
         script_path
     }

--- a/crates/ralph-core/src/hooks/executor.rs
+++ b/crates/ralph-core/src/hooks/executor.rs
@@ -258,7 +258,7 @@ impl HookExecutorContract for HookExecutor {
                     return Err(HookExecutorError::Spawn {
                         phase_event: request.phase_event.clone(),
                         hook_name: request.hook_name.clone(),
-                        command: command_display.clone(),
+                        command: command_display,
                         cwd: resolved_cwd.display().to_string(),
                         source,
                     });

--- a/crates/ralph-tui/src/state.rs
+++ b/crates/ralph-tui/src/state.rs
@@ -357,7 +357,7 @@ impl TuiState {
                 self.pending_backend = saved_pending_backend;
                 self.guidance_next_queue = saved_guidance_next_queue;
                 self.events_path = saved_events_path;
-                if let Some((hat_id, hat_display)) = custom_hat.clone() {
+                if let Some((hat_id, hat_display)) = custom_hat {
                     self.pending_hat = Some((hat_id, hat_display));
                 } else {
                     self.pending_hat = Some((HatId::new("planner"), "📋Planner".to_string()));

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -175,8 +175,8 @@ ralph hooks <COMMAND>
 Try it against the minimal sample hooks config:
 
 - `ralph hooks validate -c examples/hooks/minimal/ralph.hooks.yml`
-- Config: [`examples/hooks/minimal/ralph.hooks.yml`](../../examples/hooks/minimal/ralph.hooks.yml)
-- Scripts: [`examples/hooks/scripts/env-guard.sh`](../../examples/hooks/scripts/env-guard.sh), [`examples/hooks/scripts/notify.sh`](../../examples/hooks/scripts/notify.sh)
+- Config: [`examples/hooks/minimal/ralph.hooks.yml`](https://github.com/mikeyobrien/ralph-orchestrator/blob/main/examples/hooks/minimal/ralph.hooks.yml)
+- Scripts: [`examples/hooks/scripts/env-guard.sh`](https://github.com/mikeyobrien/ralph-orchestrator/blob/main/examples/hooks/scripts/env-guard.sh), [`examples/hooks/scripts/notify.sh`](https://github.com/mikeyobrien/ralph-orchestrator/blob/main/examples/hooks/scripts/notify.sh)
 
 ### ralph doctor
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -266,8 +266,8 @@ Mutation scope in v1 is intentionally narrow:
 
 Minimal runnable example:
 
-- Config: [`examples/hooks/minimal/ralph.hooks.yml`](../../examples/hooks/minimal/ralph.hooks.yml)
-- Scripts: [`examples/hooks/scripts/env-guard.sh`](../../examples/hooks/scripts/env-guard.sh), [`examples/hooks/scripts/notify.sh`](../../examples/hooks/scripts/notify.sh)
+- Config: [`examples/hooks/minimal/ralph.hooks.yml`](https://github.com/mikeyobrien/ralph-orchestrator/blob/main/examples/hooks/minimal/ralph.hooks.yml)
+- Scripts: [`examples/hooks/scripts/env-guard.sh`](https://github.com/mikeyobrien/ralph-orchestrator/blob/main/examples/hooks/scripts/env-guard.sh), [`examples/hooks/scripts/notify.sh`](https://github.com/mikeyobrien/ralph-orchestrator/blob/main/examples/hooks/scripts/notify.sh)
 - Validate: `ralph hooks validate -c examples/hooks/minimal/ralph.hooks.yml`
 
 ### hats

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export PYTHONPATH=$(pwd)/src
 python3 -m ralph_orchestrator -c test_ralph.yml -i 50 --dry-run

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Setup git hooks for development
 # Run this once after cloning the repository
 

--- a/scripts/test_issue_213.sh
+++ b/scripts/test_issue_213.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Manual regression test for issue #213
 # Run this script to verify the fix for "Subprocess TUI run wrongly spawns worktree on first run"
 #

--- a/tools/evaluate-all-presets.sh
+++ b/tools/evaluate-all-presets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # evaluate-all-presets.sh - Evaluate all hat collection presets
 #
 # Usage: ./tools/evaluate-all-presets.sh [backend]

--- a/tools/evaluate-preset.sh
+++ b/tools/evaluate-preset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # evaluate-preset.sh - Evaluate a single hat collection preset
 #
 # Usage: ./tools/evaluate-preset.sh <preset-name> [backend]

--- a/tools/test-tui.sh
+++ b/tools/test-tui.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # TUI Manual Testing Script
 # Run this in a real terminal (not from Claude Code)
 


### PR DESCRIPTION
## Summary
- Fix 5 pre-existing test failures (3 ACP shebang on NixOS, 2 flaky ETXTBSY in hook executor)
- Remove redundant `.clone()` calls across 8 files (clippy::redundant_clone)
- Consolidate 6 identical `now_ts()` definitions in ralph-api into 1

## Details

### Fix: NixOS shebang + ETXTBSY race
- ACP mock script used `#!/bin/bash` which doesn't exist on NixOS → `#!/usr/bin/env bash`
- Hook executor `spawn()` hits intermittent ETXTBSY when kernel defers `fput()` from `close()` → added retry loop (3 attempts, 10ms backoff)

### Refactor: redundant clones
- Automated clippy fix across ralph-api, ralph-cli, ralph-core, ralph-tui

### Refactor: now_ts() dedup
- 6 identical `fn now_ts()` → 1 `pub(crate)` in loop_support.rs
- Cleaned up 5 unused chrono::SecondsFormat imports

## Test plan
- [x] `cargo test` — all pass (0 failures)
- [x] `cargo clippy --all-targets` — zero warnings
- [x] E2E mock tests — 9/15 pass (6 failures are pre-existing completion backend issues)
- [x] TUI + Claude backend smoke test in tmux — full loop: task create → file write → commit → LOOP_COMPLETE

🤖 Generated with [Claude Code](https://claude.com/claude-code)