### PR TITLE
docs(specs): add roo-cli provider design spec

### DIFF
--- a/.agents/planning/2026-03-03-roo-cli-provider/design/detailed-design.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/design/detailed-design.md
@@ -1,0 +1,279 @@
+# Detailed Design: Add roo-cli as a Provider
+
+## Overview
+
+This design adds Roo Code CLI (`roo`) as a new backend provider in ralph-orchestrator, following the same adapter pattern used by kiro, claude, gemini, and other existing backends. The integration uses **text mode** (plain stdout capture) for simplicity and reliability, with `--prompt-file` for prompt passing.
+
+Roo is an AI coding assistant CLI (v0.1.15+) that supports multiple LLM providers (Anthropic, OpenAI, AWS Bedrock, OpenRouter, etc.) and features tool auto-approval by default, making it well-suited for Ralph's autonomous loop.
+
+## Detailed Requirements
+
+### Functional Requirements
+
+1. **Headless execution**: `roo --print --ephemeral --prompt-file <path>` runs roo in non-interactive mode with clean disk state, reads prompt from file, executes, and exits
+2. **Interactive execution**: `roo "prompt"` launches roo's TUI for `ralph plan` use
+3. **Extra args passthrough**: Users configure model, provider, AWS flags via `cli.args` in ralph.yml
+4. **Auto-detection**: `roo --version` checks if roo is available in PATH
+5. **Preset file**: `presets/minimal/roo.yml` provides a ready-to-use configuration
+
+### Non-Functional Requirements
+
+1. **Text output format**: Plain text capture (like kiro, gemini, codex)
+2. **Pipe mode**: `pty_mode: false` for clean output without ANSI codes
+3. **Standard error handling**: Exit codes + event tags + LOOP_COMPLETE token
+4. **No roo-specific parsing**: No custom error detection or output processing
+
+## Out of Scope
+
+- **Stream-JSON support**: Roo's `--output-format stream-json` provides structured NDJSON with cost/token tracking. Deferred to future enhancement.
+- **`--ephemeral` issue**: Previously broke Bedrock authentication, now fixed in roo v0.1.15+. Included in defaults.
+- **Roo mode integration**: Ralph hats don't map to roo `--mode` flags. Users configure via `cli.args`.
+- **Custom RooStreamParser**: Not needed for text mode. Required only if stream-json is added later.
+- **Roo session management**: No `--continue` or `--session-id` usage. Each iteration is a fresh invocation.
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    Config["ralph.yml<br/>cli.backend: 'roo'"] --> CliBackend["CliBackend::from_config()"]
+    CliBackend --> |"roo --print --ephemeral --prompt-file tmp"| CliExecutor["CliExecutor<br/>(pipe-based)"]
+    CliBackend --> |"roo prompt"| PtyExecutor["PtyExecutor<br/>(interactive)"]
+    CliExecutor --> Output["Text output<br/>parsed for events"]
+    PtyExecutor --> TUI["User interacts<br/>with roo TUI"]
+    
+    subgraph "Auto-Detection"
+        AutoDetect["detect_backend()"] --> |"roo --version"| Check["is_backend_available()"]
+        Check --> |"exit 0"| Found["Backend: roo"]
+    end
+    
+    subgraph "Config Flow"
+        UserConfig["User ralph.yml"] --> |"cli.args"| MergedArgs["--provider bedrock<br/>--aws-profile ...<br/>--model ..."]
+        Preset["presets/minimal/roo.yml"] --> UserConfig
+    end
+```
+
+## Components and Interfaces
+
+### 1. Backend Definition (`cli_backend.rs`)
+
+Two new methods on `CliBackend`:
+
+#### `roo()` — Headless mode
+```rust
+pub fn roo() -> Self {
+    Self {
+        command: "roo".to_string(),
+        args: vec!["--print".to_string(), "--ephemeral".to_string()],
+        prompt_mode: PromptMode::Arg,      // Uses --prompt-file in build_command
+        prompt_flag: None,                  // Positional prompt (small) or --prompt-file (large)
+        output_format: OutputFormat::Text,
+        env_vars: vec![],
+    }
+}
+```
+
+#### `roo_interactive()` — Interactive mode
+```rust
+pub fn roo_interactive() -> Self {
+    Self {
+        command: "roo".to_string(),
+        args: vec![],
+        prompt_mode: PromptMode::Arg,
+        prompt_flag: None,                  // Positional prompt
+        output_format: OutputFormat::Text,
+        env_vars: vec![],
+    }
+}
+```
+
+### 2. Prompt Handling via `--prompt-file` (`build_command()`)
+
+Roo natively supports `--prompt-file <path>`. **All roo prompts** are passed via `--prompt-file` (not positional args). This is simpler than conditional logic — one code path, no size threshold, verified working for both small and large prompts.
+
+`build_command()` will:
+1. Write prompt to a `NamedTempFile`
+2. Add `--prompt-file <path>` to args (no positional prompt)
+3. Return the temp file handle to keep it alive during execution
+
+```rust
+// In build_command() for roo:
+if self.command == "roo" {
+    // Always write prompt to temp file and use --prompt-file
+    match NamedTempFile::new() {
+        Ok(mut file) => {
+            file.write_all(prompt.as_bytes())?;
+            args.push("--prompt-file".to_string());
+            args.push(file.path().display().to_string());
+            (None, Some(file))
+        }
+        Err(_) => {
+            // Fallback to positional arg if temp file fails
+            args.push(prompt.to_string());
+            (None, None)
+        }
+    }
+}
+```
+
+This is cleaner than Claude's workaround (which writes a temp file and tells the agent "please read file X"). Roo reads the file directly as a native CLI feature.
+
+### 3. Registration Points
+
+| Location | Change |
+|----------|--------|
+| `from_config()` | Add `"roo" => Self::roo()` match arm |
+| `from_name()` | Add `"roo" => Ok(Self::roo())` match arm |
+| `for_interactive_prompt()` | Add `"roo" => Ok(Self::roo_interactive())` match arm |
+| `filter_args_for_interactive()` | Add `"roo"` arm that removes `--print` and `--ephemeral` |
+
+### 4. Auto-Detection (`auto_detect.rs`)
+
+| Change | Value |
+|--------|-------|
+| `DEFAULT_PRIORITY` | Append `"roo"` at end |
+| `detection_command("roo")` | Returns `"roo"` (no mapping needed, unlike kiro→kiro-cli) |
+| `NoBackendError` display | Add `"• Roo CLI: https://github.com/RooVetGit/Roo-Code"` |
+
+### 5. Preset File (`presets/minimal/roo.yml`)
+
+Mirrors the kiro preset pattern:
+
+```yaml
+# Ralph Orchestrator Configuration for Roo Code CLI
+# v2 nested format - optimized for Roo CLI
+
+# Event loop settings
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400      # 4 hours
+  max_consecutive_failures: 5
+
+# CLI backend settings
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  pty_interactive: true
+  idle_timeout_secs: 30
+
+# Core behaviors
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - save learnings to memories for next time"
+    - "Don't assume 'not implemented' - search first"
+    - "Verification is mandatory - tests/typecheck/lint/audit must pass"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document; <50 choose safe default + document."
+
+hats:
+  builder:
+    name: "Builder"
+    description: "Implements code, creates files, runs tests. Does the actual work."
+    triggers: ["build.task"]
+    publishes: ["build.done", "build.blocked"]
+    instructions: |
+      ## WORKFLOW
+      You are Builder. Your job is to IMPLEMENT - write code, create files, run tests.
+      1. Read the build.task event payload - that's your task
+      2. IMPLEMENT: Create files, write code, run commands
+      3. VERIFY: Run tests/builds to confirm it works
+      4. COMPLETE: Emit build.done when verified, or build.blocked if stuck
+      RULES:
+      - Do the actual work - don't just plan or delegate
+      - Never emit build.task (that's for coordination, not you)
+```
+
+## Data Models
+
+No new data models needed. The existing `CliBackend`, `OutputFormat`, `PromptMode`, and `HatBackend` types are sufficient.
+
+## Error Handling
+
+Standard Ralph error handling applies with one important caveat:
+
+Roo's exit code behavior varies by error type (verified via live testing):
+
+| Error Type | Exit Code | Behavior |
+|-----------|-----------|----------|
+| **Config error** (invalid provider) | **1** | Exits immediately |
+| **API auth error** (invalid key) | **Never exits** | Retries indefinitely, `--exit-on-error` doesn't stop retries |
+| **Success** | **0** | Exits normally |
+
+Ralph's error detection handles all cases:
+
+- **Config errors** → Non-zero exit code → Ralph detects failure immediately
+- **API auth errors** → Roo retries indefinitely → Ralph's **idle timeout** kills the process → counted as failure
+- **No events emitted** → Consecutive failure counter increments (primary detection)
+- **LOOP_COMPLETE not found** → Loop continues to next iteration, failure counter increments
+- **Max consecutive failures** → Loop terminates after N iterations without events
+
+No roo-specific error detection or parsing needed.
+
+## Testing Strategy
+
+### Unit Tests (in `cli_backend.rs`)
+
+| Test | Validates |
+|------|-----------|
+| `test_roo_backend` | `roo()` produces `roo --print --ephemeral --prompt-file <path>` |
+| `test_roo_interactive` | `roo_interactive()` produces `roo "prompt"` |
+| `test_from_name_roo` | `from_name("roo")` returns correct backend |
+| `test_from_config_roo` | Config `backend: "roo"` creates correct backend |
+| `test_from_config_roo_with_args` | Extra args (model, provider) are appended |
+| `test_for_interactive_prompt_roo` | Interactive factory returns `roo_interactive()` |
+| `test_roo_interactive_mode_removes_print` | `build_command("prompt", true)` removes `--print` and `--ephemeral` |
+
+### Unit Tests (in `auto_detect.rs`)
+
+| Test | Validates |
+|------|-----------|
+| `test_detection_command_roo` | `detection_command("roo")` returns `"roo"` |
+| `test_default_priority_includes_roo` | "roo" in `DEFAULT_PRIORITY` |
+| `test_default_priority_roo_is_last` | "roo" is last in priority |
+
+### Integration Test (manual)
+
+```bash
+# Verify roo backend works end-to-end
+ralph run -b roo -- --provider bedrock --aws-profile roo-bedrock \
+  --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 \
+  --max-tokens 64000 -p "Create a hello.txt file with 'Hello World'"
+```
+
+## Key Learnings (verified via live testing)
+
+1. **Conversation history clears between iterations** — Each `roo --print` is a fresh process. Second invocation reports "I have no memory of previous conversations."
+2. **`--ephemeral` now works with Bedrock** — Fixed in roo v0.1.15+. Previously broke Bedrock auth by using temp dir that lost provider settings.
+3. **Tool auto-approval is roo's default** — No `--trust-all-tools` equivalent needed. File write/read executed without any approval flag.
+4. **`--prompt-file` is native** — Verified working with 7530-char prompt. Cleaner than Claude's temp-file workaround.
+5. **Roo exit codes are nuanced** — Config errors exit 1 ✅. API auth errors cause infinite retry (never exits) — Ralph's idle timeout handles this. Success exits 0 ✅.
+6. **Event tags work with proper context** — Roo refuses bare "output this text" prompts as injection attacks, but cooperates when event protocol is part of system instructions (as Ralph provides).
+7. **Roo outputs `[task complete]`** — Not parsed by Ralph, but useful for debugging.
+
+## Appendices
+
+### Technology Choices
+
+| Choice | Rationale |
+|--------|-----------|
+| Text mode | Simple, proven (6/9 providers use it), no parser needed |
+| `--prompt-file` | Native roo support, cleaner than positional args for large prompts |
+| Pipe mode | Clean output, no ANSI codes, easier event parsing |
+| `--ephemeral` included | Clean disk state, fixed in roo v0.1.15+ to work with Bedrock |
+
+### Alternative Approaches Considered
+
+1. **Stream-JSON mode**: Would provide cost tracking, token usage, tool-use visibility. Deferred due to: (a) roo's format is different from Claude/Pi requiring a new parser, (b) roo CLI is still evolving (v0.1.15), (c) text mode is proven and sufficient.
+
+2. **No `--ephemeral`**: Initially considered because `--ephemeral` broke Bedrock auth. Now fixed in roo v0.1.15+, so `--ephemeral` is included by default for clean disk state.
+
+3. **Roo mode mapping**: Ralph hats → roo `--mode`. Rejected as over-engineering; users can set `--mode` via `cli.args` if needed.
+
+4. **Custom roo mode for Ralph**: Creating a dedicated roo mode with Ralph-specific system instructions. Rejected — roo's default "code" mode provides all necessary tool groups and its system prompt complements Ralph's user prompt.
+
+### Research References
+
+- [roo CLI interface research](./../research/roo-cli-interface.md)
+- [Ralph adapter system research](./../research/ralph-adapter-system.md)  
+- [Text vs stream-json analysis](./../research/text-vs-stream-json.md)

--- a/.agents/planning/2026-03-03-roo-cli-provider/idea-honing.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/idea-honing.md
@@ -1,0 +1,146 @@
+# Idea Honing: roo-cli Provider
+
+Requirements clarification through Q&A.
+
+---
+
+## Q1: Output Format — Text-only or Stream-JSON?
+
+Roo CLI supports two modes Ralph could integrate with:
+
+1. **Text mode** (`roo --print "prompt"`) — Simple text output, like kiro. Easiest to implement but no real-time streaming, cost tracking, or tool-use visibility.
+2. **Stream-JSON mode** (`roo --print --output-format stream-json "prompt"`) — Rich NDJSON streaming with deltas, tool_use events, cost data, and thinking events. Requires a new `RooStreamParser` (similar to how Pi has `PiStreamParser`).
+
+**Which approach should we take?**
+
+**A1**: Text mode only — simple, fast, proven by 6/9 providers. Add stream-json later if needed. The output format will be `OutputFormat::Text`, like kiro/gemini/codex/amp/copilot/opencode.
+
+---
+
+## Q2: Headless Command — What flags should the roo headless backend use?
+
+Based on research, `roo --print "prompt"` runs headless and exits. But we need to decide on additional flags:
+
+- `--print` — Required for non-interactive exit
+- `--ephemeral` — Run without persisting state? (Prevents roo from accumulating task history across Ralph iterations)
+- `--require-approval` — Should this default to false (auto-approve tools)?
+
+The default model is `anthropic/claude-opus-4.6` but the user's working config uses `--provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000`. Should model/provider be configured via ralph.yml `cli.args` or baked into the backend defaults?
+
+**A2**: Use `--ephemeral` as default. Headless command: `roo --print --ephemeral "prompt"`.
+- Tool auto-approval is already the default in roo (`--require-approval` defaults to false), so no additional flag needed (unlike kiro's `--trust-all-tools`)
+- Model/provider configured via `cli.args` in ralph.yml — not baked into the backend
+- Extra args from ralph.yml are always appended (existing pattern in `from_config()`)
+
+---
+
+## Q3: Interactive Mode — What should `roo_interactive()` look like?
+
+For `ralph plan` and PTY interactive mode, we need a variant that removes headless flags and lets the user interact with roo's TUI. Following the pattern of other backends:
+
+- Kiro interactive: removes `--no-interactive`
+- Claude interactive: removes `-p` flag
+- For roo: remove `--print` and `--ephemeral`
+
+Proposed interactive command: `roo "prompt"` (just positional arg, no flags)
+
+**A3**: Both modes needed.
+- **Headless** (`ralph run`): `roo --print --ephemeral "prompt"`
+- **Interactive** (`ralph plan`): `roo "prompt"` (no `--print`, no `--ephemeral`)
+
+---
+
+## Q4: Auto-Detection Priority — Where should "roo" be in the detection order?
+
+The current `DEFAULT_PRIORITY` is: `["claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi"]`
+
+Where should "roo" go? The detection command would check `roo --version`.
+
+**A4**: At the end of the priority list. New order: `["claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi", "roo"]`. Only auto-detected as fallback if nothing else is available. Detection command: `roo --version`.
+
+---
+
+## Q5: Preset Configuration — What should the minimal roo preset look like?
+
+Should the `presets/minimal/roo.yml` just mirror the kiro preset pattern (same hats, guardrails) but with `cli.backend: "roo"`? Or should it include roo-specific defaults like `--provider` and `--model` flags?
+
+**A5**: Mirror kiro preset pattern — same hats (builder), same guardrails, just `cli.backend: "roo"` with empty `cli.args: []`. No model/provider baked in. User configures model/provider via their `ralph.yml` `cli.args` or CLI `-- ...` flags.
+
+---
+
+## Q6: Scope Confirmation — Is this everything?
+
+Based on our discussion, the full scope is:
+1. **Backend definitions**: `roo()` headless and `roo_interactive()` in `cli_backend.rs`
+2. **Registration points**: `from_config()`, `from_name()`, `for_interactive_prompt()`, `from_hat_backend()`
+3. **Auto-detection**: Add "roo" at end of `DEFAULT_PRIORITY`, `detection_command("roo") → "roo"`
+4. **Error display**: Add roo install URL in `NoBackendError`
+5. **Preset file**: `presets/minimal/roo.yml`
+6. **Tests**: Unit tests for all new backend functions
+7. **Documentation**: Update `lib.rs` doc comment to include Roo
+
+Anything else?
+
+---
+
+## Q7: Large Prompts — How should roo handle prompts >7000 chars?
+
+Claude has a special case: when prompts exceed 7000 characters, Ralph writes the prompt to a temp file and tells Claude to read it. This is because long CLI arguments can fail on some systems.
+
+Roo has `--prompt-file <path>` which reads a prompt from a file — verified working.
+
+**Historical note**: Initially `--ephemeral` broke Bedrock auth, but this was fixed in roo v0.1.15+. `--ephemeral` is now included in the default backend.
+
+**A7**: Always use `--prompt-file` for all prompts. One code path, no size threshold — write prompt to temp file, pass `--prompt-file <path>`. Roo handles it natively. Simpler than conditional logic, verified working for both small and large prompts.
+
+---
+
+## Q8: PTY Mode — Should roo support PTY mode (`pty_mode: true`)?
+
+Ralph's PTY mode runs the CLI tool in a pseudo-terminal, preserving rich TUI features (colors, spinners). This is used for:
+- `ralph run` with TUI display (ratatui-based)
+- Interactive sessions
+
+Kiro uses `pty_mode: false` by default. Claude uses PTY for its TUI. Should roo default to `pty_mode: false` or `true`?
+
+**A8**: `pty_mode: false` (pipe mode). Roo with `--print` outputs clean text, PTY adds unnecessary ANSI complexity. 6/9 providers use pipe mode. User can enable PTY via config if needed.
+
+---
+
+## Q9: Error Handling — How should roo failures be detected?
+
+With text mode, Ralph detects failures via:
+1. **Exit code** — non-zero means failure
+2. **LOOP_COMPLETE token** — agent emits this when done
+3. **Event tags** — `<event topic="build.done">` etc.
+
+Should we add any roo-specific error detection? For example, roo outputs `[task complete]` when done and `Error:` lines when failing. Should Ralph parse these?
+
+**A9**: No roo-specific error handling. Use standard Ralph mechanisms (exit code + event tags + LOOP_COMPLETE). Keep it simple.
+
+---
+
+## Q10: Roo Modes — Should the backend support `--mode` flag?
+
+Roo has a `--mode` flag (`code`, `architect`, `ask`, `debug`, etc.). Ralph's hat system conceptually overlaps with roo modes — for example, the "Builder" hat could map to `--mode code`, while a "Planner" hat could use `--mode architect`.
+
+Should we support passing `--mode` through the backend, or leave it for users to configure via `cli.args`?
+
+**A10**: Leave it for users to configure via `cli.args`. Roo defaults to `--mode code` which is the right default for Ralph's builder hat. Users can override in their ralph.yml if needed.
+
+---
+
+## Requirements Clarification Complete
+
+All key decisions have been made. Summary of confirmed requirements:
+
+1. **Output format**: Text mode only (like kiro)
+2. **Headless command**: `roo --print --ephemeral "prompt"` (both flags included)
+3. **Prompt passing**: Always use `--prompt-file` for all prompts (one code path, simpler)
+4. **Interactive mode**: `roo "prompt"` (for `ralph plan`, no `--print`/`--ephemeral`)
+5. **Auto-detection**: "roo" at end of priority list
+6. **Preset**: Mirror kiro pattern, no model/provider baked in
+7. **PTY mode**: `pty_mode: false` (pipe mode)
+8. **Error handling**: Standard Ralph mechanisms, no roo-specific parsing. Note: roo always exits 0, even on errors.
+9. **Roo modes/provider/model**: Configured via `cli.args`, not baked into backend
+10. **Event tags**: Work correctly when Ralph provides event protocol as system instructions

--- a/.agents/planning/2026-03-03-roo-cli-provider/implementation/plan.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/implementation/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Add roo-cli as a Provider
+
+## Checklist
+
+- [ ] Step 1: Add roo backend definitions to `cli_backend.rs`
+- [ ] Step 2: Register roo in all dispatch points
+- [ ] Step 3: Add `--prompt-file` support for all prompts
+- [ ] Step 4: Add auto-detection support
+- [ ] Step 5: Create preset file
+- [ ] Step 6: Update documentation
+- [ ] Step 7: Post-Implementation Validation
+
+---
+
+## Step 1: Add roo backend definitions to `cli_backend.rs`
+
+**Objective**: Create `roo()` and `roo_interactive()` methods on `CliBackend` with unit tests.
+
+**Implementation guidance**:
+- Add `roo()` method returning `CliBackend` with `command: "roo"`, `args: ["--print", "--ephemeral"]`, `prompt_mode: PromptMode::Arg`, `prompt_flag: None`, `output_format: OutputFormat::Text`, `env_vars: []`
+- Add `roo_interactive()` method returning `CliBackend` with `command: "roo"`, `args: []`, `prompt_mode: PromptMode::Arg`, `prompt_flag: None`, `output_format: OutputFormat::Text`, `env_vars: []`
+- Follow the exact pattern of existing backends (kiro, pi, opencode)
+
+**Test requirements**:
+- `test_roo_backend()`: Verify `roo()` produces `roo --print --ephemeral --prompt-file <path>` via `build_command()` (prompt written to temp file)
+- `test_roo_interactive()`: Verify `roo_interactive()` produces `roo "test prompt"`
+- `test_env_vars_default_empty`: Add `CliBackend::roo()` to the existing env_vars emptiness test
+
+**Integration with previous work**: This is the foundation — all subsequent steps build on these definitions.
+
+**Demo**: `cargo test -p ralph-adapters test_roo_backend` passes. The `roo()` and `roo_interactive()` constructors return correct `CliBackend` configurations.
+
+---
+
+## Step 2: Register roo in all dispatch points
+
+**Objective**: Wire `roo` into all the places where backends are resolved from config/names.
+
+**Implementation guidance**:
+- In `from_config()` (line ~69): Add `"roo" => Self::roo()` match arm
+- In `from_name()` (line ~235): Add `"roo" => Ok(Self::roo())` match arm
+- In `for_interactive_prompt()` (line ~388): Add `"roo" => Ok(Self::roo_interactive())` match arm
+- In `filter_args_for_interactive()` (line ~662): Add `"roo"` arm that filters `--print` and `--ephemeral` flags
+
+**Test requirements**:
+- `test_from_name_roo()`: `CliBackend::from_name("roo")` returns backend with command "roo"
+- `test_from_config_roo()`: Config `{ backend: "roo" }` creates correct backend
+- `test_from_config_roo_with_args()`: Config with `args: ["--provider", "bedrock", "--model", "anthropic.claude-sonnet-4-6"]` appends correctly
+- `test_for_interactive_prompt_roo()`: Factory returns `roo_interactive()` and builds correct command
+- `test_roo_interactive_mode_removes_print()`: `build_command("prompt", true)` removes `--print` from args
+
+**Integration with previous work**: Uses `roo()` and `roo_interactive()` from Step 1.
+
+**Demo**: `cargo test -p ralph-adapters from_name_roo` and `cargo test -p ralph-adapters from_config_roo` both pass. Running `ralph run -b roo --dry-run` (if available) shows the correct command would be spawned.
+
+---
+
+## Step 3: Add `--prompt-file` support for all prompts
+
+**Objective**: All roo prompts are passed via `--prompt-file` (one code path, no size threshold).
+
+**Implementation guidance**:
+- In `build_command()`, after the existing Claude large-prompt handling block, add a block for roo:
+  ```
+  if self.command == "roo" {
+      // Always write prompt to temp file
+      // Add --prompt-file <path> to args (no positional prompt)
+      // Return temp file handle to keep it alive
+  }
+  ```
+- This is simpler than conditional logic — one path, no 7000-char threshold
+- Roo natively reads from `--prompt-file` (verified working for both small and large prompts)
+- Fallback to positional arg only if temp file creation fails
+
+**Test requirements**:
+- `test_roo_uses_prompt_file()`: Any prompt results in `--prompt-file` arg and temp file
+- `test_roo_prompt_file_content()`: Verify temp file contains the full prompt text
+- `test_roo_prompt_file_fallback()`: Verify positional arg is used if temp file creation fails
+
+**Integration with previous work**: Modifies `build_command()` which uses `roo()` backend from Step 1.
+
+**Demo**: `cargo test -p ralph-adapters test_roo_uses_prompt_file` passes. All prompts use `--prompt-file`.
+
+---
+
+## Step 4: Add auto-detection support
+
+**Objective**: Enable `roo` in auto-detection when `cli.backend: auto` is configured.
+
+**Implementation guidance**:
+- In `auto_detect.rs`, add `"roo"` at the end of `DEFAULT_PRIORITY` array
+- `detection_command("roo")` should return `"roo"` (default behavior, no special mapping needed)
+- In `NoBackendError::fmt()`, add `"  • Roo CLI:      https://github.com/RooVetGit/Roo-Code"` to the install suggestions
+
+**Test requirements**:
+- `test_detection_command_roo()`: `detection_command("roo")` returns `"roo"`
+- `test_default_priority_includes_roo()`: `DEFAULT_PRIORITY` contains `"roo"`
+- `test_default_priority_roo_after_pi()`: "roo" comes after "pi" (last position)
+- Update `test_no_backend_error_display()`: Verify error message includes "Roo CLI"
+
+**Integration with previous work**: Independent of Steps 1-3. Uses only `auto_detect.rs`.
+
+**Demo**: `cargo test -p ralph-adapters detection_command_roo` passes. The error message for missing backends includes roo.
+
+---
+
+## Step 5: Create preset file
+
+**Objective**: Create `presets/minimal/roo.yml` as a ready-to-use configuration.
+
+**Implementation guidance**:
+- Copy `presets/minimal/kiro.yml` as the starting point
+- Change `cli.backend` from `"kiro"` to `"roo"`
+- Keep all other settings identical (event_loop, core guardrails, hats)
+- Update the comment header to reference Roo Code CLI
+
+**Test requirements**:
+- Verify YAML is valid: `python3 -c "import yaml; yaml.safe_load(open('presets/minimal/roo.yml'))"`
+- Verify `cli.backend` is `"roo"` in the file
+
+**Integration with previous work**: Uses the backend name registered in Steps 1-2.
+
+**Demo**: `cat presets/minimal/roo.yml` shows a valid configuration. `ralph run --preset roo -- --provider bedrock ...` would use roo as the backend.
+
+---
+
+## Step 6: Update documentation
+
+**Objective**: Update code documentation to reflect roo as a supported backend.
+
+**Implementation guidance**:
+- In `crates/ralph-adapters/src/lib.rs`, update the crate-level doc comment to include `- Roo (Roo Code)` in the list of supported backends
+- Ensure all new public methods have doc comments explaining their purpose
+
+**Test requirements**:
+- `cargo doc -p ralph-adapters --no-deps` completes without warnings
+
+**Integration with previous work**: References all work from Steps 1-5.
+
+**Demo**: `cargo doc` builds cleanly. The ralph-adapters documentation lists Roo as a supported backend.
+
+---
+
+## Step 7: Post-Implementation Validation
+
+**Objective**: Verify the complete implementation works end-to-end.
+
+**Validation checklist**:
+- [ ] `cargo test -p ralph-adapters` — All tests pass (existing + new roo tests)
+- [ ] `cargo test` — Full project test suite passes (no regressions)
+- [ ] `cargo build` — Clean build with no warnings
+- [ ] `cargo doc -p ralph-adapters --no-deps` — Documentation builds cleanly
+- [ ] YAML validation: `presets/minimal/roo.yml` is valid
+- [ ] Manual E2E (if roo is configured): `ralph run -b roo -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 -p "Create hello.txt with Hello World"` completes at least one iteration
+
+**Demo**: Full end-to-end demonstration:
+1. Show `cargo test -p ralph-adapters` with all roo tests passing
+2. Show `presets/minimal/roo.yml` contents
+3. Show `ralph run -b roo` starting and executing an iteration with roo backend

--- a/.agents/planning/2026-03-03-roo-cli-provider/research/assumption-validation.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/research/assumption-validation.md
@@ -1,0 +1,53 @@
+# Research: Assumption Validation Tests
+
+All assumptions tested with live roo CLI invocations.
+
+## Test Results (Round 1 — pre-fix)
+
+| # | Assumption | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | `roo --print` works for headless | ✅ Verified | Produces text output and exits |
+| 2 | `--prompt-file` works for large prompts | ✅ Verified | 7530-char prompt read from file successfully |
+| 3 | `roo --version` for auto-detection | ✅ Verified | Returns "0.1.15" with exit code 0 |
+| 4 | Conversation clears between iterations | ✅ Verified | Second invocation: "I have no memory of previous conversations" |
+| 5 | Tool auto-approval is default | ✅ Verified | File write + read executed without any approval flag |
+| 6 | Exit code 0 on success | ✅ Verified | Successful task returns exit code 0 |
+| 7 | Event tags work with proper context | ✅ Verified | With Ralph-style system instructions, roo emits `<event>` tags and LOOP_COMPLETE correctly |
+| 8 | `--ephemeral` breaks Bedrock | ✅ Verified | Cross-region inference error with ephemeral, works without |
+| 9 | Exit code on API errors | ⚠️ Finding | Roo exits 0 even on API failure. Ralph must rely on LOOP_COMPLETE/event presence, not exit codes. |
+
+## Test Results (Round 2 — after roo fixes)
+
+Issues 1 (exit codes) and 2 (--ephemeral + Bedrock) were fixed in roo. Re-ran validation:
+
+| # | Test | Result | Evidence |
+|---|------|--------|----------|
+| 1 | `--ephemeral` + Bedrock | ✅ **FIXED** | `roo --print --ephemeral` now works with Bedrock. Output: `[assistant] Hello!` |
+| 2 | `--prompt-file` + `--ephemeral` | ✅ Verified | Large prompt via file + ephemeral mode works |
+| 3 | Event tags + `--ephemeral` | ✅ Verified | `<event topic="build.done">` and `LOOP_COMPLETE` emitted correctly in ephemeral mode |
+| 4 | Exit codes on errors | ⚠️ Still exits 0 | Invalid provider, bad API key still exit 0. Not a blocker — Ralph uses LOOP_COMPLETE detection. |
+
+### Updated Design Decision
+With `--ephemeral` fixed, the default headless command is now: `roo --print --ephemeral "prompt"` — clean disk state between iterations.
+
+## Key Findings
+
+### Finding 1: Event Tag Emission (Assumption 7)
+Roo has built-in prompt injection detection. A bare "output this text" prompt with event tags is **refused** as a prompt injection attack. However, when the event protocol is provided as part of system instructions (as Ralph does), roo cooperates and emits event tags correctly.
+
+**Implication**: The Ralph prompt format (with `## EVENT PROTOCOL` instructions) already works correctly with roo. No changes needed.
+
+### Finding 2: Exit Code Always 0 (Assumption 9)
+Roo exits with code 0 even when:
+- API errors occur (Bedrock cross-region)
+- `--exit-on-error` is specified
+
+**Implication**: Ralph cannot use exit codes to detect roo failures. This is fine because Ralph's primary failure detection is via:
+1. **Missing LOOP_COMPLETE token** → consecutive failure counter increments
+2. **Missing event tags** → no events published → backpressure detects staleness
+3. **Idle timeout** → roo process stuck retrying → Ralph kills it
+
+### Finding 3: --ephemeral + Bedrock (Assumption 8)
+`--ephemeral` causes roo to use a temp directory for storage, losing access to persisted Bedrock settings (cross-region inference config). This causes API failures.
+
+**Implication**: `--ephemeral` must not be a default flag. Users on non-Bedrock providers (Anthropic direct, OpenRouter) might use it safely via `cli.args`.

--- a/.agents/planning/2026-03-03-roo-cli-provider/research/ralph-adapter-system.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/research/ralph-adapter-system.md
@@ -1,0 +1,99 @@
+# Research: Ralph Adapter System (Existing Codebase)
+
+## Architecture Overview
+
+Ralph supports multiple CLI backends through a layered adapter system:
+
+```mermaid
+graph TD
+    Config["ralph.yml<br>cli.backend: 'roo'"] --> CliBackend["CliBackend::from_config()"]
+    CliBackend --> |Text| CliExecutor["CliExecutor<br>(pipe-based)"]
+    CliBackend --> |StreamJson| PtyExecutor["PtyExecutor<br>(PTY-based)"]
+    CliBackend --> |Acp| AcpExecutor["AcpExecutor<br>(JSON-RPC stdio)"]
+    PtyExecutor --> StreamHandler["StreamHandler trait"]
+    StreamHandler --> Console["ConsoleStreamHandler"]
+    StreamHandler --> Pretty["PrettyStreamHandler"]
+    StreamHandler --> Tui["TuiStreamHandler"]
+    StreamHandler --> Quiet["QuietStreamHandler"]
+```
+
+## Key Files to Modify
+
+| File | Purpose | What to Add |
+|------|---------|-------------|
+| `crates/ralph-adapters/src/cli_backend.rs` | Backend definitions | `roo()`, `roo_interactive()` methods |
+| `crates/ralph-adapters/src/auto_detect.rs` | PATH detection | Add "roo" to `DEFAULT_PRIORITY`, `detection_command()` |
+| `crates/ralph-adapters/src/pty_executor.rs` | PTY streaming | Add roo stream format handling |
+| `presets/minimal/roo.yml` | Preset config | New preset file |
+
+## Backend Registration Points
+
+A new backend must be registered in these locations in `cli_backend.rs`:
+
+1. **`from_config()`** — Maps config string to backend constructor (line 69-81)
+2. **`from_name()`** — Maps name string to backend (line 235-248)
+3. **`from_hat_backend()`** — Maps HatBackend enum variant (line 254-280)
+4. **`for_interactive_prompt()`** — Interactive mode factory (line 388-399)
+
+## Output Format Dispatch
+
+The `OutputFormat` enum (4 variants) determines execution strategy:
+
+| Format | Executor | Parser | Used By |
+|--------|----------|--------|---------|
+| `Text` | CliExecutor or PtyExecutor | Raw text | kiro, gemini, codex, amp, copilot, opencode |
+| `StreamJson` | PtyExecutor | `ClaudeStreamParser` | claude |
+| `PiStreamJson` | PtyExecutor | `PiStreamParser` | pi |
+| `Acp` | `AcpExecutor` | JSON-RPC handler | kiro-acp |
+
+## Auto-Detection System
+
+- `DEFAULT_PRIORITY`: `["claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi"]`
+- `detection_command()` maps backend names to CLI binaries (e.g., "kiro" → "kiro-cli")
+- Detection runs `<command> --version` and checks exit code 0
+
+## Preset File Pattern (from `presets/minimal/kiro.yml`)
+
+```yaml
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400
+  max_consecutive_failures: 5
+
+cli:
+  backend: "kiro"
+  prompt_mode: "arg"
+  pty_mode: false
+  pty_interactive: true
+  idle_timeout_secs: 30
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration..."
+    - ...
+
+hats:
+  builder:
+    name: "Builder"
+    ...
+```
+
+## HatBackend Enum
+
+From `ralph-core`, the `HatBackend` enum supports:
+- `Named(String)` — Simple named backend
+- `NamedWithArgs { backend_type, args }` — Named with extra CLI args
+- `KiroAgent { backend_type, agent, args }` — Kiro-specific agent selection
+- `Custom { command, args }` — Fully custom command
+
+## Stream Parser Integration
+
+For **text-mode** backends (like kiro), no stream parser is needed — raw stdout is captured.
+
+For **stream-json** backends (like claude), `ClaudeStreamParser` processes NDJSON events into `StreamHandler` calls.
+
+For **pi**, `PiStreamParser` does the same with Pi's NDJSON format.
+
+Roo's stream-json format is **different from both Claude and Pi**, so a new `RooStreamParser` would be needed for stream-json support.

--- a/.agents/planning/2026-03-03-roo-cli-provider/research/roo-cli-interface.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/research/roo-cli-interface.md
@@ -1,0 +1,177 @@
+# Research: roo-cli Interface & Stream Format
+
+## CLI Binary & Version
+
+- **Binary name**: `roo` (installed via npm at `/Users/skven/.local/share/mise/installs/node/20.20.0/bin/roo`)
+- **Version**: 0.1.15
+- **Source**: `/Users/skven/workplace/Roo-Code/apps/cli/`
+
+## CLI Flags (from `roo --help`)
+
+### Core Execution Flags
+| Flag | Description |
+|------|-------------|
+| `prompt` (positional) | Your prompt |
+| `-p, --print` | Print response and exit (non-interactive mode) |
+| `--output-format <format>` | "text" (default), "json" (single result), or "stream-json" (realtime streaming) |
+| `--ephemeral` | Run without persisting state (uses temporary storage) |
+| `--oneshot` | Exit upon task completion |
+| `-w, --workspace <path>` | Workspace directory path |
+| `-a, --require-approval` | Require manual approval for actions (default: false) |
+| `-e, --extension <path>` | Path to the extension bundle directory |
+| `-d, --debug` | Enable debug output |
+
+### Model/Provider Flags
+| Flag | Description |
+|------|-------------|
+| `--provider <provider>` | API provider (roo, anthropic, openai, openrouter, etc.) |
+| `-m, --model <model>` | Model to use (default: "anthropic/claude-opus-4.6") |
+| `--max-tokens <n>` | Maximum output tokens |
+| `--max-thinking-tokens <n>` | Maximum thinking/reasoning tokens |
+| `-k, --api-key <key>` | API key for the LLM provider |
+
+### AWS Bedrock Flags
+| Flag | Description |
+|------|-------------|
+| `--aws-region <region>` | AWS region for Bedrock |
+| `--aws-profile <profile>` | AWS profile name |
+| `--aws-custom-arn <arn>` | Custom ARN for Bedrock inference |
+| `--aws-inference-routing <mode>` | none, cross-region, or global |
+| `--aws-bedrock-endpoint <url>` | Custom VPC endpoint URL |
+| `--no-aws-prompt-cache` | Disable prompt caching for Bedrock |
+
+### Mode & Behavior Flags
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | Mode to start in (code, architect, ask, debug, etc.) |
+| `-r, --reasoning-effort <effort>` | Reasoning effort level |
+| `--consecutive-mistake-limit <limit>` | Error/repetition limit |
+| `--exit-on-error` | Exit on API request errors |
+
+### Session Flags
+| Flag | Description |
+|------|-------------|
+| `--session-id <task-id>` | Resume a specific task by task ID |
+| `-c, --continue` | Resume the most recent task |
+| `--prompt-file <path>` | Read prompt from a file |
+
+### Stdin Streaming
+| Flag | Description |
+|------|-------------|
+| `--stdin-prompt-stream` | Read NDJSON commands from stdin (requires --print and --output-format stream-json) |
+| `--signal-only-exit` | Only terminate on SIGINT/SIGTERM (for stdin stream harnesses) |
+
+## Stream-JSON Format
+
+### Protocol
+- Protocol: `roo-cli-stream`
+- Schema version: 1
+- NDJSON (newline-delimited JSON)
+
+### Event Types (from source: `types/json-events.ts`)
+| Type | Description |
+|------|-------------|
+| `system` | Init event, subtypes: `init` |
+| `user` | User prompt echo |
+| `assistant` | Assistant text deltas and complete messages |
+| `thinking` | Reasoning/thinking deltas |
+| `tool_use` | Tool invocation, subtypes: `tool`, `command`, `mcp` |
+| `tool_result` | Tool result, subtypes: `command`, `mcp` |
+| `error` | Error messages |
+| `result` | Task completion (has `success` boolean and `cost` object) |
+| `control` | Control flow events (ack, done, error) |
+| `queue` | Queue management events |
+
+### Example Stream Output (observed)
+```json
+{"type":"system","subtype":"init","content":"Task started","schemaVersion":1,"protocol":"roo-cli-stream","capabilities":["stdin:start","stdin:message","stdin:cancel","stdin:ping","stdin:shutdown"]}
+{"type":"user","id":1772593478580,"content":"Say hello in one sentence","done":true}
+{"type":"assistant","id":1772593481508,"content":"Hello"}
+{"type":"assistant","id":1772593481508,"content":"! Welcome"}
+{"type":"assistant","id":1772593481508,"content":" to the"}
+{"type":"assistant","id":1772593481508,"content":" ralph"}
+{"type":"assistant","id":1772593481508,"content":"-orchest"}
+{"type":"assistant","id":1772593481508,"content":"rator project"}
+{"type":"assistant","id":1772593481508,"content":"."}
+{"type":"assistant","id":1772593481508,"content":"Hello! Welcome to the ralph-orchestrator project.","done":true}
+{"type":"result","id":1772593482878,"content":"Hello! I'm Roo, ready to help you with the ralph-orchestrator project.","done":true,"success":true}
+```
+
+### Key Schema Fields (from `JsonEvent` type)
+```typescript
+type JsonEvent = {
+  type: JsonEventType          // Event discriminator
+  id?: number                  // Message ID for correlation
+  content?: string             // Text content
+  done?: boolean               // Final message flag
+  subtype?: string             // Categorization (e.g., "init", "tool", "command")
+  schemaVersion?: number       // Protocol version (on system.init)
+  protocol?: string            // Transport protocol (on system.init)
+  capabilities?: string[]      // Supported capabilities (on system.init)
+  taskId?: string              // Active task ID
+  requestId?: string           // Correlation ID
+  command?: string             // Command name for control events
+  code?: string                // Machine-readable error code
+  tool_use?: JsonEventToolUse  // Tool call info
+  tool_result?: JsonEventToolResult  // Tool result info
+  success?: boolean            // Task success (result events)
+  cost?: JsonEventCost         // Token/cost usage (result events)
+  queueDepth?: number          // Queue depth
+  queue?: JsonEventQueueItem[] // Queue snapshots
+}
+```
+
+### Cost Structure
+```typescript
+type JsonEventCost = {
+  totalCost: number
+  inputTokens: number
+  outputTokens: number
+  cacheWrites?: number
+  cacheReads?: number
+}
+```
+
+## Comparison with Claude Stream Format
+
+| Feature | Claude (`--output-format stream-json`) | Roo (`--output-format stream-json`) |
+|---------|--------------------------------------|--------------------------------------|
+| Protocol | N/A (flat events) | `roo-cli-stream` v1 |
+| Init event | `system` with session_id, model | `system.init` with capabilities |
+| Text streaming | `assistant` with message.content[] | `assistant` with delta `content` |
+| Tool use | Inside `assistant.message.content` | Separate `tool_use` event |
+| Tool result | `user.message.content` | Separate `tool_result` event |
+| Thinking | Inside `assistant.message.content` | Separate `thinking` event |
+| Completion | `result` with cost, turns | `result` with success, cost |
+| Delta vs Full | Full snapshots per turn | Streaming deltas with `done` flag |
+
+### Key Differences
+1. **Claude** emits full turns (`assistant`, `user`) with all content blocks
+2. **Roo** emits streaming deltas (many small `assistant` events building up content, then a `done:true` final)
+3. **Roo** has separate event types for tool_use and tool_result (Claude embeds in message content blocks)
+4. **Roo** has `thinking` as a separate event type (Claude has it as a content block type)
+5. **Roo** supports bidirectional stdin streaming (`--stdin-prompt-stream`)
+
+## Headless Mode Command (confirmed working)
+```bash
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
+    --model anthropic.claude-sonnet-4-6 --max-tokens 64000 \
+    --print "Say hello in one sentence"
+```
+
+## Mapping to Ralph Adapter Pattern
+
+For a **text-mode** (simplest) integration:
+```
+roo --print <prompt>
+```
+
+For a **stream-json** integration:
+```
+roo --print --output-format stream-json <prompt>
+```
+
+For **interactive** mode:
+```
+roo <prompt>  (no --print flag)
+```

--- a/.agents/planning/2026-03-03-roo-cli-provider/research/text-vs-stream-json.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/research/text-vs-stream-json.md
@@ -1,0 +1,80 @@
+# Research: Text vs Stream-JSON for Roo — Impact on Loop Success
+
+## What the Developer Experiences
+
+### Text Mode (like kiro, gemini, codex, amp, copilot, opencode)
+
+The developer running `ralph run -b roo` sees:
+- **Raw terminal output** — whatever roo prints, streamed to console/TUI
+- **No structured event parsing** — Ralph treats all output as plain text
+- **Event extraction from text** — Ralph uses regex to find `<event topic="...">` tags in the text output
+- **No cost tracking** — Total cost per iteration is unknown
+- **No token counting** — No visibility into input/output tokens or cache hits
+- **No tool-use visibility** — Ralph can't distinguish tool calls from text output in the TUI
+
+### Stream-JSON Mode (like Claude, Pi)
+
+The developer running `ralph run -b roo` would see:
+- **Parsed, structured output** — PrettyStreamHandler renders markdown, tool calls, thinking
+- **Real-time streaming** — Text arrives as deltas, displayed incrementally
+- **Cost tracking** — Each iteration reports `totalCost`, `inputTokens`, `outputTokens`, `cacheReads`, `cacheWrites`
+- **Tool-use visibility** — Tool calls and results are displayed with names and inputs
+- **Thinking/reasoning** — Thinking tokens are shown (in TUI mode) or hidden (in console)
+- **Extracted text** — Clean text is extracted from JSON for event tag parsing (more reliable)
+
+## Impact on Loop Success Rate
+
+### Does stream-json improve loop success?
+
+**No direct impact on success rate.** The agent's behavior is identical regardless of output format — the prompt and agent logic don't change. The loop's success depends on:
+1. The prompt quality
+2. The agent's capability  
+3. Backpressure signals (test failures, lint errors)
+
+**However, stream-json provides significant operational benefits:**
+
+| Capability | Text Mode | Stream-JSON | Impact |
+|-----------|-----------|-------------|--------|
+| **Event tag extraction** | Regex on raw output (fragile) | Clean extracted_text (reliable) | Moderate — more reliable event parsing means fewer "missed events" |
+| **Cost monitoring** | None — no per-iteration cost | Per-iteration cost + totals | High for observability — developer sees burn rate |
+| **Token usage** | None | Input/output/cache tokens | Medium — developer can spot context window issues |
+| **TUI display quality** | Raw text with ANSI codes | Structured markdown rendering | Medium — cleaner display, easier to spot issues |
+| **Error detection** | Parse exit code only | Structured `result.success` + `error` events | Low — exit code is usually sufficient |
+| **Thinking visibility** | Not available | Visible in TUI | Low — nice to have for debugging |
+| **Idle detection** | Same | Same | None — both use process-level idle detection |
+
+### Key Insight: Event Tag Extraction
+
+The most impactful technical difference is **event tag extraction**. Ralph's event system relies on finding `<event topic="build.done">` tags in the agent output. With text mode, these must be found via regex in the raw terminal output (which may contain ANSI escape codes, line wrapping artifacts, etc.). With stream-json, the `extracted_text` field contains clean text extracted from structured events, making event parsing more reliable.
+
+From the code (`loop_runner.rs:3936-3939`):
+```rust
+let output_for_parsing = if pty_result.extracted_text.is_empty() {
+    pty_result.stripped_output    // Text mode: ANSI-stripped raw output
+} else {
+    pty_result.extracted_text    // Stream-JSON: clean extracted text
+};
+```
+
+## Implementation Cost
+
+| Aspect | Text Mode | Stream-JSON |
+|--------|-----------|-------------|
+| New files | 0 | 1 (`roo_stream.rs`) |
+| Lines of code | ~30 (backend defs) | ~200-400 (parser + dispatch) |
+| Test complexity | Low | Medium (parser tests needed) |
+| Maintenance | Low | Medium (must track roo-cli stream format changes) |
+| Time to implement | ~1 hour | ~4-8 hours |
+
+## Recommendation
+
+**Start with text mode, add stream-json later.**
+
+Rationale:
+1. Text mode is proven — 6 of 9 providers use it successfully
+2. The core loop works identically with text mode
+3. Stream-JSON can be added as an enhancement without breaking changes
+4. Roo's stream format is still evolving (v0.1.15) — investing in a parser now may require rework
+5. Text mode gets the feature shipped fast; stream-json is a quality-of-life improvement
+
+**However**, if cost monitoring and clean event extraction are priorities, stream-json is worth the upfront investment.

--- a/.agents/planning/2026-03-03-roo-cli-provider/rough-idea-for-implementation.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/rough-idea-for-implementation.md
@@ -1,0 +1,46 @@
+# Rough Idea: Add roo-cli as a Provider to Ralph Orchestrator
+
+## What
+Add `roo` (Roo Code CLI) as a new backend provider in ralph-orchestrator, enabling `ralph run -b roo` and `ralph plan -b roo`.
+
+## Context
+- Roo Code CLI (`roo`, v0.1.15+) is an AI coding assistant that supports multiple LLM providers (Anthropic, OpenAI, AWS Bedrock, OpenRouter)
+- Roo CLI source is at `/Users/skven/workplace/Roo-Code/apps/cli/`
+- Install: `cd /Users/skven/workplace/Roo-Code/src && pnpm run bundle && cd /Users/skven/workplace/Roo-Code && pnpm --filter @roo-code/cli build && npm install -g ./apps/cli`
+- Binary: `roo` (installed globally via npm)
+
+## Key Decisions (already researched and validated)
+1. **Text mode only** — Use `roo --print --ephemeral "prompt"` (plain text output, like kiro). Stream-JSON deferred to later.
+2. **Always use `--prompt-file`** — Roo natively supports `--prompt-file <path>`. All prompts use this (one code path, no size threshold).
+3. **`--ephemeral` included** — Fixed in roo v0.1.15+ to work with Bedrock. Clean disk state per iteration.
+4. **Tool auto-approval is default** — No `--trust-all-tools` flag needed (unlike kiro).
+5. **Interactive mode**: `roo "prompt"` for `ralph plan`.
+6. **Auto-detect last** in priority: `["claude", "kiro", ..., "pi", "roo"]`.
+7. **Roo always exits code 0** — Even on API errors. Ralph relies on LOOP_COMPLETE/event presence.
+8. **Event tags work** — Roo emits `<event topic="build.done">` and `LOOP_COMPLETE` when Ralph-style system instructions are provided.
+
+## Working Test Commands
+```bash
+# Headless (text mode)
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 --print "Say hello"
+
+# With prompt file
+echo "Your prompt" > /tmp/prompt.txt
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 --print --prompt-file /tmp/prompt.txt
+
+# Stream JSON (for future reference)
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 --print --output-format stream-json "Say hello"
+```
+
+## Files to Modify
+1. `crates/ralph-adapters/src/cli_backend.rs` — Add `roo()`, `roo_interactive()`, registration in `from_config`, `from_name`, `for_interactive_prompt`
+2. `crates/ralph-adapters/src/auto_detect.rs` — Add "roo" to `DEFAULT_PRIORITY`, update `NoBackendError`
+3. `crates/ralph-adapters/src/lib.rs` — Update doc comment
+4. `presets/minimal/roo.yml` — New preset (mirror kiro.yml, change backend to "roo")
+
+## Design & Research (already completed)
+Full PDD artifacts at `.agents/planning/2026-03-03-roo-cli-provider/`:
+- `design/detailed-design.md` — Complete design document
+- `implementation/plan.md` — 7-step implementation plan with checklist
+- `research/assumption-validation.md` — All 9 assumptions verified with live tests
+- `research/roo-cli-interface.md` — Complete CLI flag documentation

--- a/.agents/planning/2026-03-03-roo-cli-provider/rough-idea.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/rough-idea.md
@@ -1,0 +1,11 @@
+# Rough Idea: Add roo-cli as a Provider
+
+Add `roo-cli` as a new provider/backend in ralph-orchestrator, following the same pattern as kiro and other existing backends.
+
+This means:
+- Auto-detection support (checking if `roo-cli` or equivalent binary is in PATH)
+- CLI backend configuration (headless mode, interactive mode, prompt passing)
+- A minimal preset file (`presets/minimal/roo.yml`)
+- Integration into all the places where backends are registered (from_config, from_name, for_interactive_prompt, etc.)
+
+The goal is to allow users to configure `cli.backend: "roo"` in their ralph.yml and have it work seamlessly with the roo-cli binary, similar to how kiro works with kiro-cli.

--- a/.agents/planning/2026-03-03-roo-cli-provider/summary.md
+++ b/.agents/planning/2026-03-03-roo-cli-provider/summary.md
@@ -1,0 +1,62 @@
+# Project Summary: Add roo-cli as a Provider
+
+## Directory Structure
+
+```
+.agents/planning/2026-03-03-roo-cli-provider/
+├── rough-idea.md                          # Initial concept
+├── idea-honing.md                         # Q&A requirements clarification (10 questions)
+├── research/
+│   ├── roo-cli-interface.md               # Roo CLI flags, stream-json format, examples
+│   ├── ralph-adapter-system.md            # How Ralph's adapter system works
+│   └── text-vs-stream-json.md             # Analysis of text vs stream-json impact
+├── design/
+│   └── detailed-design.md                 # Complete design document
+├── implementation/
+│   └── plan.md                            # 7-step implementation plan with checklist
+└── summary.md                             # This document
+```
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Output format | Text mode | Simple, proven (6/9 providers), no parser needed |
+| Headless command | `roo --print --ephemeral` | Non-interactive + clean disk state |
+| Prompt passing | Always `--prompt-file` | One code path, native roo support, no size threshold |
+| `--ephemeral` | Included | Fixed in roo v0.1.15+ to work with Bedrock |
+| Tool auto-approval | Default (no flag) | Roo auto-approves by default |
+| Auto-detect priority | Last position | Fallback only |
+| PTY mode | `pty_mode: false` | Clean pipe output for text parsing |
+
+## Implementation Overview
+
+The implementation consists of **7 incremental steps**, each producing working, testable functionality:
+
+1. **Backend definitions** — `roo()` and `roo_interactive()` methods
+2. **Registration** — Wire into `from_config`, `from_name`, `for_interactive_prompt`
+3. **Prompt file support** — Always use `--prompt-file` for all prompts
+4. **Auto-detection** — Add to `DEFAULT_PRIORITY`, update error messages
+5. **Preset file** — `presets/minimal/roo.yml`
+6. **Documentation** — Update crate docs
+7. **Validation** — Full test suite + manual E2E
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/ralph-adapters/src/cli_backend.rs` | Add `roo()`, `roo_interactive()`, registration points, tests |
+| `crates/ralph-adapters/src/auto_detect.rs` | Add to priority, error message, tests |
+| `crates/ralph-adapters/src/lib.rs` | Update doc comment |
+| `presets/minimal/roo.yml` | New file |
+
+## Estimated Effort
+
+~2-3 hours for a developer familiar with the codebase. The changes are mechanical — following established patterns from kiro, pi, and other backends.
+
+## Next Steps
+
+1. Review the [detailed design document](design/detailed-design.md)
+2. Check the [implementation plan](implementation/plan.md) and its checklist
+3. Begin implementation following the plan steps sequentially
+4. Run `cargo test` after each step to verify no regressions

--- a/.agents/scratchpad/roo-cli-provider/context.md
+++ b/.agents/scratchpad/roo-cli-provider/context.md
@@ -1,0 +1,28 @@
+# Context: Add roo-cli as a Provider
+
+## Project Structure
+- **ralph-adapters crate**: `crates/ralph-adapters/src/`
+- **Key files**: `cli_backend.rs` (backend definitions), `auto_detect.rs` (auto-detection), `lib.rs` (crate docs)
+- **Presets**: `presets/minimal/` (per-backend YAML configs)
+
+## Requirements
+1. Add `roo()` and `roo_interactive()` backend constructors
+2. Register roo in `from_config`, `from_name`, `for_interactive_prompt`, `filter_args_for_interactive`
+3. Always use `--prompt-file` for all roo prompts in `build_command()`
+4. Add "roo" to `DEFAULT_PRIORITY` (last position) and `NoBackendError` display
+5. Create `presets/minimal/roo.yml`
+6. Update `lib.rs` doc comment
+
+## Patterns (from existing code)
+- Backend constructors return `Self { command, args, prompt_mode, prompt_flag, output_format, env_vars }`
+- `from_config()` / `from_name()` / `for_interactive_prompt()` use match arms
+- `filter_args_for_interactive()` removes headless-only flags per backend
+- `build_command()` handles special prompt passing (Claude temp file for >7000 chars)
+- Tests follow `test_<backend>_backend()`, `test_from_name_<backend>()`, etc.
+
+## Dependencies
+- `tempfile::NamedTempFile` (already imported in cli_backend.rs)
+- `std::io::Write` (already imported)
+
+## Implementation Path
+Roo follows kiro/pi pattern: Text output, Arg prompt mode, no prompt flag. Special: always uses `--prompt-file` for prompts.

--- a/.agents/scratchpad/roo-cli-provider/plan.md
+++ b/.agents/scratchpad/roo-cli-provider/plan.md
@@ -1,0 +1,33 @@
+# Plan: Add roo-cli as a Provider
+
+## Test Strategy
+All tests in `cli_backend.rs` and `auto_detect.rs` test modules, following existing patterns.
+
+### cli_backend.rs tests
+| Test | Validates |
+|------|-----------|
+| `test_roo_backend` | `roo()` → `roo --print --ephemeral --prompt-file <path> ` |
+| `test_roo_interactive` | `roo_interactive()` → `roo "prompt"` |
+| `test_from_name_roo` | `from_name("roo")` resolves correctly |
+| `test_from_config_roo` | Config `backend: "roo"` creates correct backend |
+| `test_from_config_roo_with_args` | Extra args append correctly |
+| `test_for_interactive_prompt_roo` | Interactive factory returns `roo_interactive()` |
+| `test_roo_interactive_mode_removes_print` | `build_command(_, true)` removes `--print` and `--ephemeral` |
+| `test_roo_uses_prompt_file` | All prompts use `--prompt-file` |
+| `test_env_vars_default_empty` | Add `CliBackend::roo()` assertion |
+
+### auto_detect.rs tests
+| Test | Validates |
+|------|-----------|
+| `test_detection_command_roo` | Returns `"roo"` |
+| `test_default_priority_includes_roo` | "roo" in `DEFAULT_PRIORITY` |
+| `test_default_priority_roo_is_last` | "roo" is last in priority |
+| `test_no_backend_error_display` | Includes "Roo CLI" |
+
+## Implementation Steps
+1. Add `roo()` and `roo_interactive()` constructors
+2. Add match arms in `from_config`, `from_name`, `for_interactive_prompt`, `filter_args_for_interactive`
+3. Add roo-specific `--prompt-file` handling in `build_command()`
+4. Update `auto_detect.rs`: `DEFAULT_PRIORITY`, `NoBackendError`
+5. Create `presets/minimal/roo.yml`
+6. Update `lib.rs` doc comment

--- a/.agents/scratchpad/roo-cli-provider/progress.md
+++ b/.agents/scratchpad/roo-cli-provider/progress.md
@@ -1,0 +1,16 @@
+# Progress: Add roo-cli as a Provider
+
+## Setup
+- [x] Read design doc and implementation plan
+- [x] Explore existing codebase patterns
+- [x] Create documentation directory structure
+
+## Implementation
+- [ ] Step 1: Add `roo()` and `roo_interactive()` backend definitions + tests
+- [ ] Step 2: Register roo in dispatch points + tests
+- [ ] Step 3: Add `--prompt-file` support in `build_command()` + tests
+- [ ] Step 4: Add auto-detection support + tests
+- [ ] Step 5: Create `presets/minimal/roo.yml`
+- [ ] Step 6: Update `lib.rs` doc comment
+- [ ] Step 7: Full validation (`cargo test`)
+- [ ] Commit

--- a/.agents/summary/.last_commit
+++ b/.agents/summary/.last_commit
@@ -1,0 +1,1 @@
+26eabfd4ae6cce5aa7bce5989709ee9bb479725f

--- a/.agents/summary/architecture.md
+++ b/.agents/summary/architecture.md
@@ -1,0 +1,191 @@
+# Architecture
+
+## System Overview
+
+Ralph Orchestrator is a multi-agent orchestration framework that coordinates AI coding assistants (Claude, Kiro, Gemini, Codex, Amp, Pi) through an event-driven loop. The system uses a "hat" metaphor where different agent personas (hats) handle different phases of work, coordinated via pub/sub messaging.
+
+```mermaid
+graph TB
+    subgraph "User Interfaces"
+        CLI["ralph-cli<br/>CLI Entry Point"]
+        TUI["ralph-tui<br/>Terminal UI"]
+        WEB["ralph-web<br/>React Dashboard"]
+        TEL["ralph-telegram<br/>Telegram Bot"]
+    end
+
+    subgraph "API Layer"
+        API["ralph-api<br/>REST/WebSocket Server"]
+    end
+
+    subgraph "Core Engine"
+        CORE["ralph-core<br/>Orchestration Logic"]
+        PROTO["ralph-proto<br/>Protocol Types"]
+    end
+
+    subgraph "Agent Backends"
+        ADAPT["ralph-adapters<br/>Backend Integrations"]
+        CLAUDE["Claude CLI"]
+        KIRO["Kiro CLI"]
+        GEMINI["Gemini CLI"]
+        CODEX["Codex CLI"]
+        AMP["Amp CLI"]
+        PI["Pi CLI"]
+    end
+
+    CLI --> CORE
+    CLI --> ADAPT
+    TUI --> CORE
+    TUI --> API
+    WEB --> API
+    TEL --> CORE
+    API --> CORE
+    CORE --> PROTO
+    CORE --> ADAPT
+    ADAPT --> CLAUDE
+    ADAPT --> KIRO
+    ADAPT --> GEMINI
+    ADAPT --> CODEX
+    ADAPT --> AMP
+    ADAPT --> PI
+```
+
+## Crate Dependency Graph
+
+```mermaid
+graph LR
+    CLI["ralph-cli"] --> CORE["ralph-core"]
+    CLI --> ADAPT["ralph-adapters"]
+    CLI --> TUI["ralph-tui"]
+    CLI --> TELE["ralph-telegram"]
+    CLI --> API["ralph-api"]
+
+    CORE --> PROTO["ralph-proto"]
+    ADAPT --> PROTO
+    TUI --> PROTO
+    TUI --> CORE
+    TELE --> PROTO
+    TELE --> CORE
+    API --> CORE
+    API --> ADAPT
+    API --> PROTO
+
+    E2E["ralph-e2e"] --> CORE
+    E2E --> ADAPT
+    E2E --> PROTO
+    BENCH["ralph-bench"] --> CORE
+```
+
+## Core Architectural Patterns
+
+### 1. Event-Driven Orchestration
+
+The central architectural pattern is a pub/sub event bus. Each iteration of the loop:
+1. An agent (wearing a "hat") executes a task
+2. The agent writes events to a JSONL file (`.ralph/events.jsonl`)
+3. The event loop parses events and publishes them on the `EventBus`
+4. The `EventBus` routes events to subscribed hats based on topic patterns
+5. The next hat with pending events is activated
+
+```mermaid
+sequenceDiagram
+    participant EL as Event Loop
+    participant EB as EventBus
+    participant P as Planner Hat
+    participant B as Builder Hat
+    participant Agent as AI Backend
+
+    EL->>EB: publish(task.start)
+    EB->>P: route to Planner (subscribed)
+    EL->>Agent: Execute Planner iteration
+    Agent-->>EL: Writes build.task event
+    EL->>EB: publish(build.task)
+    EB->>B: route to Builder (subscribed)
+    EL->>Agent: Execute Builder iteration
+    Agent-->>EL: Writes build.done event
+    EL->>EB: publish(build.done)
+    EB->>P: route to Planner (subscribed)
+```
+
+### 2. Hat System (Agent Personas)
+
+Hats define how an AI agent behaves for a given iteration. Each hat has:
+- **Subscriptions**: Topic patterns it responds to (e.g., `build.task`)
+- **Publishes**: Topics it emits (e.g., `build.done`, `build.blocked`)
+- **Instructions**: Prompt content injected for the hat's iterations
+- **Backend**: Which AI CLI to use (can differ per hat)
+
+The default topology is Planner → Builder:
+- **Planner**: Subscribes to `task.start`, `task.resume`, `build.done`, `build.blocked`; publishes `build.task`
+- **Builder**: Subscribes to `build.task`; publishes `build.done`, `build.blocked`
+
+Custom hats are defined in YAML configuration and can create arbitrary workflows.
+
+### 3. Hatless Ralph (Coordinator)
+
+Ralph is the constant coordinator — always present, cannot be configured away. Ralph:
+- Handles `task.start` and `task.resume` (reserved events)
+- Performs gap analysis and planning
+- Delegates to custom hats via events
+- Acts as fallback handler for unrouted events (global wildcard `*` subscriber)
+- Builds the prompt including guardrails, memories, skills, and hat-specific instructions
+
+### 4. Topic-Based Routing
+
+Topics are dot-separated strings with glob pattern matching:
+- Exact match: `build.done` matches `build.done`
+- Wildcard suffix: `impl.*` matches `impl.done`, `impl.started`
+- Wildcard prefix: `*.done` matches `build.done`, `review.done`
+- Global wildcard: `*` matches everything (fallback priority)
+
+Routing priority: specific subscriptions > fallback wildcards.
+
+### 5. Parallel Loops via Git Worktrees
+
+When the primary loop lock is held, Ralph spawns parallel loops in git worktrees:
+- Primary loop holds `.ralph/loop.lock`
+- Worktree loops run in `.worktrees/<loop-id>/`
+- Shared state: memories, specs, and code tasks are symlinked from main repo
+- Merge queue: completed worktree loops queue for merge via `.ralph/merge-queue.jsonl`
+
+### 6. Disk-as-State, Git-as-Memory
+
+Per the Ralph Tenets, persistent state lives on disk:
+- `.ralph/agent/memories.md` — persistent learning across sessions
+- `.ralph/agent/tasks.jsonl` — runtime work tracking
+- `.ralph/events.jsonl` — event history for the current loop
+- `.ralph/loop.lock` — PID + prompt of the primary loop
+- `.ralph/loops.json` — registry of all tracked loops
+
+### 7. Communication Protocols
+
+The system supports multiple communication modes:
+
+| Protocol | Transport | Use Case |
+|----------|-----------|----------|
+| **CLI** | PTY subprocess | Default agent execution |
+| **RPC** | JSON-lines over stdin/stdout | IDE integrations, subprocess TUI |
+| **HTTP/WS** | Axum REST + WebSocket | Web dashboard, remote TUI |
+| **Telegram** | teloxide bot framework | Human-in-the-loop interaction |
+
+### 8. Backpressure Over Prescription
+
+Rather than prescribing how agents should work, Ralph creates gates that reject bad work:
+- Tests, typechecks, builds, lints (via lifecycle hooks)
+- LLM-as-judge with binary pass/fail for subjective criteria
+- Hooks can `warn`, `block`, or `suspend` the loop on failure
+
+### 9. Fresh Context Is Reliability
+
+Each iteration clears agent context. The orchestrator:
+- Re-reads specs, plans, and memories every cycle
+- Optimizes for the "smart zone" (40-60% of ~176K usable tokens)
+- Never fights to save a plan — regeneration costs one planning loop
+
+## Configuration Architecture
+
+Ralph uses a split configuration model:
+1. **Core config** (`ralph.yml`): Backend, event loop settings, features
+2. **Hat collections** (`-H builtin:feature` or YAML files): Hat definitions, event metadata
+3. **Presets** (`presets/`): Pre-built hat collection YAML files
+
+Configuration supports both v1 (flat) and v2 (nested) formats with automatic normalization.

--- a/.agents/summary/codebase_info.md
+++ b/.agents/summary/codebase_info.md
@@ -1,0 +1,75 @@
+# Codebase Information
+
+## Project Identity
+
+| Field | Value |
+|-------|-------|
+| **Name** | Ralph Orchestrator |
+| **Version** | 2.6.0 (Rust workspace) / 2.3.0 (npm workspace) |
+| **License** | MIT |
+| **Repository** | https://github.com/mikeyobrien/ralph-orchestrator |
+| **Description** | Multi-agent orchestration framework for AI coding assistants |
+| **Rust Edition** | 2024 |
+| **Node.js** | ≥ 22.0.0 |
+
+## Technology Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Primary Language** | Rust (215 source files across 9 crates) |
+| **Backend Web** | TypeScript/Node.js (Fastify + tRPC + SQLite) — 58 source files |
+| **Frontend Web** | TypeScript/React (Vite + TailwindCSS + React Flow) — 70 source files |
+| **Async Runtime** | Tokio (full features) |
+| **TUI Framework** | ratatui 0.30 + crossterm 0.28 |
+| **Serialization** | serde + serde_json + serde_yaml |
+| **CLI Parsing** | clap 4 (derive mode) |
+| **HTTP Client** | reqwest 0.12 (rustls-tls) |
+| **WebSocket** | tokio-tungstenite 0.24 |
+| **Telegram Bot** | teloxide 0.13 |
+| **Error Handling** | thiserror 2 + anyhow 1 |
+| **Logging** | tracing 0.1 + tracing-subscriber 0.3 |
+| **PTY** | portable-pty 0.9 |
+| **Keychain** | keyring 3 (apple-native, linux-native) |
+
+## Workspace Structure
+
+```
+ralph-orchestrator/
+├── Cargo.toml              # Rust workspace root
+├── package.json            # npm workspace root
+├── crates/                 # 9 Rust crates
+│   ├── ralph-proto/        # Protocol definitions and shared types
+│   ├── ralph-core/         # Orchestration logic, event loop, hats, memories, tasks
+│   ├── ralph-adapters/     # Backend integrations (Claude, Kiro, Gemini, etc.)
+│   ├── ralph-cli/          # CLI entry point and commands
+│   ├── ralph-tui/          # Terminal UI (ratatui-based)
+│   ├── ralph-telegram/     # Telegram bot for human-in-the-loop
+│   ├── ralph-api/          # REST/WebSocket API server (Axum)
+│   ├── ralph-e2e/          # End-to-end test framework
+│   └── ralph-bench/        # Benchmarking
+├── backend/                # Node.js web server
+│   └── ralph-web-server/   # @ralph-web/server (Fastify + tRPC + SQLite)
+├── frontend/               # React web dashboard
+│   └── ralph-web/          # @ralph-web/dashboard (React + Vite + TailwindCSS)
+├── presets/                 # Hat collection YAML presets
+├── docs/                   # MkDocs documentation site
+├── cassettes/              # Replay fixtures for smoke/E2E tests
+├── scripts/                # Build and CI helper scripts
+└── specs/                  # Design specifications
+```
+
+## Supported Platforms
+
+| Platform | Support |
+|----------|---------|
+| macOS (aarch64) | ✅ Primary |
+| macOS (x86_64) | ✅ Supported |
+| Linux (aarch64) | ✅ Cross-compiled |
+| Linux (x86_64) | ✅ Supported |
+| Windows | ❌ Excluded (requires Unix PTY and signal handling) |
+
+## Distribution
+
+- **cargo-dist**: GitHub CI releases with shell and npm installers
+- **npm scope**: `@ralph-orchestrator/ralph`
+- **crates.io**: All 9 crates published

--- a/.agents/summary/components.md
+++ b/.agents/summary/components.md
@@ -1,0 +1,254 @@
+# Components
+
+## Rust Crates
+
+### ralph-proto (`crates/ralph-proto/`)
+
+The foundational protocol crate providing shared types, error definitions, and traits used across all Ralph crates.
+
+| Module | Purpose |
+|--------|---------|
+| [`event.rs`](crates/ralph-proto/src/event.rs) | `Event` struct with topic, payload, source, and target fields |
+| [`event_bus.rs`](crates/ralph-proto/src/event_bus.rs) | `EventBus` — central pub/sub hub routing events between hats |
+| [`hat.rs`](crates/ralph-proto/src/hat.rs) | `Hat` and `HatId` — agent persona definitions with subscriptions/publishes |
+| [`topic.rs`](crates/ralph-proto/src/topic.rs) | `Topic` — routing keys with glob-style pattern matching |
+| [`json_rpc.rs`](crates/ralph-proto/src/json_rpc.rs) | `RpcCommand`/`RpcEvent` — JSON-lines IPC protocol types |
+| [`robot.rs`](crates/ralph-proto/src/robot.rs) | `RobotService` trait — human-in-the-loop communication abstraction |
+| [`daemon.rs`](crates/ralph-proto/src/daemon.rs) | `DaemonAdapter` trait — persistent bot daemon abstraction |
+| [`ux_event.rs`](crates/ralph-proto/src/ux_event.rs) | `UxEvent` — terminal/TUI capture events for recording/replay |
+| [`error.rs`](crates/ralph-proto/src/error.rs) | Common error types |
+
+---
+
+### ralph-core (`crates/ralph-core/`)
+
+The core orchestration engine containing the event loop, hat system, memory/task management, hooks, and all coordination logic.
+
+**Event Loop & Orchestration:**
+
+| Module | Purpose |
+|--------|---------|
+| [`event_loop/mod.rs`](crates/ralph-core/src/event_loop/mod.rs) | `EventLoop` — main orchestration loop coordinating hat execution |
+| [`event_loop/loop_state.rs`](crates/ralph-core/src/event_loop/loop_state.rs) | `LoopState` — mutable state tracked across iterations |
+| [`hatless_ralph.rs`](crates/ralph-core/src/hatless_ralph.rs) | `HatlessRalph` — constant coordinator, prompt builder |
+| [`hat_registry.rs`](crates/ralph-core/src/hat_registry.rs) | `HatRegistry` — converts config hats to proto hats |
+| [`event_parser.rs`](crates/ralph-core/src/event_parser.rs) | `EventParser` — parses JSONL events from agent output |
+| [`event_reader.rs`](crates/ralph-core/src/event_reader.rs) | `EventReader` — reads and validates event files |
+| [`event_logger.rs`](crates/ralph-core/src/event_logger.rs) | `EventLogger` — records event history for debugging |
+| [`handoff.rs`](crates/ralph-core/src/handoff.rs) | `HandoffWriter` — writes handoff events between hats |
+
+**Configuration:**
+
+| Module | Purpose |
+|--------|---------|
+| [`config.rs`](crates/ralph-core/src/config.rs) | `RalphConfig` — full configuration model with v1/v2 format support |
+| [`instructions.rs`](crates/ralph-core/src/instructions.rs) | `InstructionBuilder` — assembles prompts from guardrails, hat instructions, memories |
+
+**Memory & Task Systems:**
+
+| Module | Purpose |
+|--------|---------|
+| [`memory.rs`](crates/ralph-core/src/memory.rs) | `Memory`, `MemoryType` — persistent learning data structures |
+| [`memory_store.rs`](crates/ralph-core/src/memory_store.rs) | `MarkdownMemoryStore` — markdown-based memory persistence |
+| [`memory_parser.rs`](crates/ralph-core/src/memory_parser.rs) | Parser for structured markdown memory format |
+| [`task.rs`](crates/ralph-core/src/task.rs) | `Task`, `TaskStatus` — runtime work tracking data structures |
+| [`task_store.rs`](crates/ralph-core/src/task_store.rs) | `TaskStore` — JSONL-based task persistence |
+| [`task_definition.rs`](crates/ralph-core/src/task_definition.rs) | `TaskDefinition` — code task file parsing |
+
+**Parallel Loops & Coordination:**
+
+| Module | Purpose |
+|--------|---------|
+| [`loop_lock.rs`](crates/ralph-core/src/loop_lock.rs) | `LoopLock` — file-based PID lock for primary loop |
+| [`loop_registry.rs`](crates/ralph-core/src/loop_registry.rs) | `LoopRegistry` — registry of all tracked loops |
+| [`loop_context.rs`](crates/ralph-core/src/loop_context.rs) | `LoopContext` — primary vs worktree loop context |
+| [`worktree.rs`](crates/ralph-core/src/worktree.rs) | Worktree management (create, remove, sync, symlink) |
+| [`merge_queue.rs`](crates/ralph-core/src/merge_queue.rs) | `MergeQueue` — event-sourced merge queue for worktree branches |
+| [`loop_name.rs`](crates/ralph-core/src/loop_name.rs) | `LoopNameGenerator` — human-readable loop ID generation |
+| [`loop_completion.rs`](crates/ralph-core/src/loop_completion.rs) | `LoopCompletionHandler` — landing/merge on loop completion |
+| [`loop_history.rs`](crates/ralph-core/src/loop_history.rs) | `LoopHistory` — persistent loop run history |
+
+**Hooks System:**
+
+| Module | Purpose |
+|--------|---------|
+| [`hooks/engine.rs`](crates/ralph-core/src/hooks/engine.rs) | `HookEngine` — lifecycle hook orchestration engine |
+| [`hooks/executor.rs`](crates/ralph-core/src/hooks/executor.rs) | `HookExecutor` — runs hook commands with timeouts and output limits |
+| [`hooks/suspend_state.rs`](crates/ralph-core/src/hooks/suspend_state.rs) | `SuspendStateStore` — persistent state for suspended hooks |
+
+**Skills System:**
+
+| Module | Purpose |
+|--------|---------|
+| [`skill.rs`](crates/ralph-core/src/skill.rs) | `SkillEntry` — skill definition with frontmatter parsing |
+| [`skill_registry.rs`](crates/ralph-core/src/skill_registry.rs) | `SkillRegistry` — discovers and indexes skills from directories |
+
+**Other:**
+
+| Module | Purpose |
+|--------|---------|
+| [`git_ops.rs`](crates/ralph-core/src/git_ops.rs) | Git operations (auto-commit, branch detection, stash management) |
+| [`preflight.rs`](crates/ralph-core/src/preflight.rs) | `PreflightRunner` — pre-loop environment validation checks |
+| [`planning_session.rs`](crates/ralph-core/src/planning_session.rs) | `PlanningSession` — PDD interactive planning sessions |
+| [`diagnostics/`](crates/ralph-core/src/diagnostics/) | Diagnostic collectors (agent output, orchestration, errors, performance) |
+| [`session_recorder.rs`](crates/ralph-core/src/session_recorder.rs) | `SessionRecorder` — records sessions to JSONL for replay |
+| [`session_player.rs`](crates/ralph-core/src/session_player.rs) | `SessionPlayer` — replays recorded sessions |
+| [`workspace.rs`](crates/ralph-core/src/workspace.rs) | `WorkspaceManager` — isolated workspaces for benchmarks/E2E |
+| [`summary_writer.rs`](crates/ralph-core/src/summary_writer.rs) | `SummaryWriter` — generates loop completion summaries |
+
+**Testing Support:**
+
+| Module | Purpose |
+|--------|---------|
+| [`testing/mock_backend.rs`](crates/ralph-core/src/testing/mock_backend.rs) | Mock AI backend for unit tests |
+| [`testing/replay_backend.rs`](crates/ralph-core/src/testing/replay_backend.rs) | Replay backend using recorded JSONL fixtures |
+| [`testing/smoke_runner.rs`](crates/ralph-core/src/testing/smoke_runner.rs) | Smoke test runner using replay fixtures |
+| [`testing/scenario.rs`](crates/ralph-core/src/testing/scenario.rs) | Test scenario definitions |
+
+---
+
+### ralph-adapters (`crates/ralph-adapters/`)
+
+Backend integrations for various AI coding assistant CLIs.
+
+| Module | Purpose |
+|--------|---------|
+| [`cli_backend.rs`](crates/ralph-adapters/src/cli_backend.rs) | `CliBackend` — backend selection and command construction |
+| [`cli_executor.rs`](crates/ralph-adapters/src/cli_executor.rs) | `CliExecutor` — executes CLI commands and captures output |
+| [`pty_executor.rs`](crates/ralph-adapters/src/pty_executor.rs) | `PtyExecutor` — PTY-based execution preserving terminal UI |
+| [`pty_handle.rs`](crates/ralph-adapters/src/pty_handle.rs) | `PtyHandle` — control interface for PTY sessions |
+| [`auto_detect.rs`](crates/ralph-adapters/src/auto_detect.rs) | Auto-detection of available backends in system PATH |
+| [`claude_stream.rs`](crates/ralph-adapters/src/claude_stream.rs) | `ClaudeStreamParser` — streaming parser for Claude CLI output |
+| [`pi_stream.rs`](crates/ralph-adapters/src/pi_stream.rs) | `PiStreamParser` — streaming parser for Pi CLI output |
+| [`json_rpc_handler.rs`](crates/ralph-adapters/src/json_rpc_handler.rs) | `JsonRpcStreamHandler` — JSON-RPC protocol handler |
+| [`acp_executor.rs`](crates/ralph-adapters/src/acp_executor.rs) | `AcpExecutor` — Agent Communication Protocol executor |
+| [`stream_handler.rs`](crates/ralph-adapters/src/stream_handler.rs) | Stream handler variants (Console, Pretty, Quiet, TUI) |
+
+---
+
+### ralph-cli (`crates/ralph-cli/`)
+
+CLI entry point with all user-facing commands.
+
+| Module | Purpose |
+|--------|---------|
+| [`main.rs`](crates/ralph-cli/src/main.rs) | CLI argument parsing, command dispatch, subprocess TUI mode |
+| [`loop_runner.rs`](crates/ralph-cli/src/loop_runner.rs) | `run_loop_impl` — main loop execution orchestration |
+| [`tools.rs`](crates/ralph-cli/src/tools.rs) | `ralph tools` — agent-facing runtime tools (emit, task, memory, etc.) |
+| [`task_cli.rs`](crates/ralph-cli/src/task_cli.rs) | `ralph task` — code task generation commands |
+| [`loops.rs`](crates/ralph-cli/src/loops.rs) | `ralph loops` — parallel loop management |
+| [`hats.rs`](crates/ralph-cli/src/hats.rs) | `ralph hats` — hat management and inspection |
+| [`bot.rs`](crates/ralph-cli/src/bot.rs) | `ralph bot` — Telegram bot setup and daemon |
+| [`hooks.rs`](crates/ralph-cli/src/hooks.rs) | `ralph hooks` — hook configuration validation |
+| [`init.rs`](crates/ralph-cli/src/init.rs) | `ralph init` — project initialization |
+| [`presets.rs`](crates/ralph-cli/src/presets.rs) | Preset/hat collection loading and merging |
+| [`memory.rs`](crates/ralph-cli/src/memory.rs) | `ralph memory` — memory management CLI |
+| [`sop_runner.rs`](crates/ralph-cli/src/sop_runner.rs) | SOP-based planning runner |
+| [`web.rs`](crates/ralph-cli/src/web.rs) | `ralph web` — web dashboard launcher |
+| [`doctor.rs`](crates/ralph-cli/src/doctor.rs) | `ralph doctor` — environment diagnostic checks |
+| [`rpc_stdin.rs`](crates/ralph-cli/src/rpc_stdin.rs) | RPC stdin command reader for `--rpc` mode |
+
+---
+
+### ralph-tui (`crates/ralph-tui/`)
+
+Terminal user interface built with ratatui. Operates in three modes: in-process, RPC client (HTTP/WS), and subprocess RPC.
+
+| Module | Purpose |
+|--------|---------|
+| [`app.rs`](crates/ralph-tui/src/app.rs) | `App` — main TUI application loop and render logic |
+| [`state.rs`](crates/ralph-tui/src/state.rs) | `TuiState` — shared state model for the TUI |
+| [`state_mutations.rs`](crates/ralph-tui/src/state_mutations.rs) | State update logic for incoming events |
+| [`input.rs`](crates/ralph-tui/src/input.rs) | Keyboard input handling and action dispatch |
+| [`text_renderer.rs`](crates/ralph-tui/src/text_renderer.rs) | Markdown/ANSI to ratatui `Line` conversion |
+| [`rpc_client.rs`](crates/ralph-tui/src/rpc_client.rs) | `RpcClient` — HTTP/WS client for ralph-api |
+| [`rpc_bridge.rs`](crates/ralph-tui/src/rpc_bridge.rs) | WebSocket bridge connecting RPC events to TUI state |
+| [`rpc_source.rs`](crates/ralph-tui/src/rpc_source.rs) | Subprocess stdout event reader |
+| [`rpc_writer.rs`](crates/ralph-tui/src/rpc_writer.rs) | `RpcWriter` — sends commands to subprocess stdin |
+| [`widgets/`](crates/ralph-tui/src/widgets/) | UI widgets: header, footer, content area, help overlay |
+
+---
+
+### ralph-telegram (`crates/ralph-telegram/`)
+
+Telegram bot integration for human-in-the-loop communication.
+
+| Module | Purpose |
+|--------|---------|
+| [`bot.rs`](crates/ralph-telegram/src/bot.rs) | `TelegramBot` — teloxide bot wrapper with message sending |
+| [`service.rs`](crates/ralph-telegram/src/service.rs) | `TelegramService` — implements `RobotService` trait |
+| [`handler.rs`](crates/ralph-telegram/src/handler.rs) | `MessageHandler` — processes incoming Telegram messages |
+| [`state.rs`](crates/ralph-telegram/src/state.rs) | `StateManager` — persists chat ID, pending questions |
+| [`daemon.rs`](crates/ralph-telegram/src/daemon.rs) | `TelegramDaemon` — implements `DaemonAdapter` for persistent bot |
+| [`commands.rs`](crates/ralph-telegram/src/commands.rs) | Bot commands (/start, /status, /restart, etc.) |
+| [`error.rs`](crates/ralph-telegram/src/error.rs) | Telegram-specific error types |
+
+---
+
+### ralph-api (`crates/ralph-api/`)
+
+REST and WebSocket API server built with Axum for web dashboard and remote TUI integration.
+
+| Module | Purpose |
+|--------|---------|
+| [`runtime.rs`](crates/ralph-api/src/runtime.rs) | `RpcRuntime` — manages orchestration loop lifecycle |
+| [`transport.rs`](crates/ralph-api/src/transport.rs) | Axum router setup, HTTP/WS serving |
+| [`protocol.rs`](crates/ralph-api/src/protocol.rs) | Wire protocol types for API communication |
+| [`loop_domain.rs`](crates/ralph-api/src/loop_domain.rs) | Loop management API endpoints |
+| [`task_domain.rs`](crates/ralph-api/src/task_domain.rs) | Task management API endpoints |
+| [`planning_domain.rs`](crates/ralph-api/src/planning_domain.rs) | PDD planning session endpoints |
+| [`preset_domain.rs`](crates/ralph-api/src/preset_domain.rs) | Preset/collection browsing endpoints |
+| [`config_domain.rs`](crates/ralph-api/src/config_domain.rs) | Configuration management endpoints |
+| [`collection_domain.rs`](crates/ralph-api/src/collection_domain.rs) | Hat collection management |
+| [`stream_domain/`](crates/ralph-api/src/stream_domain/) | Real-time event streaming via WebSocket |
+| [`auth.rs`](crates/ralph-api/src/auth.rs) | Authentication middleware |
+| [`config.rs`](crates/ralph-api/src/config.rs) | `ApiConfig` — API server configuration |
+| [`idempotency.rs`](crates/ralph-api/src/idempotency.rs) | Idempotency key handling |
+
+---
+
+### ralph-e2e (`crates/ralph-e2e/`)
+
+End-to-end test framework with mock and live API test modes.
+
+| Module | Purpose |
+|--------|---------|
+| [`runner.rs`](crates/ralph-e2e/src/runner.rs) | E2E test runner |
+| [`executor.rs`](crates/ralph-e2e/src/executor.rs) | Test execution engine |
+| [`mock.rs`](crates/ralph-e2e/src/mock.rs) | Mock backend for CI-safe testing |
+| [`mock_cli.rs`](crates/ralph-e2e/src/mock_cli.rs) | Mock CLI for testing without real backends |
+| [`scenarios/`](crates/ralph-e2e/src/scenarios/) | Test scenarios (connectivity, orchestration, tasks, etc.) |
+| [`reporter.rs`](crates/ralph-e2e/src/reporter.rs) | Test report generation |
+| [`workspace.rs`](crates/ralph-e2e/src/workspace.rs) | Isolated test workspace management |
+
+---
+
+## Web Packages
+
+### @ralph-web/server (`backend/ralph-web-server/`)
+
+Node.js web server providing tRPC API and task management.
+
+| Directory | Purpose |
+|-----------|---------|
+| [`api/`](backend/ralph-web-server/src/api/) | tRPC routers, REST endpoints, log broadcasting |
+| [`runner/`](backend/ralph-web-server/src/runner/) | Ralph process management, event parsing, log streaming |
+| [`queue/`](backend/ralph-web-server/src/queue/) | Task queue with persistent storage and event bus |
+| [`repositories/`](backend/ralph-web-server/src/repositories/) | SQLite data access (tasks, logs, settings, collections) |
+| [`services/`](backend/ralph-web-server/src/services/) | Business logic (config merging, hat management, loops) |
+| [`db/`](backend/ralph-web-server/src/db/) | SQLite connection and schema |
+
+### @ralph-web/dashboard (`frontend/ralph-web/`)
+
+React web dashboard for monitoring and managing orchestration loops.
+
+| Directory | Purpose |
+|-----------|---------|
+| [`components/tasks/`](frontend/ralph-web/src/components/tasks/) | Task management UI (thread list, task detail, status bar) |
+| [`components/builder/`](frontend/ralph-web/src/components/builder/) | Visual hat collection builder (React Flow) |
+| [`components/plan/`](frontend/ralph-web/src/components/plan/) | PDD planning session UI |
+| [`components/layout/`](frontend/ralph-web/src/components/layout/) | Application shell, sidebar, navigation |
+| [`pages/`](frontend/ralph-web/src/pages/) | Route pages (tasks, builder, plan, settings) |
+| [`hooks/`](frontend/ralph-web/src/hooks/) | React hooks (WebSocket, keyboard shortcuts, notifications) |
+| [`stores/`](frontend/ralph-web/src/stores/) | Zustand state stores |
+| [`rpc/`](frontend/ralph-web/src/rpc/) | tRPC client configuration |

--- a/.agents/summary/data_models.md
+++ b/.agents/summary/data_models.md
@@ -1,0 +1,287 @@
+# Data Models
+
+## Core Protocol Types (ralph-proto)
+
+### Event
+
+The fundamental message unit in the pub/sub system.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `topic` | `Topic` | Routing key for the event |
+| `payload` | `String` | Content/payload of the event |
+| `source` | `Option<HatId>` | Hat that published this event |
+| `target` | `Option<HatId>` | Direct target hat for handoff |
+
+### Hat
+
+An agent persona that defines behavior for a given iteration.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `HatId` | Unique identifier (e.g., "planner", "builder") |
+| `name` | `String` | Human-readable name |
+| `description` | `String` | Purpose description (used in HATS table) |
+| `subscriptions` | `Vec<Topic>` | Topic patterns this hat responds to |
+| `publishes` | `Vec<Topic>` | Topics this hat emits |
+| `instructions` | `String` | Prompt content for this hat |
+
+### Topic
+
+A routing key with glob-style pattern matching. Stored as a `String` wrapper.
+
+**Pattern Rules:**
+- `*` matches any single segment
+- Single `*` matches everything (global wildcard)
+- Exact match for non-pattern topics
+
+### HatId
+
+Unique identifier for a hat. Stored as a `String` wrapper with `Display`, `Hash`, `Eq`, `Ord` implementations.
+
+---
+
+## Configuration Types (ralph-core)
+
+### RalphConfig
+
+Top-level configuration supporting both v1 flat and v2 nested formats.
+
+```mermaid
+classDiagram
+    class RalphConfig {
+        +EventLoopConfig event_loop
+        +CliConfig cli
+        +CoreConfig core
+        +HashMap~String,HatConfig~ hats
+        +HashMap~String,EventMetadata~ events
+        +MemoriesConfig memories
+        +TasksConfig tasks
+        +HooksConfig hooks
+        +SkillsConfig skills
+        +FeaturesConfig features
+        +RobotConfig robot
+        +TuiConfig tui
+    }
+
+    class EventLoopConfig {
+        +Option~String~ prompt
+        +String prompt_file
+        +String completion_promise
+        +u32 max_iterations
+        +u64 max_runtime_seconds
+        +Option~f64~ max_cost_usd
+        +u32 max_consecutive_failures
+        +bool persistent
+        +Vec~String~ required_events
+    }
+
+    class CliConfig {
+        +String backend
+        +Option~String~ command
+        +String prompt_mode
+        +String default_mode
+        +u32 idle_timeout_secs
+    }
+
+    class HatConfig {
+        +String name
+        +Option~String~ description
+        +Vec~String~ triggers
+        +Vec~String~ publishes
+        +String instructions
+        +Option~HatBackend~ backend
+        +Option~u32~ max_activations
+        +Vec~String~ disallowed_tools
+    }
+
+    RalphConfig --> EventLoopConfig
+    RalphConfig --> CliConfig
+    RalphConfig --> HatConfig
+```
+
+### HatBackend
+
+Backend configuration for a hat (supports multiple formats):
+
+| Variant | Fields | Example |
+|---------|--------|---------|
+| `Named(String)` | — | `"claude"` |
+| `NamedWithArgs` | `type`, `args` | `{ type: claude, args: [--model, opus] }` |
+| `KiroAgent` | `type`, `agent`, `args` | `{ type: kiro, agent: reviewer }` |
+| `Custom` | `command`, `args` | `{ command: ./my-agent, args: [] }` |
+
+### HooksConfig
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | `bool` | Whether hooks are active |
+| `defaults` | `HookDefaults` | Default timeout, output limits, suspend mode |
+| `events` | `HashMap<HookPhaseEvent, Vec<HookSpec>>` | Hook specs by lifecycle phase |
+
+### HookSpec
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Stable hook identifier |
+| `command` | `Vec<String>` | Command argv form |
+| `cwd` | `Option<PathBuf>` | Working directory override |
+| `env` | `HashMap<String, String>` | Environment variable overrides |
+| `timeout_seconds` | `Option<u64>` | Per-hook timeout override |
+| `on_error` | `Option<HookOnError>` | Failure behavior (warn/block/suspend) |
+| `mutate` | `HookMutationConfig` | Mutation policy (opt-in JSON payloads) |
+
+---
+
+## Runtime Data Models (ralph-core)
+
+### Task
+
+Runtime work tracking item with JSONL persistence.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String` | Unique ID: `task-{unix_timestamp}-{4_hex}` |
+| `title` | `String` | Short description |
+| `description` | `Option<String>` | Detailed description |
+| `status` | `TaskStatus` | Open, InProgress, Closed, Failed |
+| `priority` | `u8` | 1-5 (1 = highest) |
+| `blocked_by` | `Vec<String>` | Task IDs that must complete first |
+| `loop_id` | `Option<String>` | Owning loop ID for multi-loop filtering |
+| `created` | `String` | ISO 8601 timestamp |
+| `closed` | `Option<String>` | ISO 8601 completion timestamp |
+
+### TaskStatus
+
+```
+Open → InProgress → Closed
+                  → Failed
+```
+
+Terminal statuses: `Closed`, `Failed`.
+
+### Memory
+
+Persistent learning entry stored in markdown.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `memory_type` | `MemoryType` | Pattern, Decision, Fix, or Context |
+| `content` | `String` | The memory content |
+| `tags` | `Vec<String>` | Classification tags |
+| `timestamp` | `String` | ISO 8601 creation time |
+
+### MemoryType
+
+| Type | Section Header | Emoji | Purpose |
+|------|---------------|-------|---------|
+| `Pattern` | `## Patterns` | 🔄 | How this codebase does things |
+| `Decision` | `## Decisions` | ⚖️ | Why something was chosen |
+| `Fix` | `## Fixes` | 🔧 | Solution to a recurring problem |
+| `Context` | `## Context` | 📍 | Project-specific knowledge |
+
+---
+
+## Loop & Coordination Models
+
+### LoopContext
+
+Tracks whether the current loop is primary or running in a worktree.
+
+| Variant | Fields |
+|---------|--------|
+| Primary | `workspace: PathBuf` |
+| Worktree | `loop_id: String`, `workspace: PathBuf`, `repo_root: PathBuf` |
+
+### LoopEntry
+
+Registry entry for a tracked loop.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `String` | Loop identifier |
+| `prompt` | `String` | Prompt summary |
+| `worktree` | `Option<String>` | Worktree path (if parallel) |
+| `workspace` | `String` | Working directory |
+
+### MergeEntry
+
+Event-sourced entry in the merge queue.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `loop_id` | `String` | Loop that completed |
+| `branch` | `String` | Git branch to merge |
+| `state` | `MergeState` | Queued, Merged, Failed, Skipped |
+
+### LockMetadata
+
+Contents of `.ralph/loop.lock`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pid` | `u32` | Process ID holding the lock |
+| `prompt` | `String` | Summary of what's running |
+| `started` | `String` | ISO 8601 start time |
+
+---
+
+## RPC State Types (ralph-proto)
+
+### RpcState
+
+Snapshot of loop state returned by `get_state`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `iteration` | `u32` | Current iteration number |
+| `max_iterations` | `Option<u32>` | Configured limit |
+| `hat` / `hat_display` | `String` | Current hat ID and display name |
+| `backend` | `String` | Active backend |
+| `completed` | `bool` | Whether loop has finished |
+| `task_counts` | `RpcTaskCounts` | Total/open/closed/ready counts |
+| `active_task` | `Option<RpcTaskSummary>` | Currently active task |
+| `total_cost_usd` | `f64` | Cumulative cost |
+
+### TerminationReason
+
+| Reason | Exit Code | Description |
+|--------|-----------|-------------|
+| `Completed` | 0 | Completion promise detected |
+| `MaxIterations` | 2 | Iteration limit reached |
+| `MaxRuntime` | 2 | Time limit exceeded |
+| `MaxCost` | 2 | Cost limit exceeded |
+| `ConsecutiveFailures` | 1 | Too many failures |
+| `LoopThrashing` | 1 | Repeated blocked events |
+| `LoopStale` | 1 | Same topic 3+ times |
+| `Interrupted` | 130 | SIGINT/SIGTERM |
+| `Cancelled` | 0 | Graceful cancellation |
+| `RestartRequested` | 3 | Telegram `/restart` |
+
+---
+
+## UX Event Types (ralph-proto)
+
+Events for terminal/TUI capture and replay:
+
+| Variant | Key Fields | Purpose |
+|---------|-----------|---------|
+| `TerminalWrite` | `bytes` (base64), `stdout`, `offset_ms` | Raw terminal output |
+| `TerminalResize` | `width`, `height`, `offset_ms` | Terminal dimension change |
+| `TerminalColorMode` | `mode`, `detected`, `offset_ms` | Color mode detection |
+| `TuiFrame` | `frame_id`, `width`, `height`, `cells` | TUI frame capture |
+
+---
+
+## File-Based State
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `.ralph/agent/memories.md` | Structured Markdown | Persistent learning |
+| `.ralph/agent/tasks.jsonl` | JSONL (one Task per line) | Runtime task tracking |
+| `.ralph/events.jsonl` | JSONL (Event records) | Event history per loop |
+| `.ralph/loop.lock` | JSON (LockMetadata) | Primary loop PID lock |
+| `.ralph/loops.json` | JSON (Vec<LoopEntry>) | Loop registry |
+| `.ralph/merge-queue.jsonl` | JSONL (MergeEvent) | Event-sourced merge queue |
+| `.ralph/telegram-state.json` | JSON (TelegramState) | Telegram bot state |
+| `.ralph/agent/scratchpad.md` | Markdown | Legacy shared state (replaced by tasks) |

--- a/.agents/summary/dependencies.md
+++ b/.agents/summary/dependencies.md
@@ -1,0 +1,185 @@
+# Dependencies
+
+## Rust Workspace Dependencies
+
+### Async Runtime & Concurrency
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `tokio` | 1 (full features) | Primary async runtime |
+| `async-trait` | 0.1 | Async trait support |
+| `futures` | 0.3 | Async stream utilities |
+| `tokio-util` | 0.7 (compat) | Tokio compatibility utilities |
+
+### Terminal UI
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `ratatui` | 0.30 | Terminal UI framework (pinned for rustc 1.87.0) |
+| `crossterm` | 0.28 (event-stream) | Terminal manipulation and event handling |
+| `termimad` | 0.31 | Terminal markdown rendering |
+| `colored` | 3 | Terminal ANSI colors |
+| `indicatif` | 0.17 | Progress indicators |
+
+### Serialization
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `serde` | 1 (derive) | Serialization/deserialization framework |
+| `serde_json` | 1 | JSON processing |
+| `serde_yaml` | 0.9 | YAML configuration parsing |
+
+### CLI & Input
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `clap` | 4 (derive, std, cargo) | CLI argument parsing |
+| `clap_complete` | 4 | Shell completion generation |
+
+### Networking
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `reqwest` | 0.12 (rustls-tls, json) | HTTP client for remote presets and APIs |
+| `tokio-tungstenite` | 0.24 (rustls-tls-webpki-roots) | WebSocket client |
+| `tungstenite` | 0.24 | WebSocket protocol types |
+
+### Error Handling
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `thiserror` | 2 | Derive macro for custom error types |
+| `anyhow` | 1 | Flexible error handling |
+
+### Security
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `keyring` | 3 (apple-native, linux-native) | OS keychain for credential storage |
+
+### Logging & Tracing
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `tracing` | 0.1 | Structured logging framework |
+| `tracing-subscriber` | 0.3 (env-filter) | Log output and filtering |
+
+### Text Processing
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `regex` | 1 | Regular expression matching |
+| `strip-ansi-escapes` | 0.2 | Strip ANSI escape sequences |
+
+### PTY & Process
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `portable-pty` | 0.9 | Cross-platform PTY support |
+| `nix` | 0.29 (signal, term, fs) | Unix-specific system calls |
+| `vt100` | 0.15 | VT100 terminal emulation |
+| `scopeguard` | 1 | Scope-based cleanup |
+
+### Date/Time
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `chrono` | 0.4 (serde) | Date and time handling |
+
+### Bot Framework
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `teloxide` | 0.13 (macros, rustls, ctrlc_handler) | Telegram bot framework |
+
+### Other
+
+| Crate | Version | Purpose |
+|-------|---------|---------|
+| `open` | 5 | Open URLs in default browser |
+| `tempfile` | 3 | Temporary file creation (testing) |
+
+---
+
+## Internal Crate Dependencies
+
+```mermaid
+graph TD
+    PROTO["ralph-proto<br/>v2.6.0"]
+    CORE["ralph-core<br/>v2.6.0"]
+    ADAPT["ralph-adapters<br/>v2.6.0"]
+    CLI["ralph-cli<br/>v2.6.0"]
+    TUI["ralph-tui<br/>v2.6.0"]
+    TELE["ralph-telegram<br/>v2.6.0"]
+    API["ralph-api<br/>v2.6.0"]
+    E2E["ralph-e2e<br/>v2.6.0"]
+    BENCH["ralph-bench<br/>v2.6.0"]
+
+    CORE --> PROTO
+    ADAPT --> PROTO
+    TUI --> PROTO
+    TUI --> CORE
+    TELE --> PROTO
+    TELE --> CORE
+    API --> PROTO
+    API --> CORE
+    API --> ADAPT
+    CLI --> CORE
+    CLI --> ADAPT
+    CLI --> TUI
+    CLI --> TELE
+    CLI --> API
+    E2E --> PROTO
+    E2E --> CORE
+    E2E --> ADAPT
+    BENCH --> CORE
+```
+
+All internal crates are versioned at `2.6.0` and use path dependencies within the workspace.
+
+---
+
+## Node.js Dependencies
+
+### Backend (@ralph-web/server)
+
+| Package | Purpose |
+|---------|---------|
+| `fastify` | HTTP server framework |
+| `@trpc/server` | Type-safe API layer |
+| `better-sqlite3` | SQLite database driver |
+| `drizzle-orm` | ORM for SQLite |
+| `zod` | Schema validation |
+| `ws` | WebSocket support |
+
+### Frontend (@ralph-web/dashboard)
+
+| Package | Purpose |
+|---------|---------|
+| `react` + `react-dom` | UI framework |
+| `vite` | Build tool and dev server |
+| `tailwindcss` | Utility-first CSS framework |
+| `@trpc/client` + `@trpc/react-query` | Type-safe API client |
+| `@tanstack/react-query` | Async state management |
+| `reactflow` | Visual graph editor (hat collection builder) |
+| `zustand` | State management |
+| `lucide-react` | Icon library |
+
+---
+
+## Build & Distribution Tools
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| `cargo-dist` | 0.30.3 | Cross-platform binary distribution |
+| `npm` | (workspace) | Node.js package management |
+| `mkdocs` | — | Documentation site generation |
+
+---
+
+## Workspace Linting Configuration
+
+The workspace enforces strict Rust linting:
+- `unsafe_code = "forbid"` — no unsafe code allowed
+- `clippy::pedantic` level warnings enabled (with specific allowances for common patterns)
+- Multiple `clippy` lints relaxed for ergonomic API design (see `Cargo.toml` workspace lints)

--- a/.agents/summary/index.md
+++ b/.agents/summary/index.md
@@ -1,0 +1,55 @@
+# Ralph Orchestrator — Documentation Index
+
+> **For AI Assistants**: This file is the primary entry point for understanding the Ralph Orchestrator codebase. Read this file first, then consult specific files as needed based on the summaries below.
+
+## How to Use This Documentation
+
+1. **Start here** — this index provides enough context to answer most questions
+2. **Drill down** — each file below covers a specific aspect in depth
+3. **Cross-reference** — files reference each other where topics overlap
+
+## Documentation Files
+
+| File | Purpose | When to Consult |
+|------|---------|-----------------|
+| [`codebase_info.md`](.agents/summary/codebase_info.md) | Project identity, tech stack, workspace structure, platforms | Understanding project basics, technology choices, file organization |
+| [`architecture.md`](.agents/summary/architecture.md) | System architecture, design patterns, core principles | Understanding how the system works, why design decisions were made |
+| [`components.md`](.agents/summary/components.md) | Detailed breakdown of every crate, module, and web package | Finding specific code, understanding module responsibilities |
+| [`interfaces.md`](.agents/summary/interfaces.md) | Rust traits, JSON-RPC protocol, CLI commands, REST API, EventBus | Understanding APIs, integration points, communication protocols |
+| [`data_models.md`](.agents/summary/data_models.md) | All data structures, configuration types, file formats | Understanding data flow, configuration options, state management |
+| [`workflows.md`](.agents/summary/workflows.md) | End-to-end workflows with Mermaid diagrams | Understanding execution flows, debugging, process tracing |
+| [`dependencies.md`](.agents/summary/dependencies.md) | External dependencies, internal crate graph, build tools | Understanding dependency choices, version constraints |
+| [`review_notes.md`](.agents/summary/review_notes.md) | Documentation consistency and completeness review | Identifying gaps, planning documentation improvements |
+
+## Quick Reference
+
+### Project Structure
+- **9 Rust crates** in `crates/` (proto → core → adapters → cli/tui/telegram/api/e2e/bench)
+- **1 Node.js backend** in `backend/ralph-web-server/` (Fastify + tRPC + SQLite)
+- **1 React frontend** in `frontend/ralph-web/` (Vite + TailwindCSS)
+- **Hat presets** in `presets/` (YAML configuration files)
+
+### Key Concepts
+- **Event Loop**: Core orchestration via pub/sub EventBus with topic-based routing
+- **Hats**: Agent personas (Planner, Builder, custom) with subscriptions and publications
+- **HatlessRalph**: Constant coordinator that builds prompts and delegates
+- **Memories**: Persistent learning stored in markdown (`.ralph/agent/memories.md`)
+- **Tasks**: Runtime work tracking in JSONL (`.ralph/agent/tasks.jsonl`)
+- **Hooks**: Lifecycle event handlers (pre/post loop, iteration, completion)
+- **Parallel Loops**: Concurrent execution via git worktrees with merge queue
+- **RObot**: Human-in-the-loop via Telegram (blocking questions + proactive guidance)
+
+### Backends Supported
+Claude, Kiro, Gemini, Codex, Amp, Pi, and custom commands.
+
+### Execution Modes
+1. **Subprocess TUI** (default): Two-process model with ratatui frontend
+2. **Autonomous** (`--no-tui`): Headless CLI execution
+3. **RPC** (`--rpc`): JSON-lines protocol for IDE integration
+4. **Web Dashboard**: React UI via ralph-api server
+5. **Telegram Daemon**: Persistent bot for remote interaction
+
+### Configuration
+- Core config: `ralph.yml` (supports v1 flat and v2 nested formats)
+- Hat collections: `presets/*.yml` or custom YAML via `-H` flag
+- Split model: core config + hat collection merged at runtime

--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -1,0 +1,224 @@
+# Interfaces & APIs
+
+## Rust Trait Interfaces
+
+### RobotService (`ralph-proto`)
+
+The core abstraction for human-in-the-loop communication. Implemented by `TelegramService`.
+
+```rust
+pub trait RobotService: Send + Sync {
+    fn send_question(&self, payload: &str) -> anyhow::Result<i32>;
+    fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>>;
+    fn send_checkin(&self, iteration: u32, elapsed: Duration, context: Option<&CheckinContext>) -> anyhow::Result<i32>;
+    fn timeout_secs(&self) -> u64;
+    fn shutdown_flag(&self) -> Arc<AtomicBool>;
+    fn stop(self: Box<Self>);
+}
+```
+
+### DaemonAdapter (`ralph-proto`)
+
+Abstraction for persistent bot daemons that listen for messages and start loops on demand.
+
+```rust
+#[async_trait]
+pub trait DaemonAdapter: Send + Sync {
+    async fn run_daemon(&self, workspace_root: PathBuf, start_loop: StartLoopFn) -> anyhow::Result<()>;
+}
+```
+
+### FrameCapture (`ralph-proto`)
+
+Interface for capturing rendered terminal output for recording/replay.
+
+```rust
+pub trait FrameCapture: Send + Sync {
+    fn take_captures(&mut self) -> Vec<UxEvent>;
+    fn has_captures(&self) -> bool;
+}
+```
+
+### HookExecutorContract (`ralph-core`)
+
+Interface for executing hook commands, enabling test substitution.
+
+```rust
+pub trait HookExecutorContract: Send + Sync {
+    fn execute(&self, request: HookRunRequest) -> HookRunResult;
+}
+```
+
+---
+
+## JSON-RPC Protocol (stdin/stdout)
+
+The RPC protocol enables IPC between the orchestration loop and frontends. Transport is newline-delimited JSON.
+
+### Commands (stdin → Ralph)
+
+| Command | Fields | Purpose |
+|---------|--------|---------|
+| `prompt` | `prompt`, `backend?`, `max_iterations?` | Start loop with a prompt |
+| `guidance` | `message` | Inject guidance for next iteration |
+| `steer` | `message` | Steer agent during current iteration |
+| `follow_up` | `message` | Queue message for next iteration |
+| `abort` | `reason?` | Terminate the loop |
+| `get_state` | — | Request state snapshot |
+| `get_iterations` | `include_content?` | Request iteration history |
+| `set_hat` | `hat` | Force hat change |
+| `extension_ui_response` | `request_id`, `response` | Respond to UI prompt |
+
+### Events (Ralph → stdout)
+
+| Event | Key Fields | Purpose |
+|-------|-----------|---------|
+| `loop_started` | `prompt`, `backend`, `max_iterations` | Loop has begun |
+| `iteration_start` | `iteration`, `hat`, `backend` | New iteration beginning |
+| `iteration_end` | `iteration`, `duration_ms`, `cost_usd`, tokens | Iteration completed |
+| `text_delta` | `iteration`, `delta` | Streaming text from agent |
+| `tool_call_start` | `tool_name`, `tool_call_id`, `input` | Tool invocation starting |
+| `tool_call_end` | `tool_call_id`, `output`, `is_error` | Tool invocation completed |
+| `error` | `code`, `message`, `recoverable` | Error occurred |
+| `hat_changed` | `from_hat`, `to_hat`, `reason` | Hat switch |
+| `task_status_changed` | `task_id`, `from_status`, `to_status` | Task state change |
+| `task_counts_updated` | `total`, `open`, `closed`, `ready` | Task count update |
+| `guidance_ack` | `message`, `applies_to` | Guidance received |
+| `loop_terminated` | `reason`, `total_iterations`, `total_cost_usd` | Loop ended |
+| `orchestration_event` | `topic`, `payload`, `source?`, `target?` | EventBus event |
+| `response` | `command`, `success`, `data?`, `error?` | Command response |
+
+---
+
+## CLI Commands
+
+```mermaid
+graph LR
+    RALPH["ralph"] --> RUN["run"]
+    RALPH --> INIT["init"]
+    RALPH --> PLAN["plan"]
+    RALPH --> CT["code-task"]
+    RALPH --> TOOLS["tools"]
+    RALPH --> LOOPS["loops"]
+    RALPH --> HATS["hats"]
+    RALPH --> EVENTS["events"]
+    RALPH --> CLEAN["clean"]
+    RALPH --> EMIT["emit"]
+    RALPH --> BOT["bot"]
+    RALPH --> WEB["web"]
+    RALPH --> TUI_CMD["tui"]
+    RALPH --> HOOKS["hooks"]
+    RALPH --> PREFLIGHT["preflight"]
+    RALPH --> DOCTOR["doctor"]
+    RALPH --> COMPS["completions"]
+    
+    TOOLS --> T_EMIT["emit"]
+    TOOLS --> T_TASK["task"]
+    TOOLS --> T_MEM["memory"]
+    TOOLS --> T_SKILL["skill"]
+    TOOLS --> T_INTERACT["interact"]
+```
+
+| Command | Description |
+|---------|-------------|
+| `ralph run` | Run the orchestration loop (default) |
+| `ralph init` | Initialize `ralph.yml` configuration |
+| `ralph plan` | Start a PDD planning session |
+| `ralph code-task` | Generate code task files |
+| `ralph tools` | Agent-facing runtime tools |
+| `ralph loops` | Manage parallel loops |
+| `ralph hats` | Manage configured hats |
+| `ralph events` | View event history |
+| `ralph clean` | Clean up `.ralph/` artifacts |
+| `ralph emit` | Emit events to events file |
+| `ralph bot` | Telegram bot management |
+| `ralph web` | Launch web dashboard |
+| `ralph tui` | Attach TUI to running ralph-api |
+| `ralph hooks` | Validate hooks configuration |
+| `ralph preflight` | Run environment validation |
+| `ralph doctor` | First-run diagnostics |
+| `ralph completions` | Generate shell completions |
+
+---
+
+## EventBus Pub/Sub API
+
+The `EventBus` is the central routing mechanism:
+
+```rust
+// Register a hat with subscriptions
+bus.register(hat);
+
+// Publish an event — returns list of recipient hat IDs
+let recipients = bus.publish(event);
+
+// Take pending events for a specific hat
+let events = bus.take_pending(&hat_id);
+
+// Human events use a separate queue
+let human_events = bus.take_human_pending();
+
+// Observers receive ALL events regardless of routing
+bus.add_observer(|event| { /* recording, TUI update */ });
+```
+
+**Routing Rules:**
+1. Direct target (`event.target`) → route only to that hat
+2. Specific subscriptions → route to hats with matching non-wildcard patterns
+3. Fallback wildcards → route to hats with global `*` subscriptions
+4. Self-routing is allowed (handles LLM non-determinism)
+5. `human.*` events go to a separate queue (not routed to hats)
+
+---
+
+## Hook Lifecycle Events
+
+Hooks fire at specific lifecycle points:
+
+| Phase-Event | When |
+|-------------|------|
+| `pre.loop.start` | Before the orchestration loop begins |
+| `post.loop.start` | After the first iteration starts |
+| `pre.iteration.start` | Before each iteration |
+| `post.iteration.start` | After each iteration begins |
+| `pre.plan.created` | Before a plan is created |
+| `post.plan.created` | After a plan is created |
+| `pre.human.interact` | Before a human interaction event |
+| `post.human.interact` | After a human interaction event |
+| `pre.loop.complete` | Before loop completion is accepted |
+| `post.loop.complete` | After loop completion |
+| `pre.loop.error` | Before loop error handling |
+| `post.loop.error` | After loop error handling |
+
+Hook failure modes: `warn` (continue), `block` (stop), `suspend` (pause and await recovery).
+
+---
+
+## REST/WebSocket API (ralph-api)
+
+The Axum-based API server exposes:
+
+| Domain | Endpoints |
+|--------|-----------|
+| **Loop** | Start, stop, get state, guidance, steer |
+| **Task** | CRUD operations on runtime tasks |
+| **Planning** | PDD session management |
+| **Presets** | Browse builtin hat collections |
+| **Config** | Configuration management |
+| **Collections** | Hat collection CRUD |
+| **Stream** | WebSocket event streaming (real-time) |
+| **Auth** | Token-based authentication |
+
+---
+
+## Telegram Bot Commands
+
+| Command | Direction | Purpose |
+|---------|-----------|---------|
+| `human.interact` | Agent → Human | Agent asks a question (loop blocks) |
+| `human.response` | Human → Agent | Reply to a question |
+| `human.guidance` | Human → Agent | Proactive guidance |
+| `/start` | Human → Bot | Initialize bot, store chat ID |
+| `/status` | Human → Bot | Get current loop status |
+| `/restart` | Human → Bot | Request loop restart |
+| `/stop` | Human → Bot | Request loop termination |

--- a/.agents/summary/review_notes.md
+++ b/.agents/summary/review_notes.md
@@ -1,0 +1,69 @@
+# Documentation Review Notes
+
+## Consistency Check
+
+### Cross-Document Consistency ✅
+
+| Area | Status | Notes |
+|------|--------|-------|
+| Crate names and versions | ✅ Consistent | All crates at v2.6.0, npm at 2.3.0 |
+| Architecture descriptions | ✅ Consistent | EventBus, hat system, and loop patterns described consistently |
+| File path references | ✅ Consistent | All paths relative to workspace root |
+| Terminology | ✅ Consistent | "Hat", "Topic", "Event", "HatlessRalph" used uniformly |
+| Backend list | ✅ Consistent | Claude, Kiro, Gemini, Codex, Amp, Pi listed consistently |
+| Configuration format | ✅ Consistent | v1/v2 normalization documented in architecture and data_models |
+
+### Potential Ambiguities
+
+1. **"Task" has dual meaning**: The word "task" refers to both runtime work tracking items (`Task` in `ralph-core/src/task.rs`) and code task files (`.code-task.md`). The CLI disambiguates: `ralph tools task` for runtime tasks, `ralph code-task` for code task generation.
+
+2. **"Web" packages**: There are two web stacks — the Node.js legacy backend (`backend/ralph-web-server/`) and the new Rust API server (`crates/ralph-api/`). The Node.js backend uses tRPC/SQLite while the Rust API uses Axum. Both coexist.
+
+---
+
+## Completeness Check
+
+### Well-Documented Areas ✅
+
+- [x] Event-driven architecture and pub/sub patterns
+- [x] Hat system (subscriptions, publications, routing priority)
+- [x] Configuration model (v1/v2 format, validation, normalization)
+- [x] JSON-RPC protocol (all commands and events documented)
+- [x] Task and memory data models
+- [x] Parallel loop coordination (worktrees, merge queue, lock)
+- [x] Hook lifecycle system (phases, error modes, suspend)
+- [x] Telegram human-in-the-loop integration
+- [x] CLI command surface
+- [x] Dependency inventory
+
+### Areas With Limited Coverage
+
+| Area | Gap | Recommendation |
+|------|-----|----------------|
+| **ralph-api routes** | Individual API endpoint signatures not fully enumerated | Read `crates/ralph-api/src/loop_domain.rs` etc. for specific routes |
+| **Web dashboard pages** | React component props and state management not detailed | Read `frontend/ralph-web/src/pages/` for page-level implementation |
+| **Node.js backend internals** | tRPC router procedures and SQLite schema not fully mapped | Read `backend/ralph-web-server/src/api/trpc.ts` and `db/schema.ts` |
+| **Preset YAML schema** | Hat collection YAML structure (presets/) not formally documented | Read `presets/README.md` and `presets/COLLECTION.md` |
+| **Diagnostics system** | Diagnostic collector modules listed but output format not detailed | Read `crates/ralph-core/src/diagnostics/` modules |
+| **Skills system** | Skill frontmatter schema and discovery algorithm not detailed | Read `crates/ralph-core/src/skill.rs` and `skill_registry.rs` |
+
+### Language Support Limitations
+
+| Language | Support Level | Notes |
+|----------|--------------|-------|
+| Rust | ✅ Full | All 215 source files analyzed |
+| TypeScript (Backend) | ⚠️ Structural | Module listing complete; internal APIs partially documented |
+| TypeScript (Frontend) | ⚠️ Structural | Component listing complete; props/state not detailed |
+| YAML (Presets) | ⚠️ Referenced | Preset files referenced but schema not formally documented |
+
+---
+
+## Recommendations
+
+1. **No action needed for primary documentation** — architecture, components, interfaces, data models, and workflows are comprehensive for AI assistant context.
+
+2. **Future enhancement**: Add detailed API route documentation for `ralph-api` if web dashboard development increases.
+
+3. **Future enhancement**: Document the preset YAML schema formally if custom hat collection authoring becomes a common user activity.
+
+4. **Future enhancement**: Add sequence diagrams for the web dashboard data flow (tRPC ↔ SQLite ↔ React) if the web UI becomes a primary interface.

--- a/.agents/summary/workflows.md
+++ b/.agents/summary/workflows.md
@@ -1,0 +1,272 @@
+# Workflows
+
+## Primary Orchestration Loop
+
+The main workflow executed by `ralph run`:
+
+```mermaid
+flowchart TD
+    START([ralph run]) --> LOAD[Load Configuration]
+    LOAD --> NORM[Normalize v1→v2 Config]
+    NORM --> VALIDATE[Validate Config]
+    VALIDATE --> DETECT{Backend = auto?}
+    DETECT -->|Yes| AUTO[Auto-detect Backend]
+    DETECT -->|No| LOCK
+    AUTO --> LOCK{Acquire Loop Lock}
+    
+    LOCK -->|Success| PRIMARY[Run as Primary Loop]
+    LOCK -->|Already Locked| PARALLEL{Parallel Enabled?}
+    PARALLEL -->|Yes| WORKTREE[Create Git Worktree]
+    PARALLEL -->|No| ERROR[Error: Loop Running]
+    
+    WORKTREE --> SYMLINK[Symlink Memories/Specs/Tasks]
+    SYMLINK --> REGISTER[Register in Loop Registry]
+    REGISTER --> PREFLIGHT
+    
+    PRIMARY --> PREFLIGHT{Preflight Checks}
+    PREFLIGHT -->|Pass| INIT_LOOP[Initialize Event Loop]
+    PREFLIGHT -->|Fail| ABORT[Abort with Error]
+    
+    INIT_LOOP --> BUILD_PROMPT[Build Prompt<br/>Guardrails + Hat Instructions + Memories + Skills]
+    BUILD_PROMPT --> EXECUTE[Execute Agent Backend<br/>via PTY/CLI]
+    EXECUTE --> PARSE[Parse Events from JSONL]
+    PARSE --> PUBLISH[Publish Events to EventBus]
+    PUBLISH --> CHECK_TERM{Termination?}
+    
+    CHECK_TERM -->|LOOP_COMPLETE| COMPLETE[Loop Completed]
+    CHECK_TERM -->|Max Iterations| LIMIT[Limit Reached]
+    CHECK_TERM -->|Error| FAIL[Handle Failure]
+    CHECK_TERM -->|No| ROUTE[Route to Next Hat]
+    
+    ROUTE --> BUILD_PROMPT
+    
+    COMPLETE --> LANDING[Landing Handler<br/>Auto-commit, Merge Queue]
+    LIMIT --> LANDING
+```
+
+## Event Loop Iteration Cycle
+
+Detail of a single iteration within the loop:
+
+```mermaid
+sequenceDiagram
+    participant Loop as Event Loop
+    participant HR as HatlessRalph
+    participant HE as Hook Engine
+    participant Agent as AI Backend
+    participant EB as EventBus
+    participant TS as TaskStore
+    participant MS as MemoryStore
+
+    Note over Loop: Iteration N begins
+    
+    Loop->>HE: pre.iteration.start hooks
+    HE-->>Loop: OK / Block / Suspend
+    
+    Loop->>MS: Load memories (if auto-inject)
+    Loop->>TS: Load task status
+    Loop->>HR: Build prompt (guardrails + hat + memories + skills + tasks)
+    HR-->>Loop: Complete prompt string
+    
+    Loop->>Agent: Execute iteration (PTY/CLI)
+    Agent-->>Loop: Agent output + events.jsonl
+    
+    Loop->>Loop: Parse JSONL events
+    Loop->>EB: Publish parsed events
+    
+    alt human.interact event
+        Loop->>Loop: Send question via RObot
+        Loop->>Loop: Block waiting for response
+    end
+    
+    EB-->>Loop: Route events to hat queues
+    Loop->>Loop: Check termination conditions
+    
+    alt Completion Promise detected
+        Loop->>HE: pre.loop.complete hooks
+        Loop->>Loop: Verify required_events seen
+        Loop-->>Loop: Terminate (exit 0)
+    else Has pending events
+        Loop->>Loop: Select next hat
+        Note over Loop: Iteration N+1
+    else No events, no completion
+        Loop->>Loop: Continue with Ralph (fallback)
+    end
+```
+
+## Parallel Loop Workflow
+
+```mermaid
+flowchart LR
+    subgraph "Main Workspace"
+        P[Primary Loop<br/>holds loop.lock]
+        MQ[Merge Queue<br/>merge-queue.jsonl]
+        REG[Loop Registry<br/>loops.json]
+    end
+    
+    subgraph ".worktrees/fix-header/"
+        W1[Worktree Loop 1]
+        SYM1[Symlinks → main<br/>memories, specs, tasks]
+    end
+    
+    subgraph ".worktrees/add-footer/"
+        W2[Worktree Loop 2]
+        SYM2[Symlinks → main<br/>memories, specs, tasks]
+    end
+    
+    P -.->|spawns| W1
+    P -.->|spawns| W2
+    W1 -->|completes| MQ
+    W2 -->|completes| MQ
+    MQ -->|primary processes| P
+    W1 --> REG
+    W2 --> REG
+```
+
+## Telegram Human-in-the-Loop Flow
+
+```mermaid
+sequenceDiagram
+    participant Agent as AI Agent
+    participant Loop as Event Loop
+    participant Bot as Telegram Bot
+    participant Human as Human (Telegram)
+
+    Note over Agent: Agent encounters ambiguity
+    Agent->>Loop: Emit human.interact event
+    Loop->>Bot: Send question via Telegram
+    Bot->>Human: "❓ Agent asks: ..."
+    
+    Loop->>Loop: Block (wait for response or timeout)
+    
+    Human->>Bot: Reply with answer
+    Bot->>Loop: Write human.response to events.jsonl
+    Loop->>Agent: Inject response into next iteration
+    
+    Note over Human: Proactive guidance
+    Human->>Bot: Send message without question
+    Bot->>Loop: Write human.guidance to events.jsonl
+    Loop->>Agent: Inject as "## ROBOT GUIDANCE" in prompt
+```
+
+## PDD Planning Session
+
+```mermaid
+flowchart TD
+    START([ralph plan]) --> LOAD[Load Config]
+    LOAD --> BACKEND[Resolve Backend]
+    BACKEND --> SPAWN[Spawn AI Backend<br/>with PDD SOP prompt]
+    SPAWN --> INTERACT[Interactive Session<br/>Clarify requirements]
+    INTERACT --> RESEARCH[Research Phase<br/>Explore codebase]
+    RESEARCH --> DESIGN[Design Phase<br/>Architecture decisions]
+    DESIGN --> PLAN[Implementation Plan<br/>Phased steps]
+    PLAN --> OUTPUT[Write plan to .ralph/specs/]
+```
+
+## Code Task Generation
+
+```mermaid
+flowchart TD
+    START([ralph code-task]) --> INPUT{Input Type}
+    INPUT -->|Description| DESC[Parse description text]
+    INPUT -->|PDD Plan| PLAN[Parse plan file steps]
+    DESC --> GEN[Generate .code-task.md]
+    PLAN --> GEN
+    GEN --> CRITERIA[Given-When-Then<br/>Acceptance Criteria]
+    CRITERIA --> OUTPUT[Write to .ralph/tasks/]
+```
+
+## Subprocess TUI Mode
+
+The default execution mode spawns a two-process architecture:
+
+```mermaid
+flowchart LR
+    subgraph "Parent Process"
+        TUI[TUI Render Loop<br/>ratatui]
+        INPUT[Keyboard Input]
+        WRITER[RPC Writer<br/>stdin pipe]
+        READER[Event Reader<br/>stdout pipe]
+    end
+    
+    subgraph "Child Process (ralph run --rpc)"
+        RPC_IN[RPC stdin reader]
+        LOOP[Event Loop]
+        RPC_OUT[JSON-lines stdout]
+    end
+    
+    INPUT --> WRITER
+    WRITER -->|JSON commands| RPC_IN
+    RPC_IN --> LOOP
+    LOOP --> RPC_OUT
+    RPC_OUT -->|JSON events| READER
+    READER --> TUI
+```
+
+## Web Dashboard Workflow
+
+```mermaid
+flowchart TD
+    subgraph "Frontend (React + Vite)"
+        UI[Web Dashboard]
+        TRPC_C[tRPC Client]
+        WS_C[WebSocket Client]
+    end
+    
+    subgraph "Backend (Fastify + tRPC)"
+        API[tRPC Router]
+        RUNNER[Ralph Runner]
+        QUEUE[Task Queue]
+        DB[(SQLite)]
+    end
+    
+    subgraph "Ralph Process"
+        RALPH[ralph run --rpc]
+    end
+    
+    UI --> TRPC_C
+    TRPC_C --> API
+    UI --> WS_C
+    WS_C --> API
+    API --> RUNNER
+    RUNNER --> RALPH
+    API --> QUEUE
+    QUEUE --> DB
+```
+
+## Hook Execution Flow
+
+```mermaid
+flowchart TD
+    EVENT[Lifecycle Event<br/>e.g., pre.iteration.start] --> ENABLED{Hooks Enabled?}
+    ENABLED -->|No| SKIP[Skip]
+    ENABLED -->|Yes| LOOKUP[Lookup hooks for phase-event]
+    LOOKUP --> EXEC[Execute hooks sequentially]
+    
+    EXEC --> RESULT{Hook Result}
+    RESULT -->|Success| NEXT{More hooks?}
+    NEXT -->|Yes| EXEC
+    NEXT -->|No| CONTINUE[Continue Loop]
+    
+    RESULT -->|Failure| ON_ERR{on_error}
+    ON_ERR -->|warn| LOG[Log Warning] --> NEXT
+    ON_ERR -->|block| BLOCK[Block Loop Action]
+    ON_ERR -->|suspend| SUSPEND[Suspend Loop<br/>Await Recovery]
+    
+    SUSPEND --> MODE{suspend_mode}
+    MODE -->|wait_for_resume| WAIT[Wait for operator]
+    MODE -->|retry_backoff| RETRY[Retry with backoff]
+    MODE -->|wait_then_retry| WAIT_RETRY[Wait then retry once]
+```
+
+## Session Recording & Replay
+
+```mermaid
+flowchart LR
+    REC[ralph run --record-session file.jsonl] --> OBSERVER[Session Recorder<br/>EventBus Observer]
+    OBSERVER --> JSONL[(file.jsonl)]
+    
+    JSONL --> REPLAY[Smoke Test Runner]
+    REPLAY --> MOCK[Replay Backend<br/>Serves recorded responses]
+    MOCK --> TEST[Automated Test<br/>Validates behavior]
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ npm run test:server                          # Backend tests
 ```
 ralph-cli      → CLI entry point, commands (run, plan, task, loops, web)
 ralph-core     → Orchestration logic, event loop, hats, memories, tasks
-ralph-adapters → Backend integrations (Claude, Kiro, Gemini, Codex, etc.)
+ralph-adapters → Backend integrations (Claude, Kiro, Gemini, Codex, Roo, etc.)
 ralph-telegram → Telegram bot for human-in-the-loop communication
 ralph-tui      → Terminal UI (ratatui-based)
 ralph-e2e      → End-to-end test framework

--- a/code-base-summary.md
+++ b/code-base-summary.md
@@ -1,0 +1,349 @@
+# Ralph Orchestrator — Codebase Summary
+
+> Multi-agent orchestration framework for AI coding assistants.
+> Version 2.6.0 | Rust + TypeScript | MIT License
+
+---
+
+## Table of Contents
+
+- [Project Overview](#project-overview)
+- [Architecture](#architecture)
+- [Workspace Structure](#workspace-structure)
+- [Crate & Package Guide](#crate--package-guide)
+- [Core Concepts](#core-concepts)
+- [Interfaces & Protocols](#interfaces--protocols)
+- [Data Models](#data-models)
+- [Key Workflows](#key-workflows)
+- [Configuration](#configuration)
+- [Testing](#testing)
+- [Detailed Documentation](#detailed-documentation)
+
+---
+
+## Project Overview
+
+Ralph Orchestrator coordinates AI coding assistants (Claude, Kiro, Gemini, Codex, Amp, Pi) through an event-driven loop. Agents wear "hats" (personas) that define their behavior, and communicate via a pub/sub event bus with topic-based routing.
+
+| Attribute | Value |
+|-----------|-------|
+| **Repository** | https://github.com/mikeyobrien/ralph-orchestrator |
+| **Primary Language** | Rust (215 source files, 9 crates) |
+| **Web Backend** | TypeScript/Node.js — Fastify + tRPC + SQLite (58 files) |
+| **Web Frontend** | TypeScript/React — Vite + TailwindCSS (70 files) |
+| **Platforms** | macOS (aarch64/x86_64), Linux (aarch64/x86_64) |
+| **Rust Edition** | 2024 |
+| **Node.js** | ≥ 22.0.0 |
+
+---
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph "User Interfaces"
+        CLI["ralph-cli<br/>CLI Entry Point"]
+        TUI["ralph-tui<br/>Terminal UI"]
+        WEB["Web Dashboard<br/>React + Vite"]
+        TEL["ralph-telegram<br/>Telegram Bot"]
+    end
+
+    subgraph "API Layer"
+        API["ralph-api<br/>Axum REST/WS"]
+        WEBAPI["@ralph-web/server<br/>Fastify + tRPC"]
+    end
+
+    subgraph "Core Engine"
+        CORE["ralph-core<br/>Orchestration Logic"]
+        PROTO["ralph-proto<br/>Protocol Types"]
+    end
+
+    subgraph "Agent Backends"
+        ADAPT["ralph-adapters"]
+        CLAUDE["Claude"] 
+        KIRO["Kiro"]
+        GEMINI["Gemini"]
+        OTHER["Codex / Amp / Pi"]
+    end
+
+    CLI --> CORE
+    TUI --> API
+    TUI --> CORE
+    WEB --> WEBAPI
+    TEL --> CORE
+    API --> CORE
+    CORE --> PROTO
+    CORE --> ADAPT
+    ADAPT --> CLAUDE
+    ADAPT --> KIRO
+    ADAPT --> GEMINI
+    ADAPT --> OTHER
+```
+
+### Design Principles (The Ralph Tenets)
+
+1. **Fresh Context Is Reliability** — Each iteration clears context. Re-read specs, plan, code every cycle.
+2. **Backpressure Over Prescription** — Don't prescribe how; create gates that reject bad work (tests, typechecks, lints).
+3. **The Plan Is Disposable** — Regeneration costs one planning loop.
+4. **Disk Is State, Git Is Memory** — Memories and Tasks are the handoff mechanisms.
+5. **Steer With Signals, Not Scripts** — The codebase is the instruction manual.
+6. **Let Ralph Ralph** — Sit *on* the loop, not *in* it.
+
+---
+
+## Workspace Structure
+
+```
+ralph-orchestrator/
+├── crates/                 # Rust workspace (9 crates)
+│   ├── ralph-proto/        # Protocol definitions, shared types, traits
+│   ├── ralph-core/         # Event loop, hats, memories, tasks, hooks, coordination
+│   ├── ralph-adapters/     # Backend integrations (Claude, Kiro, Gemini, etc.)
+│   ├── ralph-cli/          # CLI entry point, all user-facing commands
+│   ├── ralph-tui/          # Terminal UI (ratatui-based, 3 operating modes)
+│   ├── ralph-telegram/     # Telegram bot for human-in-the-loop
+│   ├── ralph-api/          # REST/WebSocket API server (Axum)
+│   ├── ralph-e2e/          # End-to-end test framework
+│   └── ralph-bench/        # Benchmarking
+├── backend/ralph-web-server/  # @ralph-web/server (Fastify + tRPC + SQLite)
+├── frontend/ralph-web/        # @ralph-web/dashboard (React + Vite + TailwindCSS)
+├── presets/                # Hat collection YAML presets
+├── cassettes/              # Replay fixtures for smoke/E2E tests
+├── docs/                   # MkDocs documentation site
+├── scripts/                # Build and CI helpers
+└── .ralph/                 # Runtime state directory
+    ├── agent/memories.md   # Persistent learning
+    ├── agent/tasks.jsonl   # Runtime task tracking
+    ├── events.jsonl        # Event history
+    ├── loop.lock           # Primary loop PID lock
+    ├── loops.json          # Loop registry
+    └── merge-queue.jsonl   # Worktree merge queue
+```
+
+---
+
+## Crate & Package Guide
+
+### ralph-proto — Protocol Definitions
+
+Foundational types used across all crates: [`Event`](crates/ralph-proto/src/event.rs), [`EventBus`](crates/ralph-proto/src/event_bus.rs), [`Hat`](crates/ralph-proto/src/hat.rs), [`Topic`](crates/ralph-proto/src/topic.rs), [`RpcCommand`/`RpcEvent`](crates/ralph-proto/src/json_rpc.rs), [`RobotService`](crates/ralph-proto/src/robot.rs) trait, [`DaemonAdapter`](crates/ralph-proto/src/daemon.rs) trait, [`UxEvent`](crates/ralph-proto/src/ux_event.rs).
+
+### ralph-core — Orchestration Engine
+
+The largest crate, containing:
+- **Event Loop** ([`event_loop/mod.rs`](crates/ralph-core/src/event_loop/mod.rs)): Main orchestration loop
+- **HatlessRalph** ([`hatless_ralph.rs`](crates/ralph-core/src/hatless_ralph.rs)): Constant coordinator, prompt builder
+- **Configuration** ([`config.rs`](crates/ralph-core/src/config.rs)): Full config model with v1/v2 support
+- **Memory System** ([`memory.rs`](crates/ralph-core/src/memory.rs), [`memory_store.rs`](crates/ralph-core/src/memory_store.rs)): Persistent learning in markdown
+- **Task System** ([`task.rs`](crates/ralph-core/src/task.rs), [`task_store.rs`](crates/ralph-core/src/task_store.rs)): JSONL-based work tracking
+- **Hooks** ([`hooks/`](crates/ralph-core/src/hooks/)): Lifecycle event handlers with warn/block/suspend
+- **Skills** ([`skill.rs`](crates/ralph-core/src/skill.rs), [`skill_registry.rs`](crates/ralph-core/src/skill_registry.rs)): Skill discovery and injection
+- **Parallel Loops** ([`worktree.rs`](crates/ralph-core/src/worktree.rs), [`loop_lock.rs`](crates/ralph-core/src/loop_lock.rs), [`merge_queue.rs`](crates/ralph-core/src/merge_queue.rs)): Git worktree coordination
+- **Diagnostics** ([`diagnostics/`](crates/ralph-core/src/diagnostics/)): Agent output, orchestration, error, performance collectors
+
+### ralph-adapters — Backend Integrations
+
+Executes AI coding assistants: [`CliBackend`](crates/ralph-adapters/src/cli_backend.rs) (command construction), [`CliExecutor`](crates/ralph-adapters/src/cli_executor.rs) (output capture), [`PtyExecutor`](crates/ralph-adapters/src/pty_executor.rs) (PTY-based execution), [`auto_detect`](crates/ralph-adapters/src/auto_detect.rs) (PATH scanning), stream parsers for Claude and Pi protocols.
+
+### ralph-cli — CLI Entry Point
+
+All user-facing commands: `run`, `init`, `plan`, `code-task`, `tools`, `loops`, `hats`, `events`, `clean`, `emit`, `bot`, `web`, `tui`, `hooks`, `preflight`, `doctor`, `completions`. Implements subprocess TUI mode (two-process architecture).
+
+### ralph-tui — Terminal UI
+
+Three operating modes: in-process (EventBus observer), RPC client (HTTP/WS to ralph-api), subprocess RPC (JSON-lines over stdin/stdout). Built with ratatui + crossterm.
+
+### ralph-telegram — Telegram Bot
+
+Bidirectional human-in-the-loop: `human.interact` (agent asks question, loop blocks), `human.response` (human replies), `human.guidance` (proactive guidance). Implements `RobotService` trait via `TelegramService`.
+
+### ralph-api — REST/WebSocket Server
+
+Axum-based API with domains: loop management, task CRUD, planning sessions, preset browsing, configuration, hat collections, real-time event streaming.
+
+### @ralph-web/server — Node.js Backend
+
+Fastify + tRPC + SQLite: task queue with persistent storage, Ralph process supervision, event parsing, log streaming, config merging.
+
+### @ralph-web/dashboard — React Frontend
+
+Task management, visual hat collection builder (React Flow), PDD planning UI, loop monitoring with WebSocket updates.
+
+---
+
+## Core Concepts
+
+### Event-Driven Orchestration
+
+The `EventBus` routes events between hats using topic-based pub/sub:
+1. Agent writes events to `.ralph/events.jsonl`
+2. Event loop parses and publishes events
+3. `EventBus` routes to subscribed hats (specific patterns > wildcard fallbacks)
+4. Next hat with pending events is activated
+
+### Hat System
+
+Hats define agent behavior per iteration. Default topology: **Planner** (subscribes: `task.start`, `build.done`, `build.blocked`; publishes: `build.task`) → **Builder** (subscribes: `build.task`; publishes: `build.done`, `build.blocked`). Custom hats are defined in YAML with triggers, publications, instructions, and optional per-hat backends.
+
+### Parallel Loops
+
+When the primary loop lock is held, Ralph spawns parallel loops in git worktrees (`.worktrees/<loop-id>/`). Shared state (memories, specs, tasks) is symlinked. Completed loops queue for merge via `.ralph/merge-queue.jsonl`.
+
+### Hook Lifecycle
+
+Hooks fire at 12 lifecycle points (pre/post for: loop.start, iteration.start, plan.created, human.interact, loop.complete, loop.error). Failure modes: `warn` (continue), `block` (stop), `suspend` (pause and await recovery).
+
+---
+
+## Interfaces & Protocols
+
+### JSON-RPC Protocol (stdin/stdout)
+
+Newline-delimited JSON for IPC between loop and frontends.
+
+**Commands** (stdin → Ralph): `prompt`, `guidance`, `steer`, `follow_up`, `abort`, `get_state`, `get_iterations`, `set_hat`, `extension_ui_response`
+
+**Events** (Ralph → stdout): `loop_started`, `iteration_start`, `iteration_end`, `text_delta`, `tool_call_start`, `tool_call_end`, `error`, `hat_changed`, `task_status_changed`, `task_counts_updated`, `guidance_ack`, `loop_terminated`, `orchestration_event`, `response`
+
+### Key Rust Traits
+
+- **`RobotService`** (`ralph-proto`): Human-in-the-loop communication (send question, wait response, send checkin)
+- **`DaemonAdapter`** (`ralph-proto`): Persistent bot daemon (run_daemon)
+- **`FrameCapture`** (`ralph-proto`): Terminal output capture for recording/replay
+- **`HookExecutorContract`** (`ralph-core`): Hook command execution
+
+### EventBus Routing Rules
+
+1. Direct target → route only to that hat
+2. Specific subscriptions → route to matching non-wildcard patterns
+3. Fallback wildcards → global `*` subscribers
+4. Self-routing allowed (handles LLM non-determinism)
+5. `human.*` events use separate queue
+
+---
+
+## Data Models
+
+### Core Types
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `Event` | `ralph-proto` | Pub/sub message: topic + payload + source + target |
+| `Hat` | `ralph-proto` | Agent persona: id, subscriptions, publishes, instructions |
+| `Topic` | `ralph-proto` | Routing key with glob patterns |
+| `RalphConfig` | `ralph-core` | Full configuration (event_loop, cli, core, hats, hooks, etc.) |
+| `Task` | `ralph-core` | Runtime work item: id, title, status, priority, blocked_by |
+| `Memory` | `ralph-core` | Persistent learning: type (pattern/decision/fix/context), content, tags |
+
+### File-Based State
+
+| File | Format | Purpose |
+|------|--------|---------|
+| `.ralph/agent/memories.md` | Structured Markdown | Persistent learning |
+| `.ralph/agent/tasks.jsonl` | JSONL | Runtime task tracking |
+| `.ralph/events.jsonl` | JSONL | Event history |
+| `.ralph/loop.lock` | JSON | Primary loop PID lock |
+| `.ralph/loops.json` | JSON | Loop registry |
+| `.ralph/merge-queue.jsonl` | JSONL | Merge queue |
+
+### Termination Reasons
+
+| Reason | Exit Code | Description |
+|--------|-----------|-------------|
+| `Completed` | 0 | LOOP_COMPLETE detected |
+| `MaxIterations` | 2 | Iteration limit |
+| `MaxRuntime` | 2 | Time limit |
+| `MaxCost` | 2 | Cost limit |
+| `ConsecutiveFailures` | 1 | Too many failures |
+| `Interrupted` | 130 | SIGINT/SIGTERM |
+
+---
+
+## Key Workflows
+
+### Orchestration Loop
+
+```mermaid
+flowchart TD
+    START([ralph run]) --> LOAD[Load & Validate Config]
+    LOAD --> LOCK{Acquire Loop Lock}
+    LOCK -->|Success| INIT[Initialize Event Loop]
+    LOCK -->|Locked| WT[Create Worktree Loop]
+    WT --> INIT
+    INIT --> PROMPT[Build Prompt<br/>Guardrails + Hat + Memories + Skills]
+    PROMPT --> EXEC[Execute Agent Backend]
+    EXEC --> PARSE[Parse Events from JSONL]
+    PARSE --> ROUTE[Route via EventBus]
+    ROUTE --> CHECK{Termination?}
+    CHECK -->|No| NEXT[Select Next Hat]
+    NEXT --> PROMPT
+    CHECK -->|Yes| DONE[Landing & Cleanup]
+```
+
+### Subprocess TUI Mode (Default)
+
+```mermaid
+flowchart LR
+    subgraph Parent
+        TUI[ratatui UI]
+        WRITER[RPC Writer]
+        READER[Event Reader]
+    end
+    subgraph Child["ralph run --rpc"]
+        RPC_IN[stdin reader]
+        LOOP[Event Loop]
+        RPC_OUT[stdout JSON]
+    end
+    WRITER -->|commands| RPC_IN
+    RPC_OUT -->|events| READER
+    READER --> TUI
+```
+
+---
+
+## Configuration
+
+Configuration uses a split model:
+
+1. **Core config** (`ralph.yml`): backend, event loop, features, hooks, memories, tasks
+2. **Hat collections** (`-H builtin:feature` or YAML): hat definitions, event metadata
+
+Supports both v1 (flat: `agent: claude`, `max_iterations: 100`) and v2 (nested: `cli.backend`, `event_loop.max_iterations`) formats with automatic normalization.
+
+Key config sections: `event_loop` (iterations, runtime, cost limits, completion_promise), `cli` (backend, prompt_mode), `core` (scratchpad, specs_dir, guardrails), `hats` (custom hat definitions), `hooks` (lifecycle hooks), `memories` (inject mode, budget, filters), `tasks` (enabled), `skills` (directories, overrides), `features` (parallel, auto_merge, preflight), `RObot` (Telegram integration).
+
+---
+
+## Testing
+
+```bash
+cargo build                                    # Build all crates
+cargo test                                     # Run all tests
+cargo test -p ralph-core test_name             # Single test
+cargo test -p ralph-core smoke_runner          # Smoke tests (replay-based)
+cargo run -p ralph-e2e -- --mock               # E2E tests (CI-safe)
+npm run test:server                            # Backend tests
+```
+
+- **Unit tests**: Throughout all crates
+- **Smoke tests**: Replay-based using recorded JSONL fixtures in `crates/ralph-core/tests/fixtures/`
+- **E2E tests**: Full orchestration with mock or live backends, reports in `.e2e-tests/`
+- **Session recording**: `ralph run --record-session file.jsonl` captures sessions for replay
+
+---
+
+## Detailed Documentation
+
+For in-depth information, see the `.agents/summary/` directory:
+
+| File | Content |
+|------|---------|
+| [`.agents/summary/index.md`](.agents/summary/index.md) | Documentation index and quick reference |
+| [`.agents/summary/codebase_info.md`](.agents/summary/codebase_info.md) | Project identity, tech stack, platforms |
+| [`.agents/summary/architecture.md`](.agents/summary/architecture.md) | System architecture and design patterns |
+| [`.agents/summary/components.md`](.agents/summary/components.md) | Every crate, module, and web package |
+| [`.agents/summary/interfaces.md`](.agents/summary/interfaces.md) | Traits, RPC protocol, CLI commands, REST API |
+| [`.agents/summary/data_models.md`](.agents/summary/data_models.md) | All data structures and file formats |
+| [`.agents/summary/workflows.md`](.agents/summary/workflows.md) | End-to-end workflow diagrams |
+| [`.agents/summary/dependencies.md`](.agents/summary/dependencies.md) | External and internal dependencies |
+| [`.agents/summary/review_notes.md`](.agents/summary/review_notes.md) | Documentation review and gap analysis |

--- a/crates/ralph-adapters/src/auto_detect.rs
+++ b/crates/ralph-adapters/src/auto_detect.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 /// Default priority order for backend detection.
 pub const DEFAULT_PRIORITY: &[&str] = &[
-    "claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi",
+    "claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi", "roo",
 ];
 
 /// Maps backend config names to their actual CLI command names.
@@ -60,6 +60,7 @@ impl std::fmt::Display for NoBackendError {
             f,
             "  • Pi CLI:       https://github.com/anthropics/pi-coding-agent"
         )?;
+        writeln!(f, "  • Roo CLI:      https://github.com/RooVetGit/Roo-Code")?;
         Ok(())
     }
 }
@@ -210,6 +211,7 @@ mod tests {
         assert_eq!(detection_command("codex"), "codex");
         assert_eq!(detection_command("amp"), "amp");
         assert_eq!(detection_command("pi"), "pi");
+        assert_eq!(detection_command("roo"), "roo");
     }
 
     #[test]
@@ -221,12 +223,35 @@ mod tests {
     }
 
     #[test]
-    fn test_default_priority_pi_is_last() {
+    fn test_default_priority_pi_is_second_to_last() {
+        let len = DEFAULT_PRIORITY.len();
+        assert_eq!(
+            DEFAULT_PRIORITY[len - 2],
+            "pi",
+            "Pi should be second-to-last in DEFAULT_PRIORITY"
+        );
+    }
+
+    #[test]
+    fn test_default_priority_includes_roo() {
+        assert!(
+            DEFAULT_PRIORITY.contains(&"roo"),
+            "DEFAULT_PRIORITY should include 'roo'"
+        );
+    }
+
+    #[test]
+    fn test_default_priority_roo_is_last() {
         assert_eq!(
             DEFAULT_PRIORITY.last(),
-            Some(&"pi"),
-            "Pi should be the last entry in DEFAULT_PRIORITY"
+            Some(&"roo"),
+            "Roo should be the last entry in DEFAULT_PRIORITY"
         );
+    }
+
+    #[test]
+    fn test_detection_command_roo() {
+        assert_eq!(detection_command("roo"), "roo");
     }
 
     #[test]

--- a/crates/ralph-adapters/src/cli_backend.rs
+++ b/crates/ralph-adapters/src/cli_backend.rs
@@ -76,6 +76,7 @@ impl CliBackend {
             "copilot" => Self::copilot(),
             "opencode" => Self::opencode(),
             "pi" => Self::pi(),
+            "roo" => Self::roo(),
             "custom" => return Self::custom(config),
             _ => Self::claude(), // Default to claude
         };
@@ -243,6 +244,7 @@ impl CliBackend {
             "copilot" => Ok(Self::copilot()),
             "opencode" => Ok(Self::opencode()),
             "pi" => Ok(Self::pi()),
+            "roo" => Ok(Self::roo()),
             _ => Err(CustomBackendError),
         }
     }
@@ -395,6 +397,7 @@ impl CliBackend {
             "copilot" => Ok(Self::copilot_interactive()),
             "opencode" => Ok(Self::opencode_interactive()),
             "pi" => Ok(Self::pi_interactive()),
+            "roo" => Ok(Self::roo_interactive()),
             _ => Err(CustomBackendError),
         }
     }
@@ -567,6 +570,38 @@ impl CliBackend {
         }
     }
 
+    /// Creates the Roo backend for headless execution.
+    ///
+    /// Uses `--print` for non-interactive output and `--ephemeral` for clean
+    /// disk state. Prompts are always passed via `--prompt-file` (handled in
+    /// `build_command()`). Roo auto-approves tools by default, so no
+    /// `--trust-all-tools` equivalent is needed.
+    pub fn roo() -> Self {
+        Self {
+            command: "roo".to_string(),
+            args: vec!["--print".to_string(), "--ephemeral".to_string()],
+            prompt_mode: PromptMode::Arg,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        }
+    }
+
+    /// Creates the Roo backend for interactive mode with initial prompt.
+    ///
+    /// Runs roo TUI without `--print` or `--ephemeral`, passing the prompt
+    /// as a positional argument. Used by `ralph plan` for interactive sessions.
+    pub fn roo_interactive() -> Self {
+        Self {
+            command: "roo".to_string(),
+            args: vec![],
+            prompt_mode: PromptMode::Arg,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        }
+    }
+
     /// Creates a custom backend from configuration.
     ///
     /// # Errors
@@ -589,6 +624,33 @@ impl CliBackend {
         })
     }
 
+    /// Builds roo prompt-file args: writes prompt to a temp file and
+    /// appends `--prompt-file <path>` to args. Falls back to positional
+    /// arg if temp file creation fails.
+    fn build_roo_prompt_file(
+        args: &mut Vec<String>,
+        prompt: &str,
+    ) -> (Option<String>, Option<NamedTempFile>) {
+        match NamedTempFile::new() {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(prompt.as_bytes()) {
+                    tracing::warn!("Failed to write roo prompt to temp file: {}", e);
+                    args.push(prompt.to_string());
+                    (None, None)
+                } else {
+                    args.push("--prompt-file".to_string());
+                    args.push(file.path().display().to_string());
+                    (None, Some(file))
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to create temp file for roo: {}", e);
+                args.push(prompt.to_string());
+                (None, None)
+            }
+        }
+    }
+
     /// Builds the full command with arguments for execution.
     ///
     /// # Arguments
@@ -606,38 +668,47 @@ impl CliBackend {
             args = self.filter_args_for_interactive(args);
         }
 
-        // Handle large prompts for Claude (>7000 chars)
+        // Handle prompt passing: Roo uses --prompt-file, Claude uses temp file for large prompts
         let (stdin_input, temp_file) = match self.prompt_mode {
             PromptMode::Arg => {
-                let (prompt_text, temp_file) = if self.command == "claude" && prompt.len() > 7000 {
-                    // Write to temp file and instruct Claude to read it
-                    match NamedTempFile::new() {
-                        Ok(mut file) => {
-                            if let Err(e) = file.write_all(prompt.as_bytes()) {
-                                tracing::warn!("Failed to write prompt to temp file: {}", e);
+                // Roo headless: always use --prompt-file for all prompts
+                // Only headless roo() has --print in args; roo_interactive() does not
+                if self.command == "roo" && args.contains(&"--print".to_string()) {
+                    Self::build_roo_prompt_file(&mut args, prompt)
+                } else {
+                    // Handle large prompts for Claude (>7000 chars)
+                    let (prompt_text, temp_file) = if self.command == "claude"
+                        && prompt.len() > 7000
+                    {
+                        // Write to temp file and instruct Claude to read it
+                        match NamedTempFile::new() {
+                            Ok(mut file) => {
+                                if let Err(e) = file.write_all(prompt.as_bytes()) {
+                                    tracing::warn!("Failed to write prompt to temp file: {}", e);
+                                    (prompt.to_string(), None)
+                                } else {
+                                    let path = file.path().display().to_string();
+                                    (
+                                        format!("Please read and execute the task in {}", path),
+                                        Some(file),
+                                    )
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("Failed to create temp file: {}", e);
                                 (prompt.to_string(), None)
-                            } else {
-                                let path = file.path().display().to_string();
-                                (
-                                    format!("Please read and execute the task in {}", path),
-                                    Some(file),
-                                )
                             }
                         }
-                        Err(e) => {
-                            tracing::warn!("Failed to create temp file: {}", e);
-                            (prompt.to_string(), None)
-                        }
-                    }
-                } else {
-                    (prompt.to_string(), None)
-                };
+                    } else {
+                        (prompt.to_string(), None)
+                    };
 
-                if let Some(ref flag) = self.prompt_flag {
-                    args.push(flag.clone());
+                    if let Some(ref flag) = self.prompt_flag {
+                        args.push(flag.clone());
+                    }
+                    args.push(prompt_text);
+                    (None, temp_file)
                 }
-                args.push(prompt_text);
-                (None, temp_file)
             }
             PromptMode::Stdin => (Some(prompt.to_string()), None),
         };
@@ -673,6 +744,10 @@ impl CliBackend {
             "copilot" => args
                 .into_iter()
                 .filter(|a| a != "--allow-all-tools")
+                .collect(),
+            "roo" => args
+                .into_iter()
+                .filter(|a| a != "--print" && a != "--ephemeral")
                 .collect(),
             _ => args, // claude, gemini, opencode unchanged
         }
@@ -1619,5 +1694,176 @@ mod tests {
         assert!(CliBackend::copilot().env_vars.is_empty());
         assert!(CliBackend::opencode().env_vars.is_empty());
         assert!(CliBackend::pi().env_vars.is_empty());
+        assert!(CliBackend::roo().env_vars.is_empty());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Tests for Roo backend
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_roo_backend() {
+        let backend = CliBackend::roo();
+        let (cmd, args, stdin, temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "roo");
+        // Should use --prompt-file with temp file, not positional arg
+        assert!(
+            temp.is_some(),
+            "roo should always use temp file for prompts"
+        );
+        assert!(
+            args.contains(&"--print".to_string()),
+            "roo headless should have --print"
+        );
+        assert!(
+            args.contains(&"--ephemeral".to_string()),
+            "roo headless should have --ephemeral"
+        );
+        assert!(
+            args.contains(&"--prompt-file".to_string()),
+            "roo should use --prompt-file"
+        );
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn test_roo_interactive() {
+        let backend = CliBackend::roo_interactive();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "roo");
+        // Interactive mode: no --print, no --ephemeral, positional prompt
+        assert_eq!(args, vec!["test prompt"]);
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+        assert_eq!(backend.prompt_flag, None);
+    }
+
+    #[test]
+    fn test_from_name_roo() {
+        let backend = CliBackend::from_name("roo").unwrap();
+        assert_eq!(backend.command, "roo");
+        assert_eq!(backend.prompt_flag, None);
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn test_from_config_roo() {
+        let config = CliConfig {
+            backend: "roo".to_string(),
+            command: None,
+            prompt_mode: "arg".to_string(),
+            ..Default::default()
+        };
+        let backend = CliBackend::from_config(&config).unwrap();
+
+        assert_eq!(backend.command, "roo");
+        assert_eq!(backend.output_format, OutputFormat::Text);
+        assert!(backend.args.contains(&"--print".to_string()));
+        assert!(backend.args.contains(&"--ephemeral".to_string()));
+    }
+
+    #[test]
+    fn test_from_config_roo_with_args() {
+        let config = CliConfig {
+            backend: "roo".to_string(),
+            command: None,
+            prompt_mode: "arg".to_string(),
+            args: vec![
+                "--provider".to_string(),
+                "bedrock".to_string(),
+                "--model".to_string(),
+                "anthropic.claude-sonnet-4-6".to_string(),
+            ],
+            ..Default::default()
+        };
+        let backend = CliBackend::from_config(&config).unwrap();
+        let (_cmd, args, _stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(backend.command, "roo");
+        // Should have default args + extra args + --prompt-file
+        assert!(args.contains(&"--print".to_string()));
+        assert!(args.contains(&"--ephemeral".to_string()));
+        assert!(args.contains(&"--provider".to_string()));
+        assert!(args.contains(&"bedrock".to_string()));
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"anthropic.claude-sonnet-4-6".to_string()));
+        assert!(args.contains(&"--prompt-file".to_string()));
+    }
+
+    #[test]
+    fn test_for_interactive_prompt_roo() {
+        let backend = CliBackend::for_interactive_prompt("roo").unwrap();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "roo");
+        // Interactive: no --print, no --ephemeral, positional prompt
+        assert_eq!(args, vec!["test prompt"]);
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
+    fn test_roo_interactive_mode_removes_print() {
+        let backend = CliBackend::roo();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", true);
+
+        assert_eq!(cmd, "roo");
+        // In interactive mode, --print and --ephemeral should be removed
+        assert!(
+            !args.contains(&"--print".to_string()),
+            "interactive mode should remove --print"
+        );
+        assert!(
+            !args.contains(&"--ephemeral".to_string()),
+            "interactive mode should remove --ephemeral"
+        );
+        assert!(stdin.is_none());
+    }
+
+    #[test]
+    fn test_roo_uses_prompt_file() {
+        let backend = CliBackend::roo();
+        // Test with small prompt
+        let (_, args_small, _, temp_small) = backend.build_command("small prompt", false);
+        assert!(
+            temp_small.is_some(),
+            "even small prompts should use temp file"
+        );
+        assert!(
+            args_small.contains(&"--prompt-file".to_string()),
+            "should use --prompt-file"
+        );
+
+        // Test with large prompt
+        let large_prompt = "x".repeat(10000);
+        let (_, args_large, _, temp_large) = backend.build_command(&large_prompt, false);
+        assert!(temp_large.is_some(), "large prompts should use temp file");
+        assert!(
+            args_large.contains(&"--prompt-file".to_string()),
+            "should use --prompt-file for large prompts"
+        );
+    }
+
+    #[test]
+    fn test_roo_prompt_file_content() {
+        use std::io::{Read, Seek};
+        let backend = CliBackend::roo();
+        let prompt = "This is a test prompt for roo";
+        let (_, _, _, temp) = backend.build_command(prompt, false);
+
+        let mut temp_file = temp.expect("should have temp file");
+        let mut content = String::new();
+        temp_file
+            .as_file_mut()
+            .seek(std::io::SeekFrom::Start(0))
+            .unwrap();
+        temp_file
+            .as_file_mut()
+            .read_to_string(&mut content)
+            .unwrap();
+        assert_eq!(content, prompt);
     }
 }

--- a/crates/ralph-adapters/src/lib.rs
+++ b/crates/ralph-adapters/src/lib.rs
@@ -7,6 +7,7 @@
 //! - Gemini (Google)
 //! - Codex (OpenAI)
 //! - Pi (pi-coding-agent)
+//! - Roo (Roo Code)
 //! - Amp
 //! - Custom commands
 //!

--- a/docs/guide/roo-backend.md
+++ b/docs/guide/roo-backend.md
@@ -1,0 +1,253 @@
+# Using Ralph Orchestrator with Roo Code CLI
+
+## Quick Start
+
+### Prerequisites
+
+1. **Ralph** installed (`cargo build` from this repo)
+2. **Roo CLI** installed (`roo --version` should return 0.1.15+)
+3. **AWS Bedrock** access configured (or another supported provider)
+
+### Run Your First Loop
+
+```bash
+# Simple one-iteration test
+ralph run -b roo --max-iterations 1 \
+  -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
+     --model anthropic.claude-sonnet-4-6 --max-tokens 64000 \
+  -p "Create a hello.txt file with 'Hello World'"
+```
+
+## Configuration
+
+### Option 1: CLI Flags (Quick)
+
+Pass roo-specific flags after `--`:
+
+```bash
+ralph run -b roo -- \
+  --provider bedrock \
+  --aws-profile roo-bedrock \
+  --aws-region us-east-1 \
+  --model anthropic.claude-sonnet-4-6 \
+  --max-tokens 64000
+```
+
+### Option 2: Config File (Recommended)
+
+Create a `ralph.roo.yml`:
+
+```yaml
+# Ralph + Roo Configuration
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400      # 4 hours
+  max_consecutive_failures: 5
+
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  idle_timeout_secs: 30
+  args:
+    - "--provider"
+    - "bedrock"
+    - "--aws-profile"
+    - "roo-bedrock"
+    - "--aws-region"
+    - "us-east-1"
+    - "--model"
+    - "anthropic.claude-sonnet-4-6"
+    - "--max-tokens"
+    - "100000"
+    - "--reasoning-effort"
+    - "medium"
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - save learnings to memories for next time"
+    - "Don't assume 'not implemented' - search first"
+    - "Verification is mandatory - tests/typecheck/lint/audit must pass"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document; <50 choose safe default + document."
+
+hats:
+  builder:
+    name: "Builder"
+    description: "Implements code, creates files, runs tests. Does the actual work."
+    triggers: ["build.task"]
+    publishes: ["build.done", "build.blocked"]
+    instructions: |
+      ## WORKFLOW
+      You are Builder. Your job is to IMPLEMENT - write code, create files, run tests.
+      1. Read the build.task event payload - that's your task
+      2. IMPLEMENT: Create files, write code, run commands
+      3. VERIFY: Run tests/builds to confirm it works
+      4. COMPLETE: Emit build.done when verified, or build.blocked if stuck
+      RULES:
+      - Do the actual work - don't just plan or delegate
+      - Never emit build.task (that's for coordination, not you)
+```
+
+Then run:
+
+```bash
+ralph run -c ralph.roo.yml -p "Build feature X"
+```
+
+### Option 3: PDD-to-Code-Assist with Roo
+
+For the full PDD → Code Assist workflow using Roo with Claude Opus 4.6:
+
+Create `ralph.roo.pdd.yml`:
+
+```yaml
+# PDD-to-Code-Assist with Roo Code CLI
+# Uses Claude Opus 4.6 via Bedrock with medium reasoning effort
+
+event_loop:
+  prompt_file: "PROMPT.md"
+  completion_promise: "LOOP_COMPLETE"
+  starting_event: "design.start"
+  max_iterations: 150
+  max_runtime_seconds: 14400
+  checkpoint_interval: 5
+
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  idle_timeout_secs: 60
+  args:
+    - "--provider"
+    - "bedrock"
+    - "--aws-profile"
+    - "roo-bedrock"
+    - "--aws-region"
+    - "us-east-1"
+    - "--model"
+    - "anthropic.claude-opus-4-6"
+    - "--max-tokens"
+    - "100000"
+    - "--reasoning-effort"
+    - "medium"
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration — save learnings to memories for next time"
+    - "Verification is mandatory — tests/typecheck/lint/audit must pass"
+    - "YAGNI ruthlessly — no speculative features"
+    - "KISS always — simplest solution that works"
+    - "Preserve primary sources — all referenced files, research findings, code snippets, and external docs must be captured with source attribution"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document in .ralph/agent/decisions.md; <50 choose safe default + document."
+
+# Copy hats from presets/pdd-to-code-assist.yml
+# (inquisitor, architect, design_critic, explorer, planner, task_writer, builder, validator, committer)
+```
+
+Then run:
+
+```bash
+ralph run -c ralph.roo.pdd.yml -p "Build a CLI tool for managing tasks"
+```
+
+Or use the built-in preset with roo args:
+
+```bash
+ralph run -c presets/pdd-to-code-assist.yml \
+  -c cli.backend=roo \
+  -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
+     --model anthropic.claude-opus-4-6 --max-tokens 100000 \
+     --reasoning-effort medium \
+  -p "Build a CLI tool for managing tasks"
+```
+
+## Roo-Specific Configuration Options
+
+### Model Selection
+
+Pass model flags via `cli.args` or `--`:
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `--provider` | LLM provider | `bedrock`, `anthropic`, `openai`, `openrouter` |
+| `--model` | Model identifier | `anthropic.claude-opus-4-6`, `anthropic.claude-sonnet-4-6` |
+| `--max-tokens` | Max output tokens | `100000` |
+| `--reasoning-effort` | Thinking effort | `medium`, `high`, `xhigh` |
+| `--aws-profile` | AWS credentials profile | `roo-bedrock` |
+| `--aws-region` | AWS Bedrock region | `us-east-1` |
+
+### Roo Modes
+
+Roo has built-in modes (`code`, `architect`, `ask`, `debug`). By default, it uses `code` mode which has all tools (read, edit, command, mcp). Override with:
+
+```yaml
+cli:
+  args:
+    - "--mode"
+    - "architect"  # For planning-focused hats
+```
+
+### Interactive Planning
+
+Use `ralph plan` for interactive sessions with Roo's TUI:
+
+```bash
+ralph plan -b roo -- --provider bedrock --aws-profile roo-bedrock \
+  --aws-region us-east-1 --model anthropic.claude-opus-4-6 \
+  --max-tokens 100000 \
+  -p "Design the auth system architecture"
+```
+
+## How It Works
+
+### Architecture
+
+```
+Ralph Loop (each iteration):
+1. Ralph builds prompt (context + events + memories + instructions)
+2. Writes prompt to temp file
+3. Spawns: roo --print --ephemeral --prompt-file /tmp/xxx [user args]
+4. Roo reads prompt, executes tools, produces text output
+5. Ralph parses output for events (<event topic="...">) and LOOP_COMPLETE
+6. Next iteration with updated context
+```
+
+### Key Behaviors
+
+| Aspect | Behavior |
+|--------|----------|
+| **Context** | Fresh each iteration — roo has no memory between iterations |
+| **Tool approval** | Auto-approved by default (no flag needed) |
+| **Disk state** | `--ephemeral` keeps disk clean between iterations |
+| **Prompt passing** | Always via `--prompt-file` (handles any prompt size) |
+| **Error detection** | LOOP_COMPLETE presence + consecutive failure counter |
+| **Exit codes** | Config errors → exit 1; API errors → infinite retry (idle timeout handles) |
+
+## Troubleshooting
+
+### Bedrock Cross-Region Errors
+
+If you see "Try enabling cross-region inference":
+1. Ensure `--aws-region` matches your Bedrock setup
+2. Check `--aws-profile` has correct credentials
+3. Verify the model is available in your region
+
+### Roo Retries Indefinitely
+
+Roo retries API errors with exponential backoff. Ralph's `idle_timeout_secs` (default 30s) will kill the process. Increase if your model is slow:
+
+```yaml
+cli:
+  idle_timeout_secs: 60  # or higher for large prompts
+```
+
+### CustomModesManager Warning
+
+```
+[CustomModesManager] Failed to load modes from .../custom_modes.yaml: ENOENT
+```
+
+This is benign — `--ephemeral` mode uses a temp directory where custom modes don't exist. No action needed.

--- a/presets/minimal/roo.yml
+++ b/presets/minimal/roo.yml
@@ -1,0 +1,46 @@
+# Ralph Orchestrator Configuration for Roo Code CLI
+# v2 nested format - optimized for Roo CLI
+
+# Event loop settings
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400      # 4 hours
+  max_consecutive_failures: 5
+
+# CLI backend settings
+cli:
+  backend: "roo"
+  prompt_mode: "arg"              # Pass prompt as CLI argument
+  pty_mode: false                 # Set true for rich terminal UI
+  pty_interactive: true           # Forward keystrokes in PTY mode
+  idle_timeout_secs: 30           # Kill after 30s of inactivity
+
+# Core behaviors (always injected into prompts)
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - save learnings to memories for next time"
+    - "Don't assume 'not implemented' - search first"
+    - "Verification is mandatory - tests/typecheck/lint/audit must pass"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document in .ralph/agent/decisions.md; <50 choose safe default + document."
+
+hats:
+  builder:
+    name: "Builder"
+    description: "Implements code, creates files, runs tests. Does the actual work."
+    triggers: ["build.task"]
+    publishes: ["build.done", "build.blocked"]
+    instructions: |
+      ## WORKFLOW
+
+      You are Builder. Your job is to IMPLEMENT - write code, create files, run tests.
+
+      1. Read the build.task event payload - that's your task
+      2. IMPLEMENT: Create files, write code, run commands
+      3. VERIFY: Run tests/builds to confirm it works
+      4. COMPLETE: Emit build.done when verified, or build.blocked if stuck
+
+      RULES:
+      - Do the actual work - don't just plan or delegate
+      - Never emit build.task (that's for coordination, not you)

--- a/ralph.roo.yml
+++ b/ralph.roo.yml
@@ -1,0 +1,27 @@
+# Ralph + Roo: PDD-to-Code-Assist Configuration
+# Uses Claude Opus 4.6 via Bedrock with adaptive thinking
+#
+# Usage:
+#   ralph run -c ralph.roo.yml -p "Build a feature to..."
+#
+# Or with the pdd-to-code-assist preset:
+#   ralph run -c presets/pdd-to-code-assist.yml -c ralph.roo.yml -p "Build a feature to..."
+
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  idle_timeout_secs: 60           # Opus can be slow; 60s idle timeout
+  args:
+    - "--provider"
+    - "bedrock"
+    - "--aws-profile"
+    - "roo-bedrock"
+    - "--aws-region"
+    - "us-east-1"
+    - "--model"
+    - "anthropic.claude-opus-4-6"
+    - "--max-tokens"
+    - "100000"
+    - "--reasoning-effort"
+    - "medium"                    # Adaptive thinking: medium (default)

--- a/specs/roo-cli-provider/design/detailed-design.md
+++ b/specs/roo-cli-provider/design/detailed-design.md
@@ -1,0 +1,279 @@
+# Detailed Design: Add roo-cli as a Provider
+
+## Overview
+
+This design adds Roo Code CLI (`roo`) as a new backend provider in ralph-orchestrator, following the same adapter pattern used by kiro, claude, gemini, and other existing backends. The integration uses **text mode** (plain stdout capture) for simplicity and reliability, with `--prompt-file` for prompt passing.
+
+Roo is an AI coding assistant CLI (v0.1.15+) that supports multiple LLM providers (Anthropic, OpenAI, AWS Bedrock, OpenRouter, etc.) and features tool auto-approval by default, making it well-suited for Ralph's autonomous loop.
+
+## Detailed Requirements
+
+### Functional Requirements
+
+1. **Headless execution**: `roo --print --ephemeral --prompt-file <path>` runs roo in non-interactive mode with clean disk state, reads prompt from file, executes, and exits
+2. **Interactive execution**: `roo "prompt"` launches roo's TUI for `ralph plan` use
+3. **Extra args passthrough**: Users configure model, provider, AWS flags via `cli.args` in ralph.yml
+4. **Auto-detection**: `roo --version` checks if roo is available in PATH
+5. **Preset file**: `presets/minimal/roo.yml` provides a ready-to-use configuration
+
+### Non-Functional Requirements
+
+1. **Text output format**: Plain text capture (like kiro, gemini, codex)
+2. **Pipe mode**: `pty_mode: false` for clean output without ANSI codes
+3. **Standard error handling**: Exit codes + event tags + LOOP_COMPLETE token
+4. **No roo-specific parsing**: No custom error detection or output processing
+
+## Out of Scope
+
+- **Stream-JSON support**: Roo's `--output-format stream-json` provides structured NDJSON with cost/token tracking. Deferred to future enhancement.
+- **`--ephemeral` issue**: Previously broke Bedrock authentication, now fixed in roo v0.1.15+. Included in defaults.
+- **Roo mode integration**: Ralph hats don't map to roo `--mode` flags. Users configure via `cli.args`.
+- **Custom RooStreamParser**: Not needed for text mode. Required only if stream-json is added later.
+- **Roo session management**: No `--continue` or `--session-id` usage. Each iteration is a fresh invocation.
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    Config["ralph.yml<br/>cli.backend: 'roo'"] --> CliBackend["CliBackend::from_config()"]
+    CliBackend --> |"roo --print --ephemeral --prompt-file tmp"| CliExecutor["CliExecutor<br/>(pipe-based)"]
+    CliBackend --> |"roo prompt"| PtyExecutor["PtyExecutor<br/>(interactive)"]
+    CliExecutor --> Output["Text output<br/>parsed for events"]
+    PtyExecutor --> TUI["User interacts<br/>with roo TUI"]
+    
+    subgraph "Auto-Detection"
+        AutoDetect["detect_backend()"] --> |"roo --version"| Check["is_backend_available()"]
+        Check --> |"exit 0"| Found["Backend: roo"]
+    end
+    
+    subgraph "Config Flow"
+        UserConfig["User ralph.yml"] --> |"cli.args"| MergedArgs["--provider bedrock<br/>--aws-profile ...<br/>--model ..."]
+        Preset["presets/minimal/roo.yml"] --> UserConfig
+    end
+```
+
+## Components and Interfaces
+
+### 1. Backend Definition (`cli_backend.rs`)
+
+Two new methods on `CliBackend`:
+
+#### `roo()` — Headless mode
+```rust
+pub fn roo() -> Self {
+    Self {
+        command: "roo".to_string(),
+        args: vec!["--print".to_string(), "--ephemeral".to_string()],
+        prompt_mode: PromptMode::Arg,      // Uses --prompt-file in build_command
+        prompt_flag: None,                  // Positional prompt (small) or --prompt-file (large)
+        output_format: OutputFormat::Text,
+        env_vars: vec![],
+    }
+}
+```
+
+#### `roo_interactive()` — Interactive mode
+```rust
+pub fn roo_interactive() -> Self {
+    Self {
+        command: "roo".to_string(),
+        args: vec![],
+        prompt_mode: PromptMode::Arg,
+        prompt_flag: None,                  // Positional prompt
+        output_format: OutputFormat::Text,
+        env_vars: vec![],
+    }
+}
+```
+
+### 2. Prompt Handling via `--prompt-file` (`build_command()`)
+
+Roo natively supports `--prompt-file <path>`. **All roo prompts** are passed via `--prompt-file` (not positional args). This is simpler than conditional logic — one code path, no size threshold, verified working for both small and large prompts.
+
+`build_command()` will:
+1. Write prompt to a `NamedTempFile`
+2. Add `--prompt-file <path>` to args (no positional prompt)
+3. Return the temp file handle to keep it alive during execution
+
+```rust
+// In build_command() for roo:
+if self.command == "roo" {
+    // Always write prompt to temp file and use --prompt-file
+    match NamedTempFile::new() {
+        Ok(mut file) => {
+            file.write_all(prompt.as_bytes())?;
+            args.push("--prompt-file".to_string());
+            args.push(file.path().display().to_string());
+            (None, Some(file))
+        }
+        Err(_) => {
+            // Fallback to positional arg if temp file fails
+            args.push(prompt.to_string());
+            (None, None)
+        }
+    }
+}
+```
+
+This is cleaner than Claude's workaround (which writes a temp file and tells the agent "please read file X"). Roo reads the file directly as a native CLI feature.
+
+### 3. Registration Points
+
+| Location | Change |
+|----------|--------|
+| `from_config()` | Add `"roo" => Self::roo()` match arm |
+| `from_name()` | Add `"roo" => Ok(Self::roo())` match arm |
+| `for_interactive_prompt()` | Add `"roo" => Ok(Self::roo_interactive())` match arm |
+| `filter_args_for_interactive()` | Add `"roo"` arm that removes `--print` and `--ephemeral` |
+
+### 4. Auto-Detection (`auto_detect.rs`)
+
+| Change | Value |
+|--------|-------|
+| `DEFAULT_PRIORITY` | Append `"roo"` at end |
+| `detection_command("roo")` | Returns `"roo"` (no mapping needed, unlike kiro→kiro-cli) |
+| `NoBackendError` display | Add `"• Roo CLI: https://github.com/RooVetGit/Roo-Code"` |
+
+### 5. Preset File (`presets/minimal/roo.yml`)
+
+Mirrors the kiro preset pattern:
+
+```yaml
+# Ralph Orchestrator Configuration for Roo Code CLI
+# v2 nested format - optimized for Roo CLI
+
+# Event loop settings
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400      # 4 hours
+  max_consecutive_failures: 5
+
+# CLI backend settings
+cli:
+  backend: "roo"
+  prompt_mode: "arg"
+  pty_mode: false
+  pty_interactive: true
+  idle_timeout_secs: 30
+
+# Core behaviors
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration - save learnings to memories for next time"
+    - "Don't assume 'not implemented' - search first"
+    - "Verification is mandatory - tests/typecheck/lint/audit must pass"
+    - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document; <50 choose safe default + document."
+
+hats:
+  builder:
+    name: "Builder"
+    description: "Implements code, creates files, runs tests. Does the actual work."
+    triggers: ["build.task"]
+    publishes: ["build.done", "build.blocked"]
+    instructions: |
+      ## WORKFLOW
+      You are Builder. Your job is to IMPLEMENT - write code, create files, run tests.
+      1. Read the build.task event payload - that's your task
+      2. IMPLEMENT: Create files, write code, run commands
+      3. VERIFY: Run tests/builds to confirm it works
+      4. COMPLETE: Emit build.done when verified, or build.blocked if stuck
+      RULES:
+      - Do the actual work - don't just plan or delegate
+      - Never emit build.task (that's for coordination, not you)
+```
+
+## Data Models
+
+No new data models needed. The existing `CliBackend`, `OutputFormat`, `PromptMode`, and `HatBackend` types are sufficient.
+
+## Error Handling
+
+Standard Ralph error handling applies with one important caveat:
+
+Roo's exit code behavior varies by error type (verified via live testing):
+
+| Error Type | Exit Code | Behavior |
+|-----------|-----------|----------|
+| **Config error** (invalid provider) | **1** | Exits immediately |
+| **API auth error** (invalid key) | **Never exits** | Retries indefinitely, `--exit-on-error` doesn't stop retries |
+| **Success** | **0** | Exits normally |
+
+Ralph's error detection handles all cases:
+
+- **Config errors** → Non-zero exit code → Ralph detects failure immediately
+- **API auth errors** → Roo retries indefinitely → Ralph's **idle timeout** kills the process → counted as failure
+- **No events emitted** → Consecutive failure counter increments (primary detection)
+- **LOOP_COMPLETE not found** → Loop continues to next iteration, failure counter increments
+- **Max consecutive failures** → Loop terminates after N iterations without events
+
+No roo-specific error detection or parsing needed.
+
+## Testing Strategy
+
+### Unit Tests (in `cli_backend.rs`)
+
+| Test | Validates |
+|------|-----------|
+| `test_roo_backend` | `roo()` produces `roo --print --ephemeral --prompt-file <path>` |
+| `test_roo_interactive` | `roo_interactive()` produces `roo "prompt"` |
+| `test_from_name_roo` | `from_name("roo")` returns correct backend |
+| `test_from_config_roo` | Config `backend: "roo"` creates correct backend |
+| `test_from_config_roo_with_args` | Extra args (model, provider) are appended |
+| `test_for_interactive_prompt_roo` | Interactive factory returns `roo_interactive()` |
+| `test_roo_interactive_mode_removes_print` | `build_command("prompt", true)` removes `--print` and `--ephemeral` |
+
+### Unit Tests (in `auto_detect.rs`)
+
+| Test | Validates |
+|------|-----------|
+| `test_detection_command_roo` | `detection_command("roo")` returns `"roo"` |
+| `test_default_priority_includes_roo` | "roo" in `DEFAULT_PRIORITY` |
+| `test_default_priority_roo_is_last` | "roo" is last in priority |
+
+### Integration Test (manual)
+
+```bash
+# Verify roo backend works end-to-end
+ralph run -b roo -- --provider bedrock --aws-profile roo-bedrock \
+  --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 \
+  --max-tokens 64000 -p "Create a hello.txt file with 'Hello World'"
+```
+
+## Key Learnings (verified via live testing)
+
+1. **Conversation history clears between iterations** — Each `roo --print` is a fresh process. Second invocation reports "I have no memory of previous conversations."
+2. **`--ephemeral` now works with Bedrock** — Fixed in roo v0.1.15+. Previously broke Bedrock auth by using temp dir that lost provider settings.
+3. **Tool auto-approval is roo's default** — No `--trust-all-tools` equivalent needed. File write/read executed without any approval flag.
+4. **`--prompt-file` is native** — Verified working with 7530-char prompt. Cleaner than Claude's temp-file workaround.
+5. **Roo exit codes are nuanced** — Config errors exit 1 ✅. API auth errors cause infinite retry (never exits) — Ralph's idle timeout handles this. Success exits 0 ✅.
+6. **Event tags work with proper context** — Roo refuses bare "output this text" prompts as injection attacks, but cooperates when event protocol is part of system instructions (as Ralph provides).
+7. **Roo outputs `[task complete]`** — Not parsed by Ralph, but useful for debugging.
+
+## Appendices
+
+### Technology Choices
+
+| Choice | Rationale |
+|--------|-----------|
+| Text mode | Simple, proven (6/9 providers use it), no parser needed |
+| `--prompt-file` | Native roo support, cleaner than positional args for large prompts |
+| Pipe mode | Clean output, no ANSI codes, easier event parsing |
+| `--ephemeral` included | Clean disk state, fixed in roo v0.1.15+ to work with Bedrock |
+
+### Alternative Approaches Considered
+
+1. **Stream-JSON mode**: Would provide cost tracking, token usage, tool-use visibility. Deferred due to: (a) roo's format is different from Claude/Pi requiring a new parser, (b) roo CLI is still evolving (v0.1.15), (c) text mode is proven and sufficient.
+
+2. **No `--ephemeral`**: Initially considered because `--ephemeral` broke Bedrock auth. Now fixed in roo v0.1.15+, so `--ephemeral` is included by default for clean disk state.
+
+3. **Roo mode mapping**: Ralph hats → roo `--mode`. Rejected as over-engineering; users can set `--mode` via `cli.args` if needed.
+
+4. **Custom roo mode for Ralph**: Creating a dedicated roo mode with Ralph-specific system instructions. Rejected — roo's default "code" mode provides all necessary tool groups and its system prompt complements Ralph's user prompt.
+
+### Research References
+
+- [roo CLI interface research](./../research/roo-cli-interface.md)
+- [Ralph adapter system research](./../research/ralph-adapter-system.md)  
+- [Text vs stream-json analysis](./../research/text-vs-stream-json.md)

--- a/specs/roo-cli-provider/idea-honing.md
+++ b/specs/roo-cli-provider/idea-honing.md
@@ -1,0 +1,146 @@
+# Idea Honing: roo-cli Provider
+
+Requirements clarification through Q&A.
+
+---
+
+## Q1: Output Format — Text-only or Stream-JSON?
+
+Roo CLI supports two modes Ralph could integrate with:
+
+1. **Text mode** (`roo --print "prompt"`) — Simple text output, like kiro. Easiest to implement but no real-time streaming, cost tracking, or tool-use visibility.
+2. **Stream-JSON mode** (`roo --print --output-format stream-json "prompt"`) — Rich NDJSON streaming with deltas, tool_use events, cost data, and thinking events. Requires a new `RooStreamParser` (similar to how Pi has `PiStreamParser`).
+
+**Which approach should we take?**
+
+**A1**: Text mode only — simple, fast, proven by 6/9 providers. Add stream-json later if needed. The output format will be `OutputFormat::Text`, like kiro/gemini/codex/amp/copilot/opencode.
+
+---
+
+## Q2: Headless Command — What flags should the roo headless backend use?
+
+Based on research, `roo --print "prompt"` runs headless and exits. But we need to decide on additional flags:
+
+- `--print` — Required for non-interactive exit
+- `--ephemeral` — Run without persisting state? (Prevents roo from accumulating task history across Ralph iterations)
+- `--require-approval` — Should this default to false (auto-approve tools)?
+
+The default model is `anthropic/claude-opus-4.6` but the user's working config uses `--provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000`. Should model/provider be configured via ralph.yml `cli.args` or baked into the backend defaults?
+
+**A2**: Use `--ephemeral` as default. Headless command: `roo --print --ephemeral "prompt"`.
+- Tool auto-approval is already the default in roo (`--require-approval` defaults to false), so no additional flag needed (unlike kiro's `--trust-all-tools`)
+- Model/provider configured via `cli.args` in ralph.yml — not baked into the backend
+- Extra args from ralph.yml are always appended (existing pattern in `from_config()`)
+
+---
+
+## Q3: Interactive Mode — What should `roo_interactive()` look like?
+
+For `ralph plan` and PTY interactive mode, we need a variant that removes headless flags and lets the user interact with roo's TUI. Following the pattern of other backends:
+
+- Kiro interactive: removes `--no-interactive`
+- Claude interactive: removes `-p` flag
+- For roo: remove `--print` and `--ephemeral`
+
+Proposed interactive command: `roo "prompt"` (just positional arg, no flags)
+
+**A3**: Both modes needed.
+- **Headless** (`ralph run`): `roo --print --ephemeral "prompt"`
+- **Interactive** (`ralph plan`): `roo "prompt"` (no `--print`, no `--ephemeral`)
+
+---
+
+## Q4: Auto-Detection Priority — Where should "roo" be in the detection order?
+
+The current `DEFAULT_PRIORITY` is: `["claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi"]`
+
+Where should "roo" go? The detection command would check `roo --version`.
+
+**A4**: At the end of the priority list. New order: `["claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi", "roo"]`. Only auto-detected as fallback if nothing else is available. Detection command: `roo --version`.
+
+---
+
+## Q5: Preset Configuration — What should the minimal roo preset look like?
+
+Should the `presets/minimal/roo.yml` just mirror the kiro preset pattern (same hats, guardrails) but with `cli.backend: "roo"`? Or should it include roo-specific defaults like `--provider` and `--model` flags?
+
+**A5**: Mirror kiro preset pattern — same hats (builder), same guardrails, just `cli.backend: "roo"` with empty `cli.args: []`. No model/provider baked in. User configures model/provider via their `ralph.yml` `cli.args` or CLI `-- ...` flags.
+
+---
+
+## Q6: Scope Confirmation — Is this everything?
+
+Based on our discussion, the full scope is:
+1. **Backend definitions**: `roo()` headless and `roo_interactive()` in `cli_backend.rs`
+2. **Registration points**: `from_config()`, `from_name()`, `for_interactive_prompt()`, `from_hat_backend()`
+3. **Auto-detection**: Add "roo" at end of `DEFAULT_PRIORITY`, `detection_command("roo") → "roo"`
+4. **Error display**: Add roo install URL in `NoBackendError`
+5. **Preset file**: `presets/minimal/roo.yml`
+6. **Tests**: Unit tests for all new backend functions
+7. **Documentation**: Update `lib.rs` doc comment to include Roo
+
+Anything else?
+
+---
+
+## Q7: Large Prompts — How should roo handle prompts >7000 chars?
+
+Claude has a special case: when prompts exceed 7000 characters, Ralph writes the prompt to a temp file and tells Claude to read it. This is because long CLI arguments can fail on some systems.
+
+Roo has `--prompt-file <path>` which reads a prompt from a file — verified working.
+
+**Historical note**: Initially `--ephemeral` broke Bedrock auth, but this was fixed in roo v0.1.15+. `--ephemeral` is now included in the default backend.
+
+**A7**: Always use `--prompt-file` for all prompts. One code path, no size threshold — write prompt to temp file, pass `--prompt-file <path>`. Roo handles it natively. Simpler than conditional logic, verified working for both small and large prompts.
+
+---
+
+## Q8: PTY Mode — Should roo support PTY mode (`pty_mode: true`)?
+
+Ralph's PTY mode runs the CLI tool in a pseudo-terminal, preserving rich TUI features (colors, spinners). This is used for:
+- `ralph run` with TUI display (ratatui-based)
+- Interactive sessions
+
+Kiro uses `pty_mode: false` by default. Claude uses PTY for its TUI. Should roo default to `pty_mode: false` or `true`?
+
+**A8**: `pty_mode: false` (pipe mode). Roo with `--print` outputs clean text, PTY adds unnecessary ANSI complexity. 6/9 providers use pipe mode. User can enable PTY via config if needed.
+
+---
+
+## Q9: Error Handling — How should roo failures be detected?
+
+With text mode, Ralph detects failures via:
+1. **Exit code** — non-zero means failure
+2. **LOOP_COMPLETE token** — agent emits this when done
+3. **Event tags** — `<event topic="build.done">` etc.
+
+Should we add any roo-specific error detection? For example, roo outputs `[task complete]` when done and `Error:` lines when failing. Should Ralph parse these?
+
+**A9**: No roo-specific error handling. Use standard Ralph mechanisms (exit code + event tags + LOOP_COMPLETE). Keep it simple.
+
+---
+
+## Q10: Roo Modes — Should the backend support `--mode` flag?
+
+Roo has a `--mode` flag (`code`, `architect`, `ask`, `debug`, etc.). Ralph's hat system conceptually overlaps with roo modes — for example, the "Builder" hat could map to `--mode code`, while a "Planner" hat could use `--mode architect`.
+
+Should we support passing `--mode` through the backend, or leave it for users to configure via `cli.args`?
+
+**A10**: Leave it for users to configure via `cli.args`. Roo defaults to `--mode code` which is the right default for Ralph's builder hat. Users can override in their ralph.yml if needed.
+
+---
+
+## Requirements Clarification Complete
+
+All key decisions have been made. Summary of confirmed requirements:
+
+1. **Output format**: Text mode only (like kiro)
+2. **Headless command**: `roo --print --ephemeral "prompt"` (both flags included)
+3. **Prompt passing**: Always use `--prompt-file` for all prompts (one code path, simpler)
+4. **Interactive mode**: `roo "prompt"` (for `ralph plan`, no `--print`/`--ephemeral`)
+5. **Auto-detection**: "roo" at end of priority list
+6. **Preset**: Mirror kiro pattern, no model/provider baked in
+7. **PTY mode**: `pty_mode: false` (pipe mode)
+8. **Error handling**: Standard Ralph mechanisms, no roo-specific parsing. Note: roo always exits 0, even on errors.
+9. **Roo modes/provider/model**: Configured via `cli.args`, not baked into backend
+10. **Event tags**: Work correctly when Ralph provides event protocol as system instructions

--- a/specs/roo-cli-provider/implementation/plan.md
+++ b/specs/roo-cli-provider/implementation/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Add roo-cli as a Provider
+
+## Checklist
+
+- [ ] Step 1: Add roo backend definitions to `cli_backend.rs`
+- [ ] Step 2: Register roo in all dispatch points
+- [ ] Step 3: Add `--prompt-file` support for all prompts
+- [ ] Step 4: Add auto-detection support
+- [ ] Step 5: Create preset file
+- [ ] Step 6: Update documentation
+- [ ] Step 7: Post-Implementation Validation
+
+---
+
+## Step 1: Add roo backend definitions to `cli_backend.rs`
+
+**Objective**: Create `roo()` and `roo_interactive()` methods on `CliBackend` with unit tests.
+
+**Implementation guidance**:
+- Add `roo()` method returning `CliBackend` with `command: "roo"`, `args: ["--print", "--ephemeral"]`, `prompt_mode: PromptMode::Arg`, `prompt_flag: None`, `output_format: OutputFormat::Text`, `env_vars: []`
+- Add `roo_interactive()` method returning `CliBackend` with `command: "roo"`, `args: []`, `prompt_mode: PromptMode::Arg`, `prompt_flag: None`, `output_format: OutputFormat::Text`, `env_vars: []`
+- Follow the exact pattern of existing backends (kiro, pi, opencode)
+
+**Test requirements**:
+- `test_roo_backend()`: Verify `roo()` produces `roo --print --ephemeral --prompt-file <path>` via `build_command()` (prompt written to temp file)
+- `test_roo_interactive()`: Verify `roo_interactive()` produces `roo "test prompt"`
+- `test_env_vars_default_empty`: Add `CliBackend::roo()` to the existing env_vars emptiness test
+
+**Integration with previous work**: This is the foundation — all subsequent steps build on these definitions.
+
+**Demo**: `cargo test -p ralph-adapters test_roo_backend` passes. The `roo()` and `roo_interactive()` constructors return correct `CliBackend` configurations.
+
+---
+
+## Step 2: Register roo in all dispatch points
+
+**Objective**: Wire `roo` into all the places where backends are resolved from config/names.
+
+**Implementation guidance**:
+- In `from_config()` (line ~69): Add `"roo" => Self::roo()` match arm
+- In `from_name()` (line ~235): Add `"roo" => Ok(Self::roo())` match arm
+- In `for_interactive_prompt()` (line ~388): Add `"roo" => Ok(Self::roo_interactive())` match arm
+- In `filter_args_for_interactive()` (line ~662): Add `"roo"` arm that filters `--print` and `--ephemeral` flags
+
+**Test requirements**:
+- `test_from_name_roo()`: `CliBackend::from_name("roo")` returns backend with command "roo"
+- `test_from_config_roo()`: Config `{ backend: "roo" }` creates correct backend
+- `test_from_config_roo_with_args()`: Config with `args: ["--provider", "bedrock", "--model", "anthropic.claude-sonnet-4-6"]` appends correctly
+- `test_for_interactive_prompt_roo()`: Factory returns `roo_interactive()` and builds correct command
+- `test_roo_interactive_mode_removes_print()`: `build_command("prompt", true)` removes `--print` from args
+
+**Integration with previous work**: Uses `roo()` and `roo_interactive()` from Step 1.
+
+**Demo**: `cargo test -p ralph-adapters from_name_roo` and `cargo test -p ralph-adapters from_config_roo` both pass. Running `ralph run -b roo --dry-run` (if available) shows the correct command would be spawned.
+
+---
+
+## Step 3: Add `--prompt-file` support for all prompts
+
+**Objective**: All roo prompts are passed via `--prompt-file` (one code path, no size threshold).
+
+**Implementation guidance**:
+- In `build_command()`, after the existing Claude large-prompt handling block, add a block for roo:
+  ```
+  if self.command == "roo" {
+      // Always write prompt to temp file
+      // Add --prompt-file <path> to args (no positional prompt)
+      // Return temp file handle to keep it alive
+  }
+  ```
+- This is simpler than conditional logic — one path, no 7000-char threshold
+- Roo natively reads from `--prompt-file` (verified working for both small and large prompts)
+- Fallback to positional arg only if temp file creation fails
+
+**Test requirements**:
+- `test_roo_uses_prompt_file()`: Any prompt results in `--prompt-file` arg and temp file
+- `test_roo_prompt_file_content()`: Verify temp file contains the full prompt text
+- `test_roo_prompt_file_fallback()`: Verify positional arg is used if temp file creation fails
+
+**Integration with previous work**: Modifies `build_command()` which uses `roo()` backend from Step 1.
+
+**Demo**: `cargo test -p ralph-adapters test_roo_uses_prompt_file` passes. All prompts use `--prompt-file`.
+
+---
+
+## Step 4: Add auto-detection support
+
+**Objective**: Enable `roo` in auto-detection when `cli.backend: auto` is configured.
+
+**Implementation guidance**:
+- In `auto_detect.rs`, add `"roo"` at the end of `DEFAULT_PRIORITY` array
+- `detection_command("roo")` should return `"roo"` (default behavior, no special mapping needed)
+- In `NoBackendError::fmt()`, add `"  • Roo CLI:      https://github.com/RooVetGit/Roo-Code"` to the install suggestions
+
+**Test requirements**:
+- `test_detection_command_roo()`: `detection_command("roo")` returns `"roo"`
+- `test_default_priority_includes_roo()`: `DEFAULT_PRIORITY` contains `"roo"`
+- `test_default_priority_roo_after_pi()`: "roo" comes after "pi" (last position)
+- Update `test_no_backend_error_display()`: Verify error message includes "Roo CLI"
+
+**Integration with previous work**: Independent of Steps 1-3. Uses only `auto_detect.rs`.
+
+**Demo**: `cargo test -p ralph-adapters detection_command_roo` passes. The error message for missing backends includes roo.
+
+---
+
+## Step 5: Create preset file
+
+**Objective**: Create `presets/minimal/roo.yml` as a ready-to-use configuration.
+
+**Implementation guidance**:
+- Copy `presets/minimal/kiro.yml` as the starting point
+- Change `cli.backend` from `"kiro"` to `"roo"`
+- Keep all other settings identical (event_loop, core guardrails, hats)
+- Update the comment header to reference Roo Code CLI
+
+**Test requirements**:
+- Verify YAML is valid: `python3 -c "import yaml; yaml.safe_load(open('presets/minimal/roo.yml'))"`
+- Verify `cli.backend` is `"roo"` in the file
+
+**Integration with previous work**: Uses the backend name registered in Steps 1-2.
+
+**Demo**: `cat presets/minimal/roo.yml` shows a valid configuration. `ralph run --preset roo -- --provider bedrock ...` would use roo as the backend.
+
+---
+
+## Step 6: Update documentation
+
+**Objective**: Update code documentation to reflect roo as a supported backend.
+
+**Implementation guidance**:
+- In `crates/ralph-adapters/src/lib.rs`, update the crate-level doc comment to include `- Roo (Roo Code)` in the list of supported backends
+- Ensure all new public methods have doc comments explaining their purpose
+
+**Test requirements**:
+- `cargo doc -p ralph-adapters --no-deps` completes without warnings
+
+**Integration with previous work**: References all work from Steps 1-5.
+
+**Demo**: `cargo doc` builds cleanly. The ralph-adapters documentation lists Roo as a supported backend.
+
+---
+
+## Step 7: Post-Implementation Validation
+
+**Objective**: Verify the complete implementation works end-to-end.
+
+**Validation checklist**:
+- [ ] `cargo test -p ralph-adapters` — All tests pass (existing + new roo tests)
+- [ ] `cargo test` — Full project test suite passes (no regressions)
+- [ ] `cargo build` — Clean build with no warnings
+- [ ] `cargo doc -p ralph-adapters --no-deps` — Documentation builds cleanly
+- [ ] YAML validation: `presets/minimal/roo.yml` is valid
+- [ ] Manual E2E (if roo is configured): `ralph run -b roo -- --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 -p "Create hello.txt with Hello World"` completes at least one iteration
+
+**Demo**: Full end-to-end demonstration:
+1. Show `cargo test -p ralph-adapters` with all roo tests passing
+2. Show `presets/minimal/roo.yml` contents
+3. Show `ralph run -b roo` starting and executing an iteration with roo backend

--- a/specs/roo-cli-provider/research/assumption-validation.md
+++ b/specs/roo-cli-provider/research/assumption-validation.md
@@ -1,0 +1,53 @@
+# Research: Assumption Validation Tests
+
+All assumptions tested with live roo CLI invocations.
+
+## Test Results (Round 1 — pre-fix)
+
+| # | Assumption | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | `roo --print` works for headless | ✅ Verified | Produces text output and exits |
+| 2 | `--prompt-file` works for large prompts | ✅ Verified | 7530-char prompt read from file successfully |
+| 3 | `roo --version` for auto-detection | ✅ Verified | Returns "0.1.15" with exit code 0 |
+| 4 | Conversation clears between iterations | ✅ Verified | Second invocation: "I have no memory of previous conversations" |
+| 5 | Tool auto-approval is default | ✅ Verified | File write + read executed without any approval flag |
+| 6 | Exit code 0 on success | ✅ Verified | Successful task returns exit code 0 |
+| 7 | Event tags work with proper context | ✅ Verified | With Ralph-style system instructions, roo emits `<event>` tags and LOOP_COMPLETE correctly |
+| 8 | `--ephemeral` breaks Bedrock | ✅ Verified | Cross-region inference error with ephemeral, works without |
+| 9 | Exit code on API errors | ⚠️ Finding | Roo exits 0 even on API failure. Ralph must rely on LOOP_COMPLETE/event presence, not exit codes. |
+
+## Test Results (Round 2 — after roo fixes)
+
+Issues 1 (exit codes) and 2 (--ephemeral + Bedrock) were fixed in roo. Re-ran validation:
+
+| # | Test | Result | Evidence |
+|---|------|--------|----------|
+| 1 | `--ephemeral` + Bedrock | ✅ **FIXED** | `roo --print --ephemeral` now works with Bedrock. Output: `[assistant] Hello!` |
+| 2 | `--prompt-file` + `--ephemeral` | ✅ Verified | Large prompt via file + ephemeral mode works |
+| 3 | Event tags + `--ephemeral` | ✅ Verified | `<event topic="build.done">` and `LOOP_COMPLETE` emitted correctly in ephemeral mode |
+| 4 | Exit codes on errors | ⚠️ Still exits 0 | Invalid provider, bad API key still exit 0. Not a blocker — Ralph uses LOOP_COMPLETE detection. |
+
+### Updated Design Decision
+With `--ephemeral` fixed, the default headless command is now: `roo --print --ephemeral "prompt"` — clean disk state between iterations.
+
+## Key Findings
+
+### Finding 1: Event Tag Emission (Assumption 7)
+Roo has built-in prompt injection detection. A bare "output this text" prompt with event tags is **refused** as a prompt injection attack. However, when the event protocol is provided as part of system instructions (as Ralph does), roo cooperates and emits event tags correctly.
+
+**Implication**: The Ralph prompt format (with `## EVENT PROTOCOL` instructions) already works correctly with roo. No changes needed.
+
+### Finding 2: Exit Code Always 0 (Assumption 9)
+Roo exits with code 0 even when:
+- API errors occur (Bedrock cross-region)
+- `--exit-on-error` is specified
+
+**Implication**: Ralph cannot use exit codes to detect roo failures. This is fine because Ralph's primary failure detection is via:
+1. **Missing LOOP_COMPLETE token** → consecutive failure counter increments
+2. **Missing event tags** → no events published → backpressure detects staleness
+3. **Idle timeout** → roo process stuck retrying → Ralph kills it
+
+### Finding 3: --ephemeral + Bedrock (Assumption 8)
+`--ephemeral` causes roo to use a temp directory for storage, losing access to persisted Bedrock settings (cross-region inference config). This causes API failures.
+
+**Implication**: `--ephemeral` must not be a default flag. Users on non-Bedrock providers (Anthropic direct, OpenRouter) might use it safely via `cli.args`.

--- a/specs/roo-cli-provider/research/ralph-adapter-system.md
+++ b/specs/roo-cli-provider/research/ralph-adapter-system.md
@@ -1,0 +1,99 @@
+# Research: Ralph Adapter System (Existing Codebase)
+
+## Architecture Overview
+
+Ralph supports multiple CLI backends through a layered adapter system:
+
+```mermaid
+graph TD
+    Config["ralph.yml<br>cli.backend: 'roo'"] --> CliBackend["CliBackend::from_config()"]
+    CliBackend --> |Text| CliExecutor["CliExecutor<br>(pipe-based)"]
+    CliBackend --> |StreamJson| PtyExecutor["PtyExecutor<br>(PTY-based)"]
+    CliBackend --> |Acp| AcpExecutor["AcpExecutor<br>(JSON-RPC stdio)"]
+    PtyExecutor --> StreamHandler["StreamHandler trait"]
+    StreamHandler --> Console["ConsoleStreamHandler"]
+    StreamHandler --> Pretty["PrettyStreamHandler"]
+    StreamHandler --> Tui["TuiStreamHandler"]
+    StreamHandler --> Quiet["QuietStreamHandler"]
+```
+
+## Key Files to Modify
+
+| File | Purpose | What to Add |
+|------|---------|-------------|
+| `crates/ralph-adapters/src/cli_backend.rs` | Backend definitions | `roo()`, `roo_interactive()` methods |
+| `crates/ralph-adapters/src/auto_detect.rs` | PATH detection | Add "roo" to `DEFAULT_PRIORITY`, `detection_command()` |
+| `crates/ralph-adapters/src/pty_executor.rs` | PTY streaming | Add roo stream format handling |
+| `presets/minimal/roo.yml` | Preset config | New preset file |
+
+## Backend Registration Points
+
+A new backend must be registered in these locations in `cli_backend.rs`:
+
+1. **`from_config()`** — Maps config string to backend constructor (line 69-81)
+2. **`from_name()`** — Maps name string to backend (line 235-248)
+3. **`from_hat_backend()`** — Maps HatBackend enum variant (line 254-280)
+4. **`for_interactive_prompt()`** — Interactive mode factory (line 388-399)
+
+## Output Format Dispatch
+
+The `OutputFormat` enum (4 variants) determines execution strategy:
+
+| Format | Executor | Parser | Used By |
+|--------|----------|--------|---------|
+| `Text` | CliExecutor or PtyExecutor | Raw text | kiro, gemini, codex, amp, copilot, opencode |
+| `StreamJson` | PtyExecutor | `ClaudeStreamParser` | claude |
+| `PiStreamJson` | PtyExecutor | `PiStreamParser` | pi |
+| `Acp` | `AcpExecutor` | JSON-RPC handler | kiro-acp |
+
+## Auto-Detection System
+
+- `DEFAULT_PRIORITY`: `["claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi"]`
+- `detection_command()` maps backend names to CLI binaries (e.g., "kiro" → "kiro-cli")
+- Detection runs `<command> --version` and checks exit code 0
+
+## Preset File Pattern (from `presets/minimal/kiro.yml`)
+
+```yaml
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 100
+  max_runtime_seconds: 14400
+  max_consecutive_failures: 5
+
+cli:
+  backend: "kiro"
+  prompt_mode: "arg"
+  pty_mode: false
+  pty_interactive: true
+  idle_timeout_secs: 30
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Fresh context each iteration..."
+    - ...
+
+hats:
+  builder:
+    name: "Builder"
+    ...
+```
+
+## HatBackend Enum
+
+From `ralph-core`, the `HatBackend` enum supports:
+- `Named(String)` — Simple named backend
+- `NamedWithArgs { backend_type, args }` — Named with extra CLI args
+- `KiroAgent { backend_type, agent, args }` — Kiro-specific agent selection
+- `Custom { command, args }` — Fully custom command
+
+## Stream Parser Integration
+
+For **text-mode** backends (like kiro), no stream parser is needed — raw stdout is captured.
+
+For **stream-json** backends (like claude), `ClaudeStreamParser` processes NDJSON events into `StreamHandler` calls.
+
+For **pi**, `PiStreamParser` does the same with Pi's NDJSON format.
+
+Roo's stream-json format is **different from both Claude and Pi**, so a new `RooStreamParser` would be needed for stream-json support.

--- a/specs/roo-cli-provider/research/roo-cli-interface.md
+++ b/specs/roo-cli-provider/research/roo-cli-interface.md
@@ -1,0 +1,177 @@
+# Research: roo-cli Interface & Stream Format
+
+## CLI Binary & Version
+
+- **Binary name**: `roo` (installed via npm at `/Users/skven/.local/share/mise/installs/node/20.20.0/bin/roo`)
+- **Version**: 0.1.15
+- **Source**: `/Users/skven/workplace/Roo-Code/apps/cli/`
+
+## CLI Flags (from `roo --help`)
+
+### Core Execution Flags
+| Flag | Description |
+|------|-------------|
+| `prompt` (positional) | Your prompt |
+| `-p, --print` | Print response and exit (non-interactive mode) |
+| `--output-format <format>` | "text" (default), "json" (single result), or "stream-json" (realtime streaming) |
+| `--ephemeral` | Run without persisting state (uses temporary storage) |
+| `--oneshot` | Exit upon task completion |
+| `-w, --workspace <path>` | Workspace directory path |
+| `-a, --require-approval` | Require manual approval for actions (default: false) |
+| `-e, --extension <path>` | Path to the extension bundle directory |
+| `-d, --debug` | Enable debug output |
+
+### Model/Provider Flags
+| Flag | Description |
+|------|-------------|
+| `--provider <provider>` | API provider (roo, anthropic, openai, openrouter, etc.) |
+| `-m, --model <model>` | Model to use (default: "anthropic/claude-opus-4.6") |
+| `--max-tokens <n>` | Maximum output tokens |
+| `--max-thinking-tokens <n>` | Maximum thinking/reasoning tokens |
+| `-k, --api-key <key>` | API key for the LLM provider |
+
+### AWS Bedrock Flags
+| Flag | Description |
+|------|-------------|
+| `--aws-region <region>` | AWS region for Bedrock |
+| `--aws-profile <profile>` | AWS profile name |
+| `--aws-custom-arn <arn>` | Custom ARN for Bedrock inference |
+| `--aws-inference-routing <mode>` | none, cross-region, or global |
+| `--aws-bedrock-endpoint <url>` | Custom VPC endpoint URL |
+| `--no-aws-prompt-cache` | Disable prompt caching for Bedrock |
+
+### Mode & Behavior Flags
+| Flag | Description |
+|------|-------------|
+| `--mode <mode>` | Mode to start in (code, architect, ask, debug, etc.) |
+| `-r, --reasoning-effort <effort>` | Reasoning effort level |
+| `--consecutive-mistake-limit <limit>` | Error/repetition limit |
+| `--exit-on-error` | Exit on API request errors |
+
+### Session Flags
+| Flag | Description |
+|------|-------------|
+| `--session-id <task-id>` | Resume a specific task by task ID |
+| `-c, --continue` | Resume the most recent task |
+| `--prompt-file <path>` | Read prompt from a file |
+
+### Stdin Streaming
+| Flag | Description |
+|------|-------------|
+| `--stdin-prompt-stream` | Read NDJSON commands from stdin (requires --print and --output-format stream-json) |
+| `--signal-only-exit` | Only terminate on SIGINT/SIGTERM (for stdin stream harnesses) |
+
+## Stream-JSON Format
+
+### Protocol
+- Protocol: `roo-cli-stream`
+- Schema version: 1
+- NDJSON (newline-delimited JSON)
+
+### Event Types (from source: `types/json-events.ts`)
+| Type | Description |
+|------|-------------|
+| `system` | Init event, subtypes: `init` |
+| `user` | User prompt echo |
+| `assistant` | Assistant text deltas and complete messages |
+| `thinking` | Reasoning/thinking deltas |
+| `tool_use` | Tool invocation, subtypes: `tool`, `command`, `mcp` |
+| `tool_result` | Tool result, subtypes: `command`, `mcp` |
+| `error` | Error messages |
+| `result` | Task completion (has `success` boolean and `cost` object) |
+| `control` | Control flow events (ack, done, error) |
+| `queue` | Queue management events |
+
+### Example Stream Output (observed)
+```json
+{"type":"system","subtype":"init","content":"Task started","schemaVersion":1,"protocol":"roo-cli-stream","capabilities":["stdin:start","stdin:message","stdin:cancel","stdin:ping","stdin:shutdown"]}
+{"type":"user","id":1772593478580,"content":"Say hello in one sentence","done":true}
+{"type":"assistant","id":1772593481508,"content":"Hello"}
+{"type":"assistant","id":1772593481508,"content":"! Welcome"}
+{"type":"assistant","id":1772593481508,"content":" to the"}
+{"type":"assistant","id":1772593481508,"content":" ralph"}
+{"type":"assistant","id":1772593481508,"content":"-orchest"}
+{"type":"assistant","id":1772593481508,"content":"rator project"}
+{"type":"assistant","id":1772593481508,"content":"."}
+{"type":"assistant","id":1772593481508,"content":"Hello! Welcome to the ralph-orchestrator project.","done":true}
+{"type":"result","id":1772593482878,"content":"Hello! I'm Roo, ready to help you with the ralph-orchestrator project.","done":true,"success":true}
+```
+
+### Key Schema Fields (from `JsonEvent` type)
+```typescript
+type JsonEvent = {
+  type: JsonEventType          // Event discriminator
+  id?: number                  // Message ID for correlation
+  content?: string             // Text content
+  done?: boolean               // Final message flag
+  subtype?: string             // Categorization (e.g., "init", "tool", "command")
+  schemaVersion?: number       // Protocol version (on system.init)
+  protocol?: string            // Transport protocol (on system.init)
+  capabilities?: string[]      // Supported capabilities (on system.init)
+  taskId?: string              // Active task ID
+  requestId?: string           // Correlation ID
+  command?: string             // Command name for control events
+  code?: string                // Machine-readable error code
+  tool_use?: JsonEventToolUse  // Tool call info
+  tool_result?: JsonEventToolResult  // Tool result info
+  success?: boolean            // Task success (result events)
+  cost?: JsonEventCost         // Token/cost usage (result events)
+  queueDepth?: number          // Queue depth
+  queue?: JsonEventQueueItem[] // Queue snapshots
+}
+```
+
+### Cost Structure
+```typescript
+type JsonEventCost = {
+  totalCost: number
+  inputTokens: number
+  outputTokens: number
+  cacheWrites?: number
+  cacheReads?: number
+}
+```
+
+## Comparison with Claude Stream Format
+
+| Feature | Claude (`--output-format stream-json`) | Roo (`--output-format stream-json`) |
+|---------|--------------------------------------|--------------------------------------|
+| Protocol | N/A (flat events) | `roo-cli-stream` v1 |
+| Init event | `system` with session_id, model | `system.init` with capabilities |
+| Text streaming | `assistant` with message.content[] | `assistant` with delta `content` |
+| Tool use | Inside `assistant.message.content` | Separate `tool_use` event |
+| Tool result | `user.message.content` | Separate `tool_result` event |
+| Thinking | Inside `assistant.message.content` | Separate `thinking` event |
+| Completion | `result` with cost, turns | `result` with success, cost |
+| Delta vs Full | Full snapshots per turn | Streaming deltas with `done` flag |
+
+### Key Differences
+1. **Claude** emits full turns (`assistant`, `user`) with all content blocks
+2. **Roo** emits streaming deltas (many small `assistant` events building up content, then a `done:true` final)
+3. **Roo** has separate event types for tool_use and tool_result (Claude embeds in message content blocks)
+4. **Roo** has `thinking` as a separate event type (Claude has it as a content block type)
+5. **Roo** supports bidirectional stdin streaming (`--stdin-prompt-stream`)
+
+## Headless Mode Command (confirmed working)
+```bash
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 \
+    --model anthropic.claude-sonnet-4-6 --max-tokens 64000 \
+    --print "Say hello in one sentence"
+```
+
+## Mapping to Ralph Adapter Pattern
+
+For a **text-mode** (simplest) integration:
+```
+roo --print <prompt>
+```
+
+For a **stream-json** integration:
+```
+roo --print --output-format stream-json <prompt>
+```
+
+For **interactive** mode:
+```
+roo <prompt>  (no --print flag)
+```

--- a/specs/roo-cli-provider/research/text-vs-stream-json.md
+++ b/specs/roo-cli-provider/research/text-vs-stream-json.md
@@ -1,0 +1,80 @@
+# Research: Text vs Stream-JSON for Roo — Impact on Loop Success
+
+## What the Developer Experiences
+
+### Text Mode (like kiro, gemini, codex, amp, copilot, opencode)
+
+The developer running `ralph run -b roo` sees:
+- **Raw terminal output** — whatever roo prints, streamed to console/TUI
+- **No structured event parsing** — Ralph treats all output as plain text
+- **Event extraction from text** — Ralph uses regex to find `<event topic="...">` tags in the text output
+- **No cost tracking** — Total cost per iteration is unknown
+- **No token counting** — No visibility into input/output tokens or cache hits
+- **No tool-use visibility** — Ralph can't distinguish tool calls from text output in the TUI
+
+### Stream-JSON Mode (like Claude, Pi)
+
+The developer running `ralph run -b roo` would see:
+- **Parsed, structured output** — PrettyStreamHandler renders markdown, tool calls, thinking
+- **Real-time streaming** — Text arrives as deltas, displayed incrementally
+- **Cost tracking** — Each iteration reports `totalCost`, `inputTokens`, `outputTokens`, `cacheReads`, `cacheWrites`
+- **Tool-use visibility** — Tool calls and results are displayed with names and inputs
+- **Thinking/reasoning** — Thinking tokens are shown (in TUI mode) or hidden (in console)
+- **Extracted text** — Clean text is extracted from JSON for event tag parsing (more reliable)
+
+## Impact on Loop Success Rate
+
+### Does stream-json improve loop success?
+
+**No direct impact on success rate.** The agent's behavior is identical regardless of output format — the prompt and agent logic don't change. The loop's success depends on:
+1. The prompt quality
+2. The agent's capability  
+3. Backpressure signals (test failures, lint errors)
+
+**However, stream-json provides significant operational benefits:**
+
+| Capability | Text Mode | Stream-JSON | Impact |
+|-----------|-----------|-------------|--------|
+| **Event tag extraction** | Regex on raw output (fragile) | Clean extracted_text (reliable) | Moderate — more reliable event parsing means fewer "missed events" |
+| **Cost monitoring** | None — no per-iteration cost | Per-iteration cost + totals | High for observability — developer sees burn rate |
+| **Token usage** | None | Input/output/cache tokens | Medium — developer can spot context window issues |
+| **TUI display quality** | Raw text with ANSI codes | Structured markdown rendering | Medium — cleaner display, easier to spot issues |
+| **Error detection** | Parse exit code only | Structured `result.success` + `error` events | Low — exit code is usually sufficient |
+| **Thinking visibility** | Not available | Visible in TUI | Low — nice to have for debugging |
+| **Idle detection** | Same | Same | None — both use process-level idle detection |
+
+### Key Insight: Event Tag Extraction
+
+The most impactful technical difference is **event tag extraction**. Ralph's event system relies on finding `<event topic="build.done">` tags in the agent output. With text mode, these must be found via regex in the raw terminal output (which may contain ANSI escape codes, line wrapping artifacts, etc.). With stream-json, the `extracted_text` field contains clean text extracted from structured events, making event parsing more reliable.
+
+From the code (`loop_runner.rs:3936-3939`):
+```rust
+let output_for_parsing = if pty_result.extracted_text.is_empty() {
+    pty_result.stripped_output    // Text mode: ANSI-stripped raw output
+} else {
+    pty_result.extracted_text    // Stream-JSON: clean extracted text
+};
+```
+
+## Implementation Cost
+
+| Aspect | Text Mode | Stream-JSON |
+|--------|-----------|-------------|
+| New files | 0 | 1 (`roo_stream.rs`) |
+| Lines of code | ~30 (backend defs) | ~200-400 (parser + dispatch) |
+| Test complexity | Low | Medium (parser tests needed) |
+| Maintenance | Low | Medium (must track roo-cli stream format changes) |
+| Time to implement | ~1 hour | ~4-8 hours |
+
+## Recommendation
+
+**Start with text mode, add stream-json later.**
+
+Rationale:
+1. Text mode is proven — 6 of 9 providers use it successfully
+2. The core loop works identically with text mode
+3. Stream-JSON can be added as an enhancement without breaking changes
+4. Roo's stream format is still evolving (v0.1.15) — investing in a parser now may require rework
+5. Text mode gets the feature shipped fast; stream-json is a quality-of-life improvement
+
+**However**, if cost monitoring and clean event extraction are priorities, stream-json is worth the upfront investment.

--- a/specs/roo-cli-provider/rough-idea-for-implementation.md
+++ b/specs/roo-cli-provider/rough-idea-for-implementation.md
@@ -1,0 +1,46 @@
+# Rough Idea: Add roo-cli as a Provider to Ralph Orchestrator
+
+## What
+Add `roo` (Roo Code CLI) as a new backend provider in ralph-orchestrator, enabling `ralph run -b roo` and `ralph plan -b roo`.
+
+## Context
+- Roo Code CLI (`roo`, v0.1.15+) is an AI coding assistant that supports multiple LLM providers (Anthropic, OpenAI, AWS Bedrock, OpenRouter)
+- Roo CLI source is at `/Users/skven/workplace/Roo-Code/apps/cli/`
+- Install: `cd /Users/skven/workplace/Roo-Code/src && pnpm run bundle && cd /Users/skven/workplace/Roo-Code && pnpm --filter @roo-code/cli build && npm install -g ./apps/cli`
+- Binary: `roo` (installed globally via npm)
+
+## Key Decisions (already researched and validated)
+1. **Text mode only** — Use `roo --print --ephemeral "prompt"` (plain text output, like kiro). Stream-JSON deferred to later.
+2. **Always use `--prompt-file`** — Roo natively supports `--prompt-file <path>`. All prompts use this (one code path, no size threshold).
+3. **`--ephemeral` included** — Fixed in roo v0.1.15+ to work with Bedrock. Clean disk state per iteration.
+4. **Tool auto-approval is default** — No `--trust-all-tools` flag needed (unlike kiro).
+5. **Interactive mode**: `roo "prompt"` for `ralph plan`.
+6. **Auto-detect last** in priority: `["claude", "kiro", ..., "pi", "roo"]`.
+7. **Roo always exits code 0** — Even on API errors. Ralph relies on LOOP_COMPLETE/event presence.
+8. **Event tags work** — Roo emits `<event topic="build.done">` and `LOOP_COMPLETE` when Ralph-style system instructions are provided.
+
+## Working Test Commands
+```bash
+# Headless (text mode)
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 --print "Say hello"
+
+# With prompt file
+echo "Your prompt" > /tmp/prompt.txt
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 --print --prompt-file /tmp/prompt.txt
+
+# Stream JSON (for future reference)
+roo --provider bedrock --aws-profile roo-bedrock --aws-region us-east-1 --model anthropic.claude-sonnet-4-6 --max-tokens 64000 --print --output-format stream-json "Say hello"
+```
+
+## Files to Modify
+1. `crates/ralph-adapters/src/cli_backend.rs` — Add `roo()`, `roo_interactive()`, registration in `from_config`, `from_name`, `for_interactive_prompt`
+2. `crates/ralph-adapters/src/auto_detect.rs` — Add "roo" to `DEFAULT_PRIORITY`, update `NoBackendError`
+3. `crates/ralph-adapters/src/lib.rs` — Update doc comment
+4. `presets/minimal/roo.yml` — New preset (mirror kiro.yml, change backend to "roo")
+
+## Design & Research (already completed)
+Full PDD artifacts at `.agents/planning/2026-03-03-roo-cli-provider/`:
+- `design/detailed-design.md` — Complete design document
+- `implementation/plan.md` — 7-step implementation plan with checklist
+- `research/assumption-validation.md` — All 9 assumptions verified with live tests
+- `research/roo-cli-interface.md` — Complete CLI flag documentation

--- a/specs/roo-cli-provider/rough-idea.md
+++ b/specs/roo-cli-provider/rough-idea.md
@@ -1,0 +1,11 @@
+# Rough Idea: Add roo-cli as a Provider
+
+Add `roo-cli` as a new provider/backend in ralph-orchestrator, following the same pattern as kiro and other existing backends.
+
+This means:
+- Auto-detection support (checking if `roo-cli` or equivalent binary is in PATH)
+- CLI backend configuration (headless mode, interactive mode, prompt passing)
+- A minimal preset file (`presets/minimal/roo.yml`)
+- Integration into all the places where backends are registered (from_config, from_name, for_interactive_prompt, etc.)
+
+The goal is to allow users to configure `cli.backend: "roo"` in their ralph.yml and have it work seamlessly with the roo-cli binary, similar to how kiro works with kiro-cli.

--- a/specs/roo-cli-provider/summary.md
+++ b/specs/roo-cli-provider/summary.md
@@ -1,0 +1,62 @@
+# Project Summary: Add roo-cli as a Provider
+
+## Directory Structure
+
+```
+.agents/planning/2026-03-03-roo-cli-provider/
+├── rough-idea.md                          # Initial concept
+├── idea-honing.md                         # Q&A requirements clarification (10 questions)
+├── research/
+│   ├── roo-cli-interface.md               # Roo CLI flags, stream-json format, examples
+│   ├── ralph-adapter-system.md            # How Ralph's adapter system works
+│   └── text-vs-stream-json.md             # Analysis of text vs stream-json impact
+├── design/
+│   └── detailed-design.md                 # Complete design document
+├── implementation/
+│   └── plan.md                            # 7-step implementation plan with checklist
+└── summary.md                             # This document
+```
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Output format | Text mode | Simple, proven (6/9 providers), no parser needed |
+| Headless command | `roo --print --ephemeral` | Non-interactive + clean disk state |
+| Prompt passing | Always `--prompt-file` | One code path, native roo support, no size threshold |
+| `--ephemeral` | Included | Fixed in roo v0.1.15+ to work with Bedrock |
+| Tool auto-approval | Default (no flag) | Roo auto-approves by default |
+| Auto-detect priority | Last position | Fallback only |
+| PTY mode | `pty_mode: false` | Clean pipe output for text parsing |
+
+## Implementation Overview
+
+The implementation consists of **7 incremental steps**, each producing working, testable functionality:
+
+1. **Backend definitions** — `roo()` and `roo_interactive()` methods
+2. **Registration** — Wire into `from_config`, `from_name`, `for_interactive_prompt`
+3. **Prompt file support** — Always use `--prompt-file` for all prompts
+4. **Auto-detection** — Add to `DEFAULT_PRIORITY`, update error messages
+5. **Preset file** — `presets/minimal/roo.yml`
+6. **Documentation** — Update crate docs
+7. **Validation** — Full test suite + manual E2E
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `crates/ralph-adapters/src/cli_backend.rs` | Add `roo()`, `roo_interactive()`, registration points, tests |
+| `crates/ralph-adapters/src/auto_detect.rs` | Add to priority, error message, tests |
+| `crates/ralph-adapters/src/lib.rs` | Update doc comment |
+| `presets/minimal/roo.yml` | New file |
+
+## Estimated Effort
+
+~2-3 hours for a developer familiar with the codebase. The changes are mechanical — following established patterns from kiro, pi, and other backends.
+
+## Next Steps
+
+1. Review the [detailed design document](design/detailed-design.md)
+2. Check the [implementation plan](implementation/plan.md) and its checklist
+3. Begin implementation following the plan steps sequentially
+4. Run `cargo test` after each step to verify no regressions


### PR DESCRIPTION
## Summary

PDD design spec for the roo-cli provider integration (PR #218).

Contains the research, requirements, design document, and implementation plan that guided the implementation in #218.

## Contents

### `specs/roo-cli-provider/`
- **`design/detailed-design.md`** — Complete standalone design document
- **`implementation/plan.md`** — 7-step incremental implementation plan
- **`research/roo-cli-interface.md`** — Roo CLI flags, stream-json format, examples
- **`research/ralph-adapter-system.md`** — How Ralph's adapter system works
- **`research/text-vs-stream-json.md`** — Analysis of text vs stream-json tradeoffs
- **`research/assumption-validation.md`** — 9 live tests verifying all assumptions
- **`idea-honing.md`** — 10 Q&A requirements clarification
- **`rough-idea.md`** — Initial concept
- **`summary.md`** — Project summary

Related: #218