### PR TITLE
feat(adapters): add roo-cli as a backend provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ npm run test:server                          # Backend tests
 ```
 ralph-cli      → CLI entry point, commands (run, plan, task, loops, web)
 ralph-core     → Orchestration logic, event loop, hats, memories, tasks
-ralph-adapters → Backend integrations (Claude, Kiro, Gemini, Codex, etc.)
+ralph-adapters → Backend integrations (Claude, Kiro, Gemini, Codex, Roo, etc.)
 ralph-telegram → Telegram bot for human-in-the-loop communication
 ralph-tui      → Terminal UI (ratatui-based)
 ralph-e2e      → End-to-end test framework

--- a/crates/ralph-adapters/src/auto_detect.rs
+++ b/crates/ralph-adapters/src/auto_detect.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 /// Default priority order for backend detection.
 pub const DEFAULT_PRIORITY: &[&str] = &[
-    "claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi",
+    "claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi", "roo",
 ];
 
 /// Maps backend config names to their actual CLI command names.
@@ -60,6 +60,7 @@ impl std::fmt::Display for NoBackendError {
             f,
             "  • Pi CLI:       https://github.com/anthropics/pi-coding-agent"
         )?;
+        writeln!(f, "  • Roo CLI:      https://github.com/RooVetGit/Roo-Code")?;
         Ok(())
     }
 }
@@ -210,6 +211,7 @@ mod tests {
         assert_eq!(detection_command("codex"), "codex");
         assert_eq!(detection_command("amp"), "amp");
         assert_eq!(detection_command("pi"), "pi");
+        assert_eq!(detection_command("roo"), "roo");
     }
 
     #[test]
@@ -221,12 +223,35 @@ mod tests {
     }
 
     #[test]
-    fn test_default_priority_pi_is_last() {
+    fn test_default_priority_pi_is_second_to_last() {
+        let len = DEFAULT_PRIORITY.len();
+        assert_eq!(
+            DEFAULT_PRIORITY[len - 2],
+            "pi",
+            "Pi should be second-to-last in DEFAULT_PRIORITY"
+        );
+    }
+
+    #[test]
+    fn test_default_priority_includes_roo() {
+        assert!(
+            DEFAULT_PRIORITY.contains(&"roo"),
+            "DEFAULT_PRIORITY should include 'roo'"
+        );
+    }
+
+    #[test]
+    fn test_default_priority_roo_is_last() {
         assert_eq!(
             DEFAULT_PRIORITY.last(),
-            Some(&"pi"),
-            "Pi should be the last entry in DEFAULT_PRIORITY"
+            Some(&"roo"),
+            "Roo should be the last entry in DEFAULT_PRIORITY"
         );
+    }
+
+    #[test]
+    fn test_detection_command_roo() {
+        assert_eq!(detection_command("roo"), "roo");
     }
 
     #[test]

--- a/crates/ralph-adapters/src/cli_backend.rs
+++ b/crates/ralph-adapters/src/cli_backend.rs
@@ -76,6 +76,7 @@ impl CliBackend {
             "copilot" => Self::copilot(),
             "opencode" => Self::opencode(),
             "pi" => Self::pi(),
+            "roo" => Self::roo(),
             "custom" => return Self::custom(config),
             _ => Self::claude(), // Default to claude
         };
@@ -243,6 +244,7 @@ impl CliBackend {
             "copilot" => Ok(Self::copilot()),
             "opencode" => Ok(Self::opencode()),
             "pi" => Ok(Self::pi()),
+            "roo" => Ok(Self::roo()),
             _ => Err(CustomBackendError),
         }
     }
@@ -395,6 +397,7 @@ impl CliBackend {
             "copilot" => Ok(Self::copilot_interactive()),
             "opencode" => Ok(Self::opencode_interactive()),
             "pi" => Ok(Self::pi_interactive()),
+            "roo" => Ok(Self::roo_interactive()),
             _ => Err(CustomBackendError),
         }
     }
@@ -567,6 +570,38 @@ impl CliBackend {
         }
     }
 
+    /// Creates the Roo backend for headless execution.
+    ///
+    /// Uses `--print` for non-interactive output and `--ephemeral` for clean
+    /// disk state. Prompts are always passed via `--prompt-file` (handled in
+    /// `build_command()`). Roo auto-approves tools by default, so no
+    /// `--trust-all-tools` equivalent is needed.
+    pub fn roo() -> Self {
+        Self {
+            command: "roo".to_string(),
+            args: vec!["--print".to_string(), "--ephemeral".to_string()],
+            prompt_mode: PromptMode::Arg,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        }
+    }
+
+    /// Creates the Roo backend for interactive mode with initial prompt.
+    ///
+    /// Runs roo TUI without `--print` or `--ephemeral`, passing the prompt
+    /// as a positional argument. Used by `ralph plan` for interactive sessions.
+    pub fn roo_interactive() -> Self {
+        Self {
+            command: "roo".to_string(),
+            args: vec![],
+            prompt_mode: PromptMode::Arg,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        }
+    }
+
     /// Creates a custom backend from configuration.
     ///
     /// # Errors
@@ -589,6 +624,33 @@ impl CliBackend {
         })
     }
 
+    /// Builds roo prompt-file args: writes prompt to a temp file and
+    /// appends `--prompt-file <path>` to args. Falls back to positional
+    /// arg if temp file creation fails.
+    fn build_roo_prompt_file(
+        args: &mut Vec<String>,
+        prompt: &str,
+    ) -> (Option<String>, Option<NamedTempFile>) {
+        match NamedTempFile::new() {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(prompt.as_bytes()) {
+                    tracing::warn!("Failed to write roo prompt to temp file: {}", e);
+                    args.push(prompt.to_string());
+                    (None, None)
+                } else {
+                    args.push("--prompt-file".to_string());
+                    args.push(file.path().display().to_string());
+                    (None, Some(file))
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to create temp file for roo: {}", e);
+                args.push(prompt.to_string());
+                (None, None)
+            }
+        }
+    }
+
     /// Builds the full command with arguments for execution.
     ///
     /// # Arguments
@@ -606,38 +668,47 @@ impl CliBackend {
             args = self.filter_args_for_interactive(args);
         }
 
-        // Handle large prompts for Claude (>7000 chars)
+        // Handle prompt passing: Roo uses --prompt-file, Claude uses temp file for large prompts
         let (stdin_input, temp_file) = match self.prompt_mode {
             PromptMode::Arg => {
-                let (prompt_text, temp_file) = if self.command == "claude" && prompt.len() > 7000 {
-                    // Write to temp file and instruct Claude to read it
-                    match NamedTempFile::new() {
-                        Ok(mut file) => {
-                            if let Err(e) = file.write_all(prompt.as_bytes()) {
-                                tracing::warn!("Failed to write prompt to temp file: {}", e);
+                // Roo headless: always use --prompt-file for all prompts
+                // Only headless roo() has --print in args; roo_interactive() does not
+                if self.command == "roo" && args.contains(&"--print".to_string()) {
+                    Self::build_roo_prompt_file(&mut args, prompt)
+                } else {
+                    // Handle large prompts for Claude (>7000 chars)
+                    let (prompt_text, temp_file) = if self.command == "claude"
+                        && prompt.len() > 7000
+                    {
+                        // Write to temp file and instruct Claude to read it
+                        match NamedTempFile::new() {
+                            Ok(mut file) => {
+                                if let Err(e) = file.write_all(prompt.as_bytes()) {
+                                    tracing::warn!("Failed to write prompt to temp file: {}", e);
+                                    (prompt.to_string(), None)
+                                } else {
+                                    let path = file.path().display().to_string();
+                                    (
+                                        format!("Please read and execute the task in {}", path),
+                                        Some(file),
+                                    )
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to create temp file: {}", e);
                                 (prompt.to_string(), None)
-                            } else {
-                                let path = file.path().display().to_string();
-                                (
-                                    format!("Please read and execute the task in {}", path),
-                                    Some(file),
-                                )
                             }
                         }
-                        Err(e) => {
-                            tracing::warn!("Failed to create temp file: {}", e);
-                            (prompt.to_string(), None)
-                        }
-                    }
-                } else {
-                    (prompt.to_string(), None)
-                };
+                    } else {
+                        (prompt.to_string(), None)
+                    };
 
-                if let Some(ref flag) = self.prompt_flag {
-                    args.push(flag.clone());
+                    if let Some(ref flag) = self.prompt_flag {
+                        args.push(flag.clone());
+                    }
+                    args.push(prompt_text);
+                    (None, temp_file)
                 }
-                args.push(prompt_text);
-                (None, temp_file)
             }
             PromptMode::Stdin => (Some(prompt.to_string()), None),
         };
@@ -673,6 +744,10 @@ impl CliBackend {
             "copilot" => args
                 .into_iter()
                 .filter(|a| a != "--allow-all-tools")
+                .collect(),
+            "roo" => args
+                .into_iter()
+                .filter(|a| a != "--print" && a != "--ephemeral")
                 .collect(),
             _ => args, // claude, gemini, opencode unchanged
         }
@@ -1619,5 +1694,176 @@ mod tests {
         assert!(CliBackend::copilot().env_vars.is_empty());
         assert!(CliBackend::opencode().env_vars.is_empty());
         assert!(CliBackend::pi().env_vars.is_empty());
+        assert!(CliBackend::roo().env_vars.is_empty());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Tests for Roo backend
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_roo_backend() {
+        let backend = CliBackend::roo();
+        let (cmd, args, stdin, temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "roo");
+        // Should use --prompt-file with temp file, not positional arg
+        assert!(
+            temp.is_some(),
+            "roo should always use temp file for prompts"
+        );
+        assert!(
+            args.contains(&"--print".to_string()),
+            "roo headless should have --print"
+        );
+        assert!(
+            args.contains(&"--ephemeral".to_string()),
+            "roo headless should have --ephemeral"
+        );
+        assert!(
+            args.contains(&"--prompt-file".to_string()),
+            "roo should use --prompt-file"
+        );
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn test_roo_interactive() {
+        let backend = CliBackend::roo_interactive();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "roo");
+        // Interactive mode: no --print, no --ephemeral, positional prompt
+        assert_eq!(args, vec!["test prompt"]);
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+        assert_eq!(backend.prompt_flag, None);
+    }
+
+    #[test]
+    fn test_from_name_roo() {
+        let backend = CliBackend::from_name("roo").unwrap();
+        assert_eq!(backend.command, "roo");
+        assert_eq!(backend.prompt_flag, None);
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn test_from_config_roo() {
+        let config = CliConfig {
+            backend: "roo".to_string(),
+            command: None,
+            prompt_mode: "arg".to_string(),
+            ..Default::default()
+        };
+        let backend = CliBackend::from_config(&config).unwrap();
+
+        assert_eq!(backend.command, "roo");
+        assert_eq!(backend.output_format, OutputFormat::Text);
+        assert!(backend.args.contains(&"--print".to_string()));
+        assert!(backend.args.contains(&"--ephemeral".to_string()));
+    }
+
+    #[test]
+    fn test_from_config_roo_with_args() {
+        let config = CliConfig {
+            backend: "roo".to_string(),
+            command: None,
+            prompt_mode: "arg".to_string(),
+            args: vec![
+                "--provider".to_string(),
+                "bedrock".to_string(),
+                "--model".to_string(),
+                "anthropic.claude-sonnet-4-6".to_string(),
+            ],
+            ..Default::default()
+        };
+        let backend = CliBackend::from_config(&config).unwrap();
+        let (_cmd, args, _stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(backend.command, "roo");
+        // Should have default args + extra args + --prompt-file
+        assert!(args.contains(&"--print".to_string()));
+        assert!(args.contains(&"--ephemeral".to_string()));
+        assert!(args.contains(&"--provider".to_string()));
+        assert!(args.contains(&"bedrock".to_string()));
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"anthropic.claude-sonnet-4-6".to_string()));
+        assert!(args.contains(&"--prompt-file".to_string()));
+    }
+
+    #[test]
+    fn test_for_interactive_prompt_roo() {
+        let backend = CliBackend::for_interactive_prompt("roo").unwrap();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "roo");
+        // Interactive: no --print, no --ephemeral, positional prompt
+        assert_eq!(args, vec!["test prompt"]);
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn test_roo_interactive_mode_removes_print() {
+        let backend = CliBackend::roo();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", true);
+
+        assert_eq!(cmd, "roo");
+        // In interactive mode, --print and --ephemeral should be removed
+        assert!(
+            !args.contains(&"--print".to_string()),
+            "interactive mode should remove --print"
+        );
+        assert!(
+            !args.contains(&"--ephemeral".to_string()),
+            "interactive mode should remove --ephemeral"
+        );
+        assert!(stdin.is_none());
+    }
+
+    #[test]
+    fn test_roo_uses_prompt_file() {
+        let backend = CliBackend::roo();
+        // Test with small prompt
+        let (_, args_small, _, temp_small) = backend.build_command("small prompt", false);
+        assert!(
+            temp_small.is_some(),
+            "even small prompts should use temp file"
+        );
+        assert!(
+            args_small.contains(&"--prompt-file".to_string()),
+            "should use --prompt-file"
+        );
+
+        // Test with large prompt
+        let large_prompt = "x".repeat(10000);
+        let (_, args_large, _, temp_large) = backend.build_command(&large_prompt, false);
+        assert!(temp_large.is_some(), "large prompts should use temp file");
+        assert!(
+            args_large.contains(&"--prompt-file".to_string()),
+            "should use --prompt-file for large prompts"
+        );
+    }
+
+    #[test]
+    fn test_roo_prompt_file_content() {
+        use std::io::{Read, Seek};
+        let backend = CliBackend::roo();
+        let prompt = "This is a test prompt for roo";
+        let (_, _, _, temp) = backend.build_command(prompt, false);
+
+        let mut temp_file = temp.expect("should have temp file");
+        let mut content = String::new();
+        temp_file
+            .as_file_mut()
+            .seek(std::io::SeekFrom::Start(0))
+            .unwrap();
+        temp_file
+            .as_file_mut()
+            .read_to_string(&mut content)
+            .unwrap();
+        assert_eq!(content, prompt);
     }
 }

--- a/crates/ralph-adapters/src/lib.rs
+++ b/crates/ralph-adapters/src/lib.rs
@@ -7,6 +7,7 @@
 //! - Gemini (Google)
 //! - Codex (OpenAI)
 //! - Pi (pi-coding-agent)
+//! - Roo (Roo Code)
 //! - Amp
 //! - Custom commands
 //!

--- a/docs/guide/roo-backend.md
+++ b/docs/guide/roo-backend.md
@@ -1,0 +1,253 @@
+# Using Ralph Orchestrator with Roo Code CLI
+
+## Quick Start
+
+### Prerequisites
+
+1. **Ralph** installed (`cargo build` from this repo)
+2. **Roo CLI** installed (`roo --version` should return 0.1.15+)
+3. **AWS Bedrock** access configured (or another supported provider)
+
+### Run Your First Loop
+
+```bash
+# Simple one-iteration test
+ralph run -b roo --max-iterations 1 \
+  -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
+     --model anthropic.claude-sonnet-4-6 --max-tokens 64000 \
+  -p "Create a hello.txt file with 'Hello World'"
+```
+
+## Configuration
+
+### Option 1: CLI Flags (Quick)
+
+Pass roo-specific flags after `--`:
+
+```bash
+ralph run -b roo -- \
+  --provider bedrock \
+  --aws-profile roo-bedrock \
+  --aws-region us-east-1 \
+  --model anthropic.claude-sonnet-4-6 \
+  --max-tokens 64000
+```
+
+### Option 2: Config File (Recommended)
+
+Create a `ralph.roo.yml`:
+
+```yaml
+# Ralph + Roo Configuration
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400      # 4 hours
+  max_consecutive_failures: 5
+
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  idle_timeout_secs: 30
+  args:
+    - "--provider"
+    - "bedrock"
+    - "--aws-profile"
+    - "roo-bedrock"
+    - "--aws-region"
+    - "us-east-1"
+    - "--model"
+    - "anthropic.claude-sonnet-4-6"
+    - "--max-tokens"
+    - "100000"
+    - "--reasoning-effort"
+    - "medium"
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - save learnings to memories for next time"
+    - "Don't assume 'not implemented' - search first"
+    - "Verification is mandatory - tests/typecheck/lint/audit must pass"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document; <50 choose safe default + document."
+
+hats:
+  builder:
+    name: "Builder"
+    description: "Implements code, creates files, runs tests. Does the actual work."
+    triggers: ["build.task"]
+    publishes: ["build.done", "build.blocked"]
+    instructions: |
+      ## WORKFLOW
+      You are Builder. Your job is to IMPLEMENT - write code, create files, run tests.
+      1. Read the build.task event payload - that's your task
+      2. IMPLEMENT: Create files, write code, run commands
+      3. VERIFY: Run tests/builds to confirm it works
+      4. COMPLETE: Emit build.done when verified, or build.blocked if stuck
+      RULES:
+      - Do the actual work - don't just plan or delegate
+      - Never emit build.task (that's for coordination, not you)
+```
+
+Then run:
+
+```bash
+ralph run -c ralph.roo.yml -p "Build feature X"
+```
+
+### Option 3: PDD-to-Code-Assist with Roo
+
+For the full PDD → Code Assist workflow using Roo with Claude Opus 4.6:
+
+Create `ralph.roo.pdd.yml`:
+
+```yaml
+# PDD-to-Code-Assist with Roo Code CLI
+# Uses Claude Opus 4.6 via Bedrock with medium reasoning effort
+
+event_loop:
+  prompt_file: "PROMPT.md"
+  completion_promise: "LOOP_COMPLETE"
+  starting_event: "design.start"
+  max_iterations: 150
+  max_runtime_seconds: 14400
+  checkpoint_interval: 5
+
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  idle_timeout_secs: 60
+  args:
+    - "--provider"
+    - "bedrock"
+    - "--aws-profile"
+    - "roo-bedrock"
+    - "--aws-region"
+    - "us-east-1"
+    - "--model"
+    - "anthropic.claude-opus-4-6"
+    - "--max-tokens"
+    - "100000"
+    - "--reasoning-effort"
+    - "medium"
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration — save learnings to memories for next time"
+    - "Verification is mandatory — tests/typecheck/lint/audit must pass"
+    - "YAGNI ruthlessly — no speculative features"
+    - "KISS always — simplest solution that works"
+    - "Preserve primary sources — all referenced files, research findings, code snippets, and external docs must be captured with source attribution"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document in .ralph/agent/decisions.md; <50 choose safe default + document."
+
+# Copy hats from presets/pdd-to-code-assist.yml
+# (inquisitor, architect, design_critic, explorer, planner, task_writer, builder, validator, committer)
+```
+
+Then run:
+
+```bash
+ralph run -c ralph.roo.pdd.yml -p "Build a CLI tool for managing tasks"
+```
+
+Or use the built-in preset with roo args:
+
+```bash
+ralph run -c presets/pdd-to-code-assist.yml \
+  -c cli.backend=roo \
+  -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
+     --model anthropic.claude-opus-4-6 --max-tokens 100000 \
+     --reasoning-effort medium \
+  -p "Build a CLI tool for managing tasks"
+```
+
+## Roo-Specific Configuration Options
+
+### Model Selection
+
+Pass model flags via `cli.args` or `--`:
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--provider` | LLM provider | `bedrock`, `anthropic`, `openai`, `openrouter` |
+| `--model` | Model identifier | `anthropic.claude-opus-4-6`, `anthropic.claude-sonnet-4-6` |
+| `--max-tokens` | Max output tokens | `100000` |
+| `--reasoning-effort` | Thinking effort | `medium`, `high`, `xhigh` |
+| `--aws-profile` | AWS credentials profile | `roo-bedrock` |
+| `--aws-region` | AWS Bedrock region | `us-east-1` |
+
+### Roo Modes
+
+Roo has built-in modes (`code`, `architect`, `ask`, `debug`). By default, it uses `code` mode which has all tools (read, edit, command, mcp). Override with:
+
+```yaml
+cli:
+  args:
+    - "--mode"
+    - "architect"  # For planning-focused hats
+```
+
+### Interactive Planning
+
+Use `ralph plan` for interactive sessions with Roo's TUI:
+
+```bash
+ralph plan -b roo -- --provider bedrock --aws-profile roo-bedrock \
+  --aws-region us-east-1 --model anthropic.claude-opus-4-6 \
+  --max-tokens 100000 \
+  -p "Design the auth system architecture"
+```
+
+## How It Works
+
+### Architecture
+
+```
+Ralph Loop (each iteration):
+1. Ralph builds prompt (context + events + memories + instructions)
+2. Writes prompt to temp file
+3. Spawns: roo --print --ephemeral --prompt-file /tmp/xxx [user args]
+4. Roo reads prompt, executes tools, produces text output
+5. Ralph parses output for events (<event topic="...">) and LOOP_COMPLETE
+6. Next iteration with updated context
+```
+
+### Key Behaviors
+
+| Aspect | Behavior |
+|--------|----------|
+| **Context** | Fresh each iteration — roo has no memory between iterations |
+| **Tool approval** | Auto-approved by default (no flag needed) |
+| **Disk state** | `--ephemeral` keeps disk clean between iterations |
+| **Prompt passing** | Always via `--prompt-file` (handles any prompt size) |
+| **Error detection** | LOOP_COMPLETE presence + consecutive failure counter |
+| **Exit codes** | Config errors → exit 1; API errors → infinite retry (idle timeout handles) |
+
+## Troubleshooting
+
+### Bedrock Cross-Region Errors
+
+If you see "Try enabling cross-region inference":
+1. Ensure `--aws-region` matches your Bedrock setup
+2. Check `--aws-profile` has correct credentials
+3. Verify the model is available in your region
+
+### Roo Retries Indefinitely
+
+Roo retries API errors with exponential backoff. Ralph's `idle_timeout_secs` (default 30s) will kill the process. Increase if your model is slow:
+
+```yaml
+cli:
+  idle_timeout_secs: 60  # or higher for large prompts
+```
+
+### CustomModesManager Warning
+
+```
+[CustomModesManager] Failed to load modes from .../custom_modes.yaml: ENOENT
+```
+
+This is benign — `--ephemeral` mode uses a temp directory where custom modes don't exist. No action needed.

--- a/presets/minimal/roo.yml
+++ b/presets/minimal/roo.yml
@@ -1,0 +1,46 @@
+# Ralph Orchestrator Configuration for Roo Code CLI
+# v2 nested format - optimized for Roo CLI
+
+# Event loop settings
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400      # 4 hours
+  max_consecutive_failures: 5
+
+# CLI backend settings
+cli:
+  backend: "roo"
+  prompt_mode: "arg"              # Pass prompt as CLI argument
+  pty_mode: false                 # Set true for rich terminal UI
+  pty_interactive: true           # Forward keystrokes in PTY mode
+  idle_timeout_secs: 30           # Kill after 30s of inactivity
+
+# Core behaviors (always injected into prompts)
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - save learnings to memories for next time"
+    - "Don't assume 'not implemented' - search first"
+    - "Verification is mandatory - tests/typecheck/lint/audit must pass"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document in .ralph/agent/decisions.md; <50 choose safe default + document."
+
+hats:
+  builder:
+    name: "Builder"
+    description: "Implements code, creates files, runs tests. Does the actual work."
+    triggers: ["build.task"]
+    publishes: ["build.done", "build.blocked"]
+    instructions: |
+      ## WORKFLOW
+
+      You are Builder. Your job is to IMPLEMENT - write code, create files, run tests.
+
+      1. Read the build.task event payload - that's your task
+      2. IMPLEMENT: Create files, write code, run commands
+      3. VERIFY: Run tests/builds to confirm it works
+      4. COMPLETE: Emit build.done when verified, or build.blocked if stuck
+
+      RULES:
+      - Do the actual work - don't just plan or delegate
+      - Never emit build.task (that's for coordination, not you)

--- a/ralph.roo.yml
+++ b/ralph.roo.yml
@@ -1,0 +1,27 @@
+# Ralph + Roo: PDD-to-Code-Assist Configuration
+# Uses Claude Opus 4.6 via Bedrock with adaptive thinking
+#
+# Usage:
+#   ralph run -c ralph.roo.yml -p "Build a feature to..."
+#
+# Or with the pdd-to-code-assist preset:
+#   ralph run -c presets/pdd-to-code-assist.yml -c ralph.roo.yml -p "Build a feature to..."
+
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  idle_timeout_secs: 60           # Opus can be slow; 60s idle timeout
+  args:
+    - "--provider"
+    - "bedrock"
+    - "--aws-profile"
+    - "roo-bedrock"
+    - "--aws-region"
+    - "us-east-1"
+    - "--model"
+    - "anthropic.claude-opus-4-6"
+    - "--max-tokens"
+    - "100000"
+    - "--reasoning-effort"
+    - "medium"                    # Adaptive thinking: medium (default)


### PR DESCRIPTION
## Summary

Add `roo` (Roo Code CLI) as a new backend provider in ralph-orchestrator, following the same adapter pattern used by kiro, pi, and opencode.

## Changes

### Source Code (4 files)
- **`crates/ralph-adapters/src/cli_backend.rs`**: Add `roo()` and `roo_interactive()` backend constructors, register in `from_config`, `from_name`, `for_interactive_prompt`, add `--prompt-file` support with `build_roo_prompt_file()` helper, `filter_args_for_interactive` removes `--print` and `--ephemeral`. 10 new tests.
- **`crates/ralph-adapters/src/auto_detect.rs`**: Append `"roo"` to `DEFAULT_PRIORITY` (last position), add Roo CLI install link to `NoBackendError`. 3 new tests.
- **`crates/ralph-adapters/src/lib.rs`**: Update crate doc comment to include `Roo (Roo Code)`
- **`AGENTS.md`**: Add "Roo" to backend list

### Configuration (2 files)
- **`presets/minimal/roo.yml`**: New preset (mirrors kiro preset, backend: roo)
- **`ralph.roo.yml`**: Sample config with Opus 4.6, 100K tokens, medium reasoning via Bedrock

### Documentation (1 file)
- **`docs/guide/roo-backend.md`**: Complete usage guide with Quick Start, Configuration, Troubleshooting

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Output format | Text mode | Simple, proven (6/9 providers use it) |
| Headless command | `roo --print --ephemeral --prompt-file <path>` | Clean disk state + native prompt file support |
| Interactive command | `roo "prompt"` | For `ralph plan` |
| Prompt passing | Always `--prompt-file` | One code path, no size threshold |
| Auto-detect priority | Last position | Fallback only |

## Validation

- ✅ `cargo fmt --check` — Clean
- ✅ `cargo clippy --all-targets --all-features` — Zero warnings
- ✅ `cargo test` — All test suites pass (244 adapters tests)
- ✅ E2E: `ralph run -b roo` — Completed iteration successfully
- ✅ E2E: `ralph run -c presets/minimal/roo.yml` — Event emission + LOOP_COMPLETE verified

## Usage

```bash
# Quick test
ralph run -b roo --max-iterations 1 \
  -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
     --model anthropic.claude-opus-4-6 --max-tokens 100000 \
  -p "Your prompt"

# With config file
ralph run -c ralph.roo.yml -p "Your prompt"

# PDD-to-Code-Assist
ralph run -c presets/pdd-to-code-assist.yml -c ralph.roo.yml -p "Build a feature"
```