### PR TITLE
chore(cli): sync pdd sop from canonical upstream

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,8 +5,8 @@
 default:
     @just --list
 
-# Run all checks (format, lint, test, check)
-check: fmt-check lint test
+# Run all checks (format, lint, embedded assets, test)
+check: fmt-check lint embedded-check test
     @echo "✅ All checks passed"
 
 # Format code using rustfmt
@@ -25,6 +25,18 @@ lint:
 test:
     cargo test --all
 
+# Sync embedded assets (crate-local mirrors + generated SOPs)
+embedded-sync:
+    ./scripts/sync-embedded-files.sh
+
+# Check embedded assets are in sync
+embedded-check:
+    ./scripts/sync-embedded-files.sh check
+
+# Update the pinned PDD upstream SHA from the canonical GitHub branch and resync
+embedded-update-pdd-ref branch="main":
+    ./scripts/sync-embedded-files.sh update-pdd-ref {{branch}}
+
 # Type check without building
 typecheck:
     cargo check --all
@@ -38,15 +50,11 @@ clean:
     cargo clean
 
 # Full CI-like check (what CI will run)
-ci: fmt-check lint test
+ci: fmt-check lint embedded-check test
     @echo "✅ CI checks passed"
 
 # Calibrated hooks mutation rollout threshold (see docs/06-analysis/hooks-mutation-baseline-2026-03-01.md)
 HOOKS_MUTATION_THRESHOLD := "55"
-
-# Baseline mutation command (tooling: cargo-mutants) scoped to hooks-critical paths
-mutants-baseline:
-    cargo mutants --file crates/ralph-core/src/hooks/executor.rs --file crates/ralph-core/src/hooks/engine.rs --file crates/ralph-core/src/preflight.rs --file crates/ralph-cli/src/loop_runner.rs
 
 # Enforced hooks mutation CI gate (threshold + critical-path no-MISS invariant)
 mutants-hooks-gate:

--- a/crates/ralph-cli/sops/addendums/pdd-ralph.md
+++ b/crates/ralph-cli/sops/addendums/pdd-ralph.md
@@ -1,0 +1,9 @@
+## Ralph Loop Handoff
+
+After the planning session is complete and the user wants implementation, tell them how to start the Ralph loop themselves.
+
+Suggest one of these commands:
+- `ralph run --config presets/pdd-to-code-assist.yml --prompt "<task>"`
+- `ralph run --config presets/spec-driven.yml --prompt "<task>"`
+
+You MUST NOT start the loop or begin implementation yourself. This SOP ends after planning and handoff.

--- a/crates/ralph-cli/sops/pdd.md
+++ b/crates/ralph-cli/sops/pdd.md
@@ -1,165 +1,308 @@
----
-name: pdd
-description: Transforms a rough idea into a detailed design document with implementation plan. Follows Prompt-Driven Development — iterative requirements clarification, research, design, and planning.
-type: anthropic-skill
-version: "1.2"
----
+<!-- GENERATED FILE: DO NOT EDIT -->
+<!-- Source: https://github.com/strands-agents/agent-sop/blob/7b71239492c51bbba5a2705e139da9503f36f0b6/agent-sops/pdd.sop.md -->
+<!-- Regenerate with: ./scripts/sync-embedded-files.sh -->
 
 # Prompt-Driven Development
 
 ## Overview
 
-Transform a rough idea into a detailed design with an implementation plan. The process is iterative: clarify requirements, research, design, plan — moving between phases as needed.
-
-## Important Notes
-
-These rules apply across ALL steps:
-
-- **User-driven flow:** Never proceed to the next step without explicit user confirmation. At each transition, ask the user what they want to do next.
-- **Iterative:** The user can move between requirements clarification and research at any time. Always offer this option at phase transitions.
-- **Record as you go:** Append questions, answers, and findings to project files in real time — don't batch-write at the end.
-- **Mermaid diagrams:** Include diagrams for architectures, data flows, and component relationships in research and design documents.
-- **Sources:** Cite references and links in research documents when based on external materials.
-- **Planning only:** This SOP produces planning artifacts. You MUST NOT implement code, run containers, execute scripts, or begin any implementation work. If the user wants implementation, direct them to `ralph run`.
+This sop guides you through the process of transforming a rough idea into a detailed design document with an implementation plan and todo list. It follows the Prompt-Driven Development methodology to systematically refine your idea, conduct necessary research, create a comprehensive design, and develop an actionable implementation plan. The process is designed to be iterative, allowing movement between requirements clarification and research as needed.
 
 ## Parameters
 
-- **rough_idea** (required): The initial concept or idea to develop
-- **project_dir** (optional, default: `specs/{task_name}/`): Base directory for all artifacts. `{task_name}` is derived as kebab-case from the idea (e.g., "build a rate limiter" → `rate-limiter`). Aligns with Ralph's spec-driven pipeline.
+- **rough_idea** (required): The initial concept or idea you want to develop into a detailed design
+- **project_name** (optional): A short, descriptive name for the project. If not provided, will be generated from the rough idea
+- **project_dir** (optional, default: ".agents/planning/{project_name}"): The base directory where all project files will be stored
 
-**Constraints:**
-- You MUST ask for all required parameters upfront in a single prompt
-- You MUST support multiple input methods: direct text, file path, URL
-- You MUST derive `task_name` from the rough idea as kebab-case
-- You MUST NOT overwrite an existing project directory — ask for a new path if it already has contents
+**Constraints for parameter acquisition:**
+- You MUST ask for all required parameters upfront in a single prompt rather than one at a time
+- You MUST support multiple input methods including:
+  - Direct input: Text provided directly in the conversation
+  - File path: Path to a local file containing the rough idea
+  - URL: Link to an internal resource (e.g., Quip doc, wiki page)
+  - Other methods: You SHOULD be open to other ways the user might want to provide the idea
+- You MUST use appropriate tools to access content based on the input method
+- You MUST confirm successful acquisition of all parameters before proceeding
+- If project_name is not provided, You MUST generate a short kebab-case name from the rough idea, prefixed with the current date in YYYY-MM-DD format (e.g., "2026-01-30-template-manager", "2026-01-30-auth-system")
+- You SHOULD save the acquired rough idea to a consistent location for use in subsequent steps
+- You MUST NOT overwrite the existing project directory because this could destroy previous work and cause data loss
+- You MUST ask for project_dir if it is not given and the generated default directory already exists and has contents from previous iteration
 
 ## Steps
 
 ### 1. Create Project Structure
 
-Create the directory and initial files:
-- `{project_dir}/rough-idea.md` — the provided rough idea
-- `{project_dir}/requirements.md` — Q&A record (initially empty)
-- `{project_dir}/research/` — directory for research notes
+Set up a directory structure to organize all artifacts created during the process.
 
-Inform the user the structure feeds into Ralph's spec-driven presets.
-
-**Gate:** You MUST NOT proceed to Step 2 until the user confirms the project structure is acceptable.
+**Constraints:**
+- You MUST create the specified project directory if it doesn't already exist
+- You MUST create the following files:
+  - {project_dir}/rough-idea.md (containing the provided rough idea)
+  - {project_dir}/idea-honing.md (for requirements clarification)
+- You MUST create the following subdirectories:
+  - {project_dir}/research/ (directory for research notes)
+  - {project_dir}/design/ (directory for design documents)
+  - {project_dir}/implementation/ (directory for implementation plans)
+- You MUST notify the user when the structure has been created
+- You MUST prompt the user to add all project files to Kiro's context using the command: `/context add {project_dir}/**/*.md`
+- You MUST explain that this will ensure all project files remain in context throughout the process
 
 ### 2. Initial Process Planning
 
-Ask the user their preferred starting point:
-- Requirements clarification (default)
-- Preliminary research on specific topics
-- Provide additional context first
+Determine the initial approach and sequence for requirements clarification and research.
 
-**Gate:** You MUST wait for the user to choose before proceeding. You MUST NOT automatically start requirements clarification or research without explicit user direction.
+**Constraints:**
+- You MUST ask the user if they prefer to:
+  - Start with requirements clarification (default)
+  - Start with preliminary research on specific topics
+  - Provide additional context or information before proceeding
+- You MUST adapt the subsequent process based on the user's preference
+- You MUST explain that the process is iterative and the user can move between requirements clarification and research as needed
+- You MUST wait for explicit user direction before proceeding to any subsequent step
+- You MUST NOT automatically proceed to requirements clarification or research without user confirmation because this could lead the process in a direction the user doesn't want
 
 ### 3. Requirements Clarification
 
-Guide the user through questions to refine the idea into a thorough specification.
+Guide the user through a series of questions to refine the initial idea and develop a thorough specification.
 
 **Constraints:**
-- You MUST ask ONE question at a time — do not list multiple questions
-- You MUST NOT pre-populate answers or batch-write Q&A to requirements.md
-- You MUST follow this cycle for each question:
-  1. Formulate and append question to requirements.md
-  2. Present to user, wait for complete response
-  3. Append answer to requirements.md
-  4. Proceed to next question
-- You MUST ask the user if requirements clarification is complete before moving on
+- You MUST create an empty {project_dir}/idea-honing.md file if it doesn't already exist
+- You MUST ask ONLY ONE question at a time and wait for the user's response before asking the next question
+- You MUST NOT list multiple questions for the user to answer at once because this overwhelms users and leads to incomplete responses
+- You MUST NOT pre-populate answers to questions without user input because this assumes user preferences without confirmation
+- You MUST NOT write multiple questions and answers to the idea-honing.md file at once because this skips the interactive clarification process
+- You MUST follow this exact process for each question:
+  1. Formulate a single question
+  2. Append the question to {project_dir}/idea-honing.md
+  3. Present the question to the user in the conversation
+  4. Wait for the user's complete response, which may require brief back-and-forth dialogue across multiple turns.
+  5. Once you have their complete response, append the user's answer (or final decision) to {project_dir}/idea-honing.md
+  6. Only then proceed to formulating the next question
+- You MAY suggest possible answers when asking a question, but MUST wait for the user's actual response
+- You MUST format the idea-honing.md document with clear question and answer sections
+- You MUST include the final chosen answer in the answer section
+- You MAY include alternative options that were considered before the final decision
+- You MUST ensure you have the user's complete response before recording it and moving to the next question
+- You MUST continue asking questions until sufficient detail is gathered
+- You SHOULD ask about edge cases, user experience, technical constraints, and success criteria
+- You SHOULD adapt follow-up questions based on previous answers
+- You MAY suggest options when the user is unsure about a particular aspect
+- You MAY recognize when the requirements clarification process appears to have reached a natural conclusion
+- You MUST explicitly ask the user if they feel the requirements clarification is complete before moving to the next step
+- You MUST offer the option to conduct research if questions arise that would benefit from additional information
+- You MUST be prepared to return to requirements clarification after research if new questions emerge
+- You MUST NOT proceed with any other steps until explicitly directed by the user because this could skip important clarification steps
 
-Cover edge cases, user experience, technical constraints, and success criteria. Suggest options when the user is unsure.
+### 4. Research Relevant Information
 
-**Gate:** You MUST NOT proceed to Research or Design until the user explicitly confirms requirements clarification is complete. You MUST offer the option to conduct research if questions arise that would benefit from additional information.
-
-### 4. Research
-
-Conduct research on technologies, libraries, or existing code to inform the design.
+Conduct research on relevant technologies, libraries, or existing code that could inform the design, while collaborating with the user for guidance.
 
 **Constraints:**
-- You MUST propose a research plan to the user and incorporate their suggestions
-- You MUST document findings in `{project_dir}/research/` as separate topic files
-- You MUST periodically check in with the user to share findings and confirm direction
-- You MUST summarize key findings before moving on
-
-**Gate:** You MUST NOT proceed to the Iteration Checkpoint until the user confirms research is sufficient. You MUST offer to return to requirements clarification if research uncovers new questions.
+- You MUST identify areas where research is needed based on the requirements
+- You MUST propose an initial research plan to the user, listing topics to investigate
+- You MUST ask the user for input on the research plan, including:
+  - Additional topics that should be researched
+  - Specific resources (files, websites, internal tools) the user recommends
+  - Areas where the user has existing knowledge to contribute
+- You MUST incorporate user suggestions into the research plan
+- You MUST document research findings in separate markdown files in the {project_dir}/research/ directory
+- You SHOULD organize research by topic (e.g., {project_dir}/research/existing-code.md, {project_dir}/research/technologies.md)
+- You MUST include mermaid diagrams when documenting system architectures, data flows, or component relationships in research
+- You MUST include links to relevant references and sources when research is based on external materials (websites, documentation, articles, etc.)
+- You MAY use tools like search_internal_code, read_internal_website, or fs_read to gather information
+- You MUST ask the user whether other available search tools should also be used.
+- You MUST periodically check with the user during the research process (these check-ins may involve brief dialogue to clarify feedback) to:
+  - Share preliminary findings
+  - Ask for feedback and additional guidance
+  - Confirm if the research direction remains valuable
+- You MUST summarize key findings that will inform the design
+- You SHOULD cite sources and include relevant links in research documents
+- You MUST ask the user if the research is sufficient before proceeding to the next step
+- You MUST offer to return to requirements clarification if research uncovers new questions or considerations
+- You MUST NOT automatically return to requirements clarification after research without explicit user direction because this could disrupt the user's intended workflow
+- You MUST wait for the user to decide the next step after completing research
 
 ### 5. Iteration Checkpoint
 
-Summarize the current state of requirements and research, then ask the user:
-- Proceed to design?
-- Return to requirements clarification?
-- Conduct additional research?
+Determine if further requirements clarification or research is needed before proceeding to design.
 
-**Gate:** You MUST NOT proceed to design without explicit user confirmation. You MUST support iterating between requirements and research as many times as needed.
+**Constraints:**
+- You MUST summarize the current state of requirements and research to help the user make an informed decision
+- You MUST explicitly ask the user if they want to:
+  - Proceed to creating the detailed design
+  - Return to requirements clarification based on research findings
+  - Conduct additional research based on requirements
+- You MUST support iterating between requirements clarification and research as many times as needed
+- You MUST ensure that both the requirements and research are sufficiently complete before proceeding to design
+- You MUST NOT proceed to the design step without explicit user confirmation because this could skip important refinement steps
 
 ### 6. Create Detailed Design
 
-Create `{project_dir}/design.md` as a standalone document with these sections:
-- Overview
-- Detailed Requirements (consolidated from requirements.md)
-- Architecture Overview
-- Components and Interfaces
-- Data Models
-- Error Handling
-- Acceptance Criteria (Given-When-Then format for machine verification)
-- Testing Strategy
-- Appendices (Technology Choices, Research Findings, Alternative Approaches)
+Develop a comprehensive design document based on the requirements and research.
 
 **Constraints:**
-- You MUST write the design as standalone — understandable without reading other files
-- You MUST consolidate all requirements from requirements.md
-- You MUST include an appendix summarizing research (technology choices, alternatives, limitations)
-- You MUST review the design with the user and iterate on feedback
-
-**Gate:** You MUST NOT proceed to the implementation plan until the user explicitly approves the design. You MUST offer to return to requirements or research if gaps are identified during design review.
+- You MUST create a detailed design document at {project_dir}/design/detailed-design.md
+- You MUST write the design as a standalone document that can be understood without reading other project files
+- You MUST include the following sections in the design document:
+  - Overview
+  - Detailed Requirements (consolidated from idea-honing.md)
+  - Architecture Overview
+  - Components and Interfaces
+  - Data Models
+  - Error Handling
+  - Testing Strategy
+  - Appendices (Technology Choices, Research Findings, Alternative Approaches)
+- You MUST consolidate all requirements from the idea-honing.md file into the Detailed Requirements section
+- You MUST include an appendix section that summarizes key research findings, including:
+  - Major technology choices with pros and cons
+  - Existing solutions analysis
+  - Alternative approaches considered
+  - Key constraints and limitations identified during research
+- You SHOULD include diagrams or visual representations when appropriate using mermaid syntax
+- You MUST generate mermaid diagrams for architectural overviews, data flow, and component relationships
+- You MUST ensure the design addresses all requirements identified during the clarification process
+- You SHOULD highlight design decisions and their rationales, referencing research findings where applicable
+- You MUST review the design with the user and iterate based on feedback
+- You MUST explicitly ask the user if they are ready to proceed to implementation before moving to Step 7
+- You MUST NOT proceed to the implementation plan step without explicit user confirmation because this could skip important design refinement
+- You MUST offer to return to requirements clarification or research if gaps are identified during design
 
 ### 7. Develop Implementation Plan
 
-Create `{project_dir}/plan.md` — a numbered series of incremental implementation steps.
-
-**Guiding principle:** Each step builds on previous steps, results in working demoable functionality, and follows TDD practices. No orphaned code — every step ends with integration. Core end-to-end functionality should be available as early as possible.
+Create a structured implementation plan with a series of steps for implementing the design.
 
 **Constraints:**
-- You MUST include a checklist at the top of plan.md tracking each step
-- You MUST format as "Step N:" with: objective, implementation guidance, test requirements, integration notes, and demo description
-- You MUST ensure the plan covers all aspects of the design without duplicating design details
-
-**Gate:** You MUST NOT proceed to the summary until the user reviews and approves the implementation plan.
+- You MUST create an implementation plan at {project_dir}/implementation/plan.md
+- You MUST include a checklist at the beginning of the plan.md file to track implementation progress
+- You MUST use the following specific instructions when creating the implementation plan:
+  ```
+  Convert the design into a series of implementation steps that will build each component in a test-driven manner following agile best practices. Each step must result in a working, demoable increment of functionality. Prioritize best practices, incremental progress, and early testing, ensuring no big jumps in complexity at any stage. Make sure that each step builds on the previous steps, and ends with wiring things together. There should be no hanging or orphaned code that isn't integrated into a previous step.
+  ```
+- You MUST format the implementation plan as a numbered series of detailed steps
+- Each step in the plan MUST be written as a clear implementation objective
+- Each step MUST begin with "Step N:" where N is the sequential number
+- You MUST ensure each step includes:
+  - A clear objective
+  - General implementation guidance
+  - Test requirements for the functionality introduced in this step
+  - How it integrates with previous work
+  - **Demo** - explicit description of the working functionality that can be demonstrated after completing this step
+- You MUST ensure each step results in working, demoable functionality that provides value
+- You MUST sequence steps so that core end-to-end functionality is available as early as possible
+- You MUST NOT include excessive implementation details that are already covered in the design document because this creates redundancy and potential inconsistencies
+- You MUST assume that all context documents (requirements, design, research) will be available during implementation
+- You MUST break down the implementation into a series of discrete, manageable steps
+- You MUST ensure each step builds incrementally on previous steps
+- You MUST structure each step so that tests are written before or alongside the implementation code
+- You MUST include test requirements as part of each step that introduces or modifies functionality, not as separate testing-only steps
+- You MUST NOT create steps that are solely dedicated to testing or "adding tests" for functionality implemented in previous steps because this violates test-driven development principles and allows untested code to accumulate
+- You MUST ensure the plan covers all aspects of the design
+- You SHOULD sequence steps to validate core functionality early
+- You MUST ensure the checklist items correspond directly to the steps in the implementation plan
 
 ### 8. Summarize and Present Results
 
-Create `{project_dir}/summary.md` listing all artifacts, a brief overview, and suggested next steps. Present this summary in the conversation.
+Provide a summary of all artifacts created and next steps.
 
-### 9. Offer Ralph Integration
+**Constraints:**
+- You MUST create a summary document at {project_dir}/summary.md
+- You MUST list all artifacts created during the process
+- You MUST provide a brief overview of the design and implementation plan
+- You MUST suggest next steps for the user
+- You SHOULD highlight any areas that may need further refinement
+- You MUST present this summary to the user in the conversation
 
-Ask: "Would you like me to create a PROMPT.md for Ralph to implement this autonomously?"
+## Examples
 
-If yes, create a concise PROMPT.md (under 100 lines) with:
-- Objective statement
-- Key requirements
-- Acceptance criteria (Given-When-Then)
-- Reference to `specs/{task_name}/`
+### Example Input
 
-Suggest the appropriate command:
-- Full pipeline: `ralph run --config presets/pdd-to-code-assist.yml`
-- Simpler flow: `ralph run --config presets/spec-driven.yml`
+```
+Rough idea: I want to build a feature for our team's internal tool that allows users to create and manage templates for common documents we produce. Users should be able to create, edit, and share templates, as well as use them to generate new documents with custom fields.
 
-If the user declines, acknowledge and conclude the session.
+Project name: template-feature
+```
 
-**Gate:** You MUST NOT run `ralph run` or begin any implementation. This SOP ends here. Implementation is a separate step the user initiates themselves.
+### Example Output
 
-## Example
+```
+# Research Phase Interaction
 
-**Input:** "I want to build a template management feature for our internal tool — create, edit, share templates, generate documents with custom fields."
+Based on your requirements, I've identified several areas that would benefit from research:
 
-**Output:** A `specs/template-management/` directory containing rough-idea.md, requirements.md, research/, design.md, plan.md, and summary.md — plus optionally a PROMPT.md for autonomous implementation.
+1. **Existing template solutions** - Understanding what's already available
+2. **Storage and versioning approaches** - How to handle template versions and sharing
+3. **Custom field validation patterns** - Best practices for dynamic field validation
+
+I notice you have several additional MCP search tools available beyond the standard ones, including 'peccy web search' and other external search capabilities. Should I incorporate these additional search tools into the research process for broader coverage of template management solutions and industry best practices?
+
+---
+
+# Project Summary
+
+I've completed the transformation of your rough idea into a detailed design with an implementation plan. Here's what was created:
+
+## Directory Structure
+- .agents/planning/template-feature/
+  - rough-idea.md (your initial concept)
+  - idea-honing.md (our Q&A requirements clarification)
+  - research/
+    - existing-templates.md
+    - storage-options.md
+    - external-solutions.md
+  - design/
+    - detailed-design.md
+  - implementation/
+    - plan.md (includes implementation checklist)
+  - summary.md (this document)
+
+## Key Design Elements
+- Template management system with CRUD operations
+- Role-based access control for sharing
+- Versioning system for templates
+- Custom fields with validation
+- Document generation engine
+
+## Implementation Approach
+The implementation plan breaks down the work into 12 incremental steps, starting with core data models and building up to the complete feature set.
+
+## Next Steps
+1. Review the detailed design document at docs/template-feature/design/detailed-design.md
+2. Check the implementation plan and checklist at docs/template-feature/implementation/plan.md
+3. Begin implementation following the checklist in the implementation plan
+
+Would you like me to explain any specific part of the design or implementation plan in more detail?
+```
 
 ## Troubleshooting
 
-**Requirements stall:** Suggest switching to a different aspect, provide examples, or pivot to research to unblock decisions.
+### Requirements Clarification Stalls
+If the requirements clarification process seems to be going in circles or not making progress:
+- You SHOULD suggest moving to a different aspect of the requirements
+- You MAY provide examples or options to help the user make decisions
+- You SHOULD summarize what has been established so far and identify specific gaps
+- You MAY suggest conducting research to inform requirements decisions
 
-**Research limitations:** Document what's missing, suggest alternatives with available information, ask user for additional context. Don't block progress.
+### Research Limitations
+If you cannot access needed information:
+- You SHOULD document what information is missing
+- You SHOULD suggest alternative approaches based on available information
+- You MAY ask the user to provide additional context or documentation
+- You SHOULD continue with available information rather than blocking progress
 
-**Design complexity:** Break into smaller components, focus on core functionality first, suggest phased implementation, return to requirements to re-prioritize.
+### Design Complexity
+If the design becomes too complex or unwieldy:
+- You SHOULD suggest breaking it down into smaller, more manageable components
+- You SHOULD focus on core functionality first
+- You MAY suggest a phased approach to implementation
+- You SHOULD return to requirements clarification to prioritize features if needed
+
+
+## Ralph Loop Handoff
+
+After the planning session is complete and the user wants implementation, tell them how to start the Ralph loop themselves.
+
+Suggest one of these commands:
+- `ralph run --config presets/pdd-to-code-assist.yml --prompt "<task>"`
+- `ralph run --config presets/spec-driven.yml --prompt "<task>"`
+
+You MUST NOT start the loop or begin implementation yourself. This SOP ends after planning and handoff.

--- a/crates/ralph-cli/sops/upstream/pdd.env
+++ b/crates/ralph-cli/sops/upstream/pdd.env
@@ -1,0 +1,9 @@
+# Canonical upstream source for the bundled Ralph PDD SOP.
+# Update to latest upstream SHA with:
+#   ./scripts/sync-embedded-files.sh update-pdd-ref [branch]
+# Resync after manual edits with:
+#   ./scripts/sync-embedded-files.sh
+
+PDD_UPSTREAM_REPO="strands-agents/agent-sop"
+PDD_UPSTREAM_REF="7b71239492c51bbba5a2705e139da9503f36f0b6"
+PDD_UPSTREAM_PATH="agent-sops/pdd.sop.md"

--- a/crates/ralph-cli/src/sop_runner.rs
+++ b/crates/ralph-cli/src/sop_runner.rs
@@ -16,8 +16,9 @@ use thiserror::Error;
 
 /// Bundled SOP content - embedded at compile time for self-contained binary.
 ///
-/// Note: SOPs are copied into crates/ralph-cli/sops/ for crates.io packaging.
-/// The source files live in .claude/skills/ but must be duplicated here because
+/// Note: SOPs are copied or generated into crates/ralph-cli/sops/ for crates.io
+/// packaging. Some come from local source files, and PDD is generated from the
+/// canonical upstream GitHub SOP plus a small Ralph-specific addendum, because
 /// `include_str!` paths outside the crate directory aren't included when publishing.
 pub mod sops {
     /// PDD (Prompt-Driven Development) SOP for planning sessions.

--- a/scripts/sync-embedded-files.sh
+++ b/scripts/sync-embedded-files.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
-# Sync mirrored files for crates.io packaging and consistency
+# Sync embedded assets for crates.io packaging and consistency.
 #
-# Files referenced via include_str!() must be inside the crate directory to be
-# included when publishing. Additionally, presets are mirrored from /presets/
-# to /crates/ralph-cli/presets/ so cargo install users get the same presets.
-# This script syncs source files to their crate-local copies.
+# Files referenced via include_str!() must live inside the crate directory to be
+# included when publishing. Most embedded assets are mirrored from local source
+# files. The PDD SOP is generated from its canonical GitHub source plus a small
+# Ralph-specific addendum.
 #
 # Usage:
-#   ./scripts/sync-embedded-files.sh        # Sync files
-#   ./scripts/sync-embedded-files.sh check  # Check if files are in sync (for CI)
+#   ./scripts/sync-embedded-files.sh                   # Sync files
+#   ./scripts/sync-embedded-files.sh check             # Check if files are in sync (for CI)
+#   ./scripts/sync-embedded-files.sh update-pdd-ref    # Pin PDD to latest upstream main and resync
+#   ./scripts/sync-embedded-files.sh update-pdd-ref <branch>
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PDD_SOURCE_CONFIG="crates/ralph-cli/sops/upstream/pdd.env"
+PDD_ADDENDUM="crates/ralph-cli/sops/addendums/pdd-ralph.md"
+PDD_DEST="crates/ralph-cli/sops/pdd.md"
 
-# Define source -> destination mappings
+# Define source -> destination mappings for direct file mirrors.
 # Format: "source_path:dest_path"
-EMBEDDED_FILES=(
+MIRRORED_FILES=(
     # SOPs for ralph plan/task commands
-    ".claude/skills/pdd/SKILL.md:crates/ralph-cli/sops/pdd.md"
     ".claude/skills/code-task-generator/SKILL.md:crates/ralph-cli/sops/code-task-generator.md"
 
     # Presets (canonical -> mirror for cargo install)
@@ -56,10 +60,120 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-sync_files() {
+require_command() {
+    local command_name="$1"
+    if ! command -v "$command_name" > /dev/null 2>&1; then
+        echo -e "${RED}ERROR: Required command not found: $command_name${NC}"
+        exit 1
+    fi
+}
+
+load_pdd_source_config() {
+    local config_path="$REPO_ROOT/$PDD_SOURCE_CONFIG"
+
+    if [[ ! -f "$config_path" ]]; then
+        echo -e "${RED}ERROR: PDD source config not found: $PDD_SOURCE_CONFIG${NC}"
+        exit 1
+    fi
+
+    # shellcheck disable=SC1090
+    source "$config_path"
+
+    : "${PDD_UPSTREAM_REPO:?PDD_UPSTREAM_REPO must be set in $PDD_SOURCE_CONFIG}"
+    : "${PDD_UPSTREAM_REF:?PDD_UPSTREAM_REF must be set in $PDD_SOURCE_CONFIG}"
+    : "${PDD_UPSTREAM_PATH:?PDD_UPSTREAM_PATH must be set in $PDD_SOURCE_CONFIG}"
+}
+
+pdd_raw_url() {
+    load_pdd_source_config
+    printf 'https://raw.githubusercontent.com/%s/%s/%s' \
+        "$PDD_UPSTREAM_REPO" "$PDD_UPSTREAM_REF" "$PDD_UPSTREAM_PATH"
+}
+
+pdd_blob_url() {
+    load_pdd_source_config
+    printf 'https://github.com/%s/blob/%s/%s' \
+        "$PDD_UPSTREAM_REPO" "$PDD_UPSTREAM_REF" "$PDD_UPSTREAM_PATH"
+}
+
+resolve_latest_pdd_ref() {
+    local branch="${1:-main}"
+
+    require_command git
+    load_pdd_source_config
+
+    local resolved_ref
+    resolved_ref="$(git ls-remote "https://github.com/${PDD_UPSTREAM_REPO}.git" "refs/heads/${branch}" | awk 'NR==1 {print $1}')"
+
+    if [[ -z "$resolved_ref" ]]; then
+        echo -e "${RED}ERROR: Failed to resolve upstream ref for ${PDD_UPSTREAM_REPO}@${branch}${NC}"
+        exit 1
+    fi
+
+    printf '%s' "$resolved_ref"
+}
+
+write_pdd_source_config() {
+    local ref="$1"
+    local config_path="$REPO_ROOT/$PDD_SOURCE_CONFIG"
+
+    load_pdd_source_config
+
+    mkdir -p "$(dirname "$config_path")"
+    cat > "$config_path" <<EOF
+# Canonical upstream source for the bundled Ralph PDD SOP.
+# Generated/updated via:
+#   ./scripts/sync-embedded-files.sh update-pdd-ref [branch]
+# Resync after manual edits with:
+#   ./scripts/sync-embedded-files.sh
+
+PDD_UPSTREAM_REPO="$PDD_UPSTREAM_REPO"
+PDD_UPSTREAM_REF="$ref"
+PDD_UPSTREAM_PATH="$PDD_UPSTREAM_PATH"
+EOF
+}
+
+generate_pdd_sop() {
+    local output_path="$1"
+    local upstream_tmp
+    upstream_tmp="$(mktemp)"
+
+    require_command curl
+    load_pdd_source_config
+
+    local addendum_path="$REPO_ROOT/$PDD_ADDENDUM"
+    if [[ ! -f "$addendum_path" ]]; then
+        echo -e "${RED}ERROR: PDD addendum not found: $PDD_ADDENDUM${NC}"
+        rm -f "$upstream_tmp"
+        exit 1
+    fi
+
+    if ! curl -fsSL "$(pdd_raw_url)" -o "$upstream_tmp"; then
+        echo -e "${RED}ERROR: Failed to fetch canonical PDD SOP from GitHub${NC}"
+        echo "  URL: $(pdd_raw_url)"
+        rm -f "$upstream_tmp"
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$output_path")"
+    {
+        echo '<!-- GENERATED FILE: DO NOT EDIT -->'
+        echo "<!-- Source: $(pdd_blob_url) -->"
+        echo '<!-- Regenerate with: ./scripts/sync-embedded-files.sh -->'
+        echo
+        cat "$upstream_tmp"
+        echo
+        echo
+        cat "$addendum_path"
+    } > "$output_path"
+
+    rm -f "$upstream_tmp"
+}
+
+sync_mirrored_files() {
     local changed=0
 
-    for mapping in "${EMBEDDED_FILES[@]}"; do
+    for mapping in "${MIRRORED_FILES[@]}"; do
         local src="${mapping%%:*}"
         local dest="${mapping##*:}"
         local src_path="$REPO_ROOT/$src"
@@ -70,10 +184,8 @@ sync_files() {
             exit 1
         fi
 
-        # Create destination directory if needed
         mkdir -p "$(dirname "$dest_path")"
 
-        # Check if files differ
         if [[ ! -f "$dest_path" ]] || ! diff -q "$src_path" "$dest_path" > /dev/null 2>&1; then
             cp "$src_path" "$dest_path"
             echo -e "${GREEN}Synced: $src -> $dest${NC}"
@@ -84,19 +196,73 @@ sync_files() {
     done
 
     if [[ $changed -eq 1 ]]; then
-        echo -e "\n${YELLOW}Files were synced. Don't forget to commit the changes!${NC}"
+        echo -e "\n${YELLOW}Mirrored files were synced.${NC}"
     else
-        echo -e "\n${GREEN}All embedded files are up to date.${NC}"
+        echo -e "\n${GREEN}All mirrored files are up to date.${NC}"
     fi
 }
 
-check_files() {
+sync_generated_files() {
+    local changed=0
+    local dest_path="$REPO_ROOT/$PDD_DEST"
+    local generated_tmp
+    generated_tmp="$(mktemp)"
+
+    generate_pdd_sop "$generated_tmp"
+
+    if [[ ! -f "$dest_path" ]] || ! diff -q "$generated_tmp" "$dest_path" > /dev/null 2>&1; then
+        mkdir -p "$(dirname "$dest_path")"
+        cp "$generated_tmp" "$dest_path"
+        echo -e "${GREEN}Generated: $PDD_DEST${NC}"
+        echo "  Source: $(pdd_blob_url)"
+        changed=1
+    else
+        echo -e "Up to date: $PDD_DEST"
+    fi
+
+    rm -f "$generated_tmp"
+
+    if [[ $changed -eq 1 ]]; then
+        echo -e "${YELLOW}Generated files were refreshed from canonical sources.${NC}"
+    fi
+}
+
+sync_files() {
+    sync_mirrored_files
+    echo
+    sync_generated_files
+    echo
+    echo -e "${GREEN}Embedded assets sync complete.${NC}"
+}
+
+update_pdd_ref() {
+    local branch="${1:-main}"
+
+    load_pdd_source_config
+    local previous_ref="$PDD_UPSTREAM_REF"
+    local next_ref
+    next_ref="$(resolve_latest_pdd_ref "$branch")"
+
+    if [[ "$previous_ref" == "$next_ref" ]]; then
+        echo -e "${GREEN}PDD upstream ref already pinned to ${next_ref}${NC}"
+        echo "  Source: https://github.com/${PDD_UPSTREAM_REPO}/tree/${branch}"
+    else
+        write_pdd_source_config "$next_ref"
+        echo -e "${GREEN}Updated PDD upstream ref${NC}"
+        echo "  Repo: ${PDD_UPSTREAM_REPO}"
+        echo "  Branch: ${branch}"
+        echo "  Old: ${previous_ref}"
+        echo "  New: ${next_ref}"
+    fi
+
+    echo
+    sync_files
+}
+
+check_mirrored_files() {
     local out_of_sync=0
 
-    echo "Checking embedded files are in sync..."
-    echo ""
-
-    for mapping in "${EMBEDDED_FILES[@]}"; do
+    for mapping in "${MIRRORED_FILES[@]}"; do
         local src="${mapping%%:*}"
         local dest="${mapping##*:}"
         local src_path="$REPO_ROOT/$src"
@@ -122,24 +288,67 @@ check_files() {
         fi
     done
 
-    echo ""
+    return $out_of_sync
+}
+
+check_generated_files() {
+    local out_of_sync=0
+    local dest_path="$REPO_ROOT/$PDD_DEST"
+    local generated_tmp
+    generated_tmp="$(mktemp)"
+
+    generate_pdd_sop "$generated_tmp"
+
+    if [[ ! -f "$dest_path" ]]; then
+        echo -e "${RED}MISSING: $PDD_DEST${NC}"
+        echo "  Source: $(pdd_blob_url)"
+        out_of_sync=1
+    elif ! diff -q "$generated_tmp" "$dest_path" > /dev/null 2>&1; then
+        echo -e "${RED}OUT OF SYNC: $PDD_DEST${NC}"
+        echo "  Source: $(pdd_blob_url)"
+        echo "  Diff:"
+        diff "$generated_tmp" "$dest_path" | head -20 || true
+        out_of_sync=1
+    else
+        echo -e "${GREEN}✓${NC} $PDD_DEST"
+    fi
+
+    rm -f "$generated_tmp"
+    return $out_of_sync
+}
+
+check_files() {
+    local out_of_sync=0
+
+    echo "Checking embedded assets are in sync..."
+    echo
+
+    if ! check_mirrored_files; then
+        out_of_sync=1
+    fi
+
+    if ! check_generated_files; then
+        out_of_sync=1
+    fi
+
+    echo
 
     if [[ $out_of_sync -eq 1 ]]; then
-        echo -e "${RED}ERROR: Embedded files are out of sync!${NC}"
-        echo ""
+        echo -e "${RED}ERROR: Embedded assets are out of sync!${NC}"
+        echo
         echo "Run './scripts/sync-embedded-files.sh' to sync them."
-        echo ""
+        echo
         echo "This check exists because files referenced via include_str!()"
         echo "must be inside the crate directory to be included when publishing"
-        echo "to crates.io. Source files live elsewhere for better organization,"
-        echo "so we must keep copies in sync."
+        echo "to crates.io. Some files are mirrored from local sources, and the"
+        echo "PDD SOP is generated from its canonical GitHub source plus a"
+        echo "small Ralph addendum."
         exit 1
     else
-        echo -e "${GREEN}All embedded files are in sync.${NC}"
+        echo -e "${GREEN}All embedded assets are in sync.${NC}"
     fi
 }
 
-# Main
 case "${1:-sync}" in
     check)
         check_files
@@ -147,10 +356,14 @@ case "${1:-sync}" in
     sync|"")
         sync_files
         ;;
+    update-pdd-ref)
+        update_pdd_ref "${2:-main}"
+        ;;
     *)
-        echo "Usage: $0 [sync|check]"
-        echo "  sync  - Sync source files to crate-local copies (default)"
-        echo "  check - Check if files are in sync (for CI)"
+        echo "Usage: $0 [sync|check|update-pdd-ref [branch]]"
+        echo "  sync            - Sync mirrored files and generated embedded assets (default)"
+        echo "  check           - Check if embedded assets are in sync (for CI)"
+        echo "  update-pdd-ref  - Pin PDD to latest upstream branch SHA and resync"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary
- generate the bundled `ralph plan` PDD SOP from the canonical `strands-agents/agent-sop` GitHub source
- keep Ralph-specific behavior in a tiny addendum that only explains how to start the implementation loop
- add sync/check/update helpers so the pinned upstream SHA can be refreshed and verified locally and in CI
- remove the duplicate `mutants-baseline` Just recipe that was breaking `just` commands

## Details
- add `crates/ralph-cli/sops/upstream/pdd.env` to pin the upstream repo/path/ref
- add `crates/ralph-cli/sops/addendums/pdd-ralph.md` for the Ralph-only handoff text
- update `scripts/sync-embedded-files.sh` to:
  - fetch upstream PDD from GitHub
  - generate `crates/ralph-cli/sops/pdd.md`
  - verify generated output in `check` mode
  - support `update-pdd-ref [branch]`
- add `just embedded-sync`, `just embedded-check`, and `just embedded-update-pdd-ref`
- include embedded asset checks in `just check` / `just ci`

## Verification
- `./scripts/sync-embedded-files.sh check`
- `./scripts/sync-embedded-files.sh update-pdd-ref main`
- `just embedded-update-pdd-ref`
- `cargo test`
- `cargo test -p ralph-core smoke_runner`
