### PR TITLE
feat(tui): show update available in header

### DIFF
--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -7,6 +7,7 @@
 use crate::input::{Action, map_key};
 use crate::rpc_writer::RpcWriter;
 use crate::state::TuiState;
+use crate::update_check;
 use crate::widgets::{content::ContentPane, footer, header, help};
 use anyhow::Result;
 use crossterm::{
@@ -153,6 +154,14 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
             let _ = disable_raw_mode();
             let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture, Show);
         }
+
+        let update_state = Arc::clone(&self.state);
+        tokio::spawn(async move {
+            let status = update_check::fetch_update_status().await;
+            if let Ok(mut state) = update_state.lock() {
+                state.set_update_status(status);
+            }
+        });
 
         // Event-driven architecture: input polling is the primary driver
         // Render is throttled to ~60fps via interval tick

--- a/crates/ralph-tui/src/lib.rs
+++ b/crates/ralph-tui/src/lib.rs
@@ -31,6 +31,7 @@ pub mod rpc_writer;
 pub mod state;
 pub mod state_mutations;
 pub mod text_renderer;
+pub mod update_check;
 pub mod widgets;
 
 use anyhow::{Context, Result};

--- a/crates/ralph-tui/src/state.rs
+++ b/crates/ralph-tui/src/state.rs
@@ -113,6 +113,17 @@ pub enum GuidanceResult {
     Failed,
 }
 
+/// Status of the background update check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateStatus {
+    /// No check result yet.
+    Unknown,
+    /// The running version matches the latest known release.
+    UpToDate,
+    /// A newer release is available.
+    Available { latest: String },
+}
+
 /// Observable state derived from loop events.
 pub struct TuiState {
     /// Which hat will process next event (ID + display name).
@@ -143,6 +154,8 @@ pub struct TuiState {
     pub max_iterations: Option<u32>,
     /// Idle timeout countdown.
     pub idle_timeout_remaining: Option<Duration>,
+    /// Status of the asynchronous update check.
+    pub update_status: UpdateStatus,
     /// Map of event topics to hat display information (for custom hats).
     /// Key: event topic (e.g., "review.security")
     /// Value: (HatId, display name including emoji)
@@ -238,6 +251,7 @@ impl TuiState {
             search_forward: true,
             max_iterations: None,
             idle_timeout_remaining: None,
+            update_status: UpdateStatus::Unknown,
             hat_map: HashMap::new(),
             // Iteration management
             iterations: Vec::new(),
@@ -285,6 +299,7 @@ impl TuiState {
             search_forward: true,
             max_iterations: None,
             idle_timeout_remaining: None,
+            update_status: UpdateStatus::Unknown,
             hat_map,
             // Iteration management
             iterations: Vec::new(),
@@ -855,6 +870,11 @@ impl TuiState {
                 None
             }
         })
+    }
+
+    /// Updates the cached result of the asynchronous version check.
+    pub fn set_update_status(&mut self, status: UpdateStatus) {
+        self.update_status = status;
     }
 }
 

--- a/crates/ralph-tui/src/update_check.rs
+++ b/crates/ralph-tui/src/update_check.rs
@@ -1,0 +1,136 @@
+use crate::state::UpdateStatus;
+use reqwest::header::{ACCEPT, HeaderMap, HeaderValue, USER_AGENT};
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::time::Duration;
+
+const UPDATE_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Deserialize)]
+struct LatestRelease {
+    tag_name: String,
+    prerelease: bool,
+}
+
+pub async fn fetch_update_status() -> UpdateStatus {
+    match fetch_latest_release_tag().await {
+        Ok(Some(latest)) => match compare_versions(env!("CARGO_PKG_VERSION"), &latest) {
+            Some(Ordering::Less) => UpdateStatus::Available { latest },
+            Some(Ordering::Equal | Ordering::Greater) => UpdateStatus::UpToDate,
+            None => UpdateStatus::Unknown,
+        },
+        Ok(None) => UpdateStatus::Unknown,
+        Err(_) => UpdateStatus::Unknown,
+    }
+}
+
+async fn fetch_latest_release_tag() -> Result<Option<String>, reqwest::Error> {
+    let Some(url) = latest_release_api_url() else {
+        return Ok(None);
+    };
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static(concat!("ralph-tui/", env!("CARGO_PKG_VERSION"))),
+    );
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static("application/vnd.github+json"),
+    );
+
+    let client = reqwest::Client::builder()
+        .default_headers(headers)
+        .timeout(UPDATE_CHECK_TIMEOUT)
+        .build()?;
+
+    let release = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<LatestRelease>()
+        .await?;
+
+    if release.prerelease {
+        return Ok(None);
+    }
+
+    Ok(normalize_version(&release.tag_name))
+}
+
+fn latest_release_api_url() -> Option<String> {
+    let repository = env!("CARGO_PKG_REPOSITORY").trim_end_matches('/');
+    let repo = repository
+        .strip_prefix("https://github.com/")
+        .or_else(|| repository.strip_prefix("http://github.com/"))
+        .map(|value| value.trim_end_matches(".git"))
+        .filter(|value| !value.is_empty())
+        .unwrap_or("mikeyobrien/ralph-orchestrator");
+
+    Some(format!(
+        "https://api.github.com/repos/{repo}/releases/latest"
+    ))
+}
+
+fn normalize_version(input: &str) -> Option<String> {
+    let trimmed = input.trim().trim_start_matches('v');
+    let core = trimmed.split(['-', '+']).next()?.trim();
+    if core.is_empty() || !core.split('.').all(|part| !part.is_empty()) {
+        return None;
+    }
+    Some(core.to_string())
+}
+
+fn compare_versions(current: &str, latest: &str) -> Option<Ordering> {
+    let current = parse_version(current)?;
+    let latest = parse_version(latest)?;
+    Some(current.cmp(&latest))
+}
+
+fn parse_version(version: &str) -> Option<Vec<u64>> {
+    normalize_version(version)?
+        .split('.')
+        .map(|part| part.parse().ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_release_tags() {
+        assert_eq!(normalize_version("v2.8.0"), Some("2.8.0".to_string()));
+        assert_eq!(normalize_version("2.8.0-beta.1"), Some("2.8.0".to_string()));
+        assert_eq!(
+            normalize_version("2.8.0+build.5"),
+            Some("2.8.0".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_versions() {
+        assert_eq!(normalize_version(""), None);
+        assert_eq!(normalize_version("v"), None);
+        assert_eq!(normalize_version("2..8"), None);
+    }
+
+    #[test]
+    fn compares_versions_numerically() {
+        assert_eq!(compare_versions("2.7.0", "2.8.0"), Some(Ordering::Less));
+        assert_eq!(compare_versions("2.8.0", "2.8.0"), Some(Ordering::Equal));
+        assert_eq!(compare_versions("2.10.0", "2.9.9"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn builds_github_release_api_url() {
+        assert_eq!(
+            latest_release_api_url(),
+            Some(
+                "https://api.github.com/repos/mikeyobrien/ralph-orchestrator/releases/latest"
+                    .to_string()
+            )
+        );
+    }
+}

--- a/crates/ralph-tui/src/widgets/header.rs
+++ b/crates/ralph-tui/src/widgets/header.rs
@@ -1,9 +1,10 @@
-use crate::state::TuiState;
+use crate::state::{TuiState, UpdateStatus};
 use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
+use unicode_width::UnicodeWidthStr;
 
 // ============================================================================
 // Width Breakpoints for Priority-Based Progressive Disclosure
@@ -31,17 +32,17 @@ const WIDTH_MINIMAL: u16 = 40; // Hide idle countdown
 /// At narrower terminal widths, lower-priority components are hidden or compressed
 /// to ensure critical information (iteration, mode) remains visible.
 pub fn render(state: &TuiState, width: u16) -> Paragraph<'static> {
-    let mut spans = vec![];
+    let mut left_spans = vec![];
 
     // Priority 1: Iteration counter or status indicator - ALWAYS shown
     if state.subprocess_error.is_some() {
-        spans.push(Span::styled(
+        left_spans.push(Span::styled(
             "[ERROR]".to_string(),
             Style::default().fg(Color::Red),
         ));
     } else if state.iterations.is_empty() && state.last_event.is_none() {
         // No events received yet — subprocess RPC connection not established
-        spans.push(Span::styled(
+        left_spans.push(Span::styled(
             "[connecting]".to_string(),
             Style::default().fg(Color::DarkGray),
         ));
@@ -54,7 +55,7 @@ pub fn render(state: &TuiState, width: u16) -> Paragraph<'static> {
         let total_iterations = state.total_iterations() as u32;
         let total_display = state.max_iterations.unwrap_or(total_iterations);
         let iter_display = format!("[iter {}/{}]", current, total_display);
-        spans.push(Span::raw(iter_display));
+        left_spans.push(Span::raw(iter_display));
     }
 
     // Priority 4: Elapsed time (iteration) - hidden at WIDTH_COMPRESS and below
@@ -64,11 +65,11 @@ pub fn render(state: &TuiState, width: u16) -> Paragraph<'static> {
         let total_secs = elapsed.as_secs();
         let mins = total_secs / 60;
         let secs = total_secs % 60;
-        spans.push(Span::raw(format!(" {mins:02}:{secs:02}")));
+        left_spans.push(Span::raw(format!(" {mins:02}:{secs:02}")));
     }
 
     // Priority 3: Hat display - compressed at WIDTH_COMPRESS and below
-    spans.push(Span::raw(" | "));
+    left_spans.push(Span::raw(" | "));
     let iteration_finished = state.current_iteration().and_then(|b| b.elapsed).is_some();
     let hat_display = if iteration_finished && state.pending_hat.is_some() {
         // Iteration done and next hat is known — show it instead of the stale frozen hat
@@ -89,23 +90,23 @@ pub fn render(state: &TuiState, width: u16) -> Paragraph<'static> {
     };
     if width > WIDTH_COMPRESS {
         // Full hat display: "🔨 Builder"
-        spans.push(Span::raw(hat_with_backend));
+        left_spans.push(Span::raw(hat_with_backend));
     } else {
         // Compressed: emoji only (first character cluster)
         let emoji = hat_display.chars().next().unwrap_or('?');
-        spans.push(Span::raw(emoji.to_string()));
+        left_spans.push(Span::raw(emoji.to_string()));
     }
 
     // Priority 5: Idle countdown - hidden at WIDTH_MINIMAL and below
     if let Some(idle) = state.idle_timeout_remaining
         && width > WIDTH_MINIMAL
     {
-        spans.push(Span::raw(format!(" | idle: {}s", idle.as_secs())));
+        left_spans.push(Span::raw(format!(" | idle: {}s", idle.as_secs())));
     }
 
     // Priority 2: Mode indicator - ALWAYS shown (compressed at WIDTH_COMPRESS and below)
     // Shows [LIVE] when following latest iteration, [REVIEW] when viewing history
-    spans.push(Span::raw(" | "));
+    left_spans.push(Span::raw(" | "));
     let mode = if state.following_latest {
         if width > WIDTH_COMPRESS {
             Span::styled("[LIVE]", Style::default().fg(Color::Green))
@@ -117,28 +118,66 @@ pub fn render(state: &TuiState, width: u16) -> Paragraph<'static> {
     } else {
         Span::styled("◀", Style::default().fg(Color::Yellow))
     };
-    spans.push(mode);
+    left_spans.push(mode);
 
     // Priority 3: Scroll indicator - compressed at WIDTH_COMPRESS and below
     if state.in_scroll_mode {
         if width > WIDTH_COMPRESS {
-            spans.push(Span::styled(" [SCROLL]", Style::default().fg(Color::Cyan)));
+            left_spans.push(Span::styled(" [SCROLL]", Style::default().fg(Color::Cyan)));
         } else {
-            spans.push(Span::styled(" [S]", Style::default().fg(Color::Cyan)));
+            left_spans.push(Span::styled(" [S]", Style::default().fg(Color::Cyan)));
         }
     }
 
     // Priority 6: Help hint - shown only at WIDTH_FULL (80+)
     if width >= WIDTH_FULL {
-        spans.push(Span::styled(
+        left_spans.push(Span::styled(
             " | ? help",
             Style::default().fg(Color::DarkGray),
         ));
     }
 
+    let left_width = spans_width(&left_spans);
+    let mut spans = left_spans;
+    if let Some(right_spans) = update_badge_spans(state, width, left_width) {
+        let gap = width as usize - left_width - spans_width(&right_spans);
+        spans.push(Span::raw(" ".repeat(gap)));
+        spans.extend(right_spans);
+    }
+
     let line = Line::from(spans);
     let block = Block::default().borders(Borders::BOTTOM);
     Paragraph::new(line).block(block)
+}
+
+fn spans_width(spans: &[Span<'_>]) -> usize {
+    spans
+        .iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum()
+}
+
+fn update_badge_spans(
+    state: &TuiState,
+    width: u16,
+    left_width: usize,
+) -> Option<Vec<Span<'static>>> {
+    let UpdateStatus::Available { latest } = &state.update_status else {
+        return None;
+    };
+
+    let style = Style::default().fg(Color::Yellow);
+    let candidates = [
+        (width >= WIDTH_FULL, format!("[update {latest}]")),
+        (width >= WIDTH_HIDE_HELP, format!("[↑ {latest}]")),
+        (width > WIDTH_MINIMAL, "↑".to_string()),
+    ];
+
+    candidates
+        .into_iter()
+        .filter(|(allowed, _)| *allowed)
+        .map(|(_, label)| vec![Span::styled(label, style)])
+        .find(|candidate| left_width + 1 + spans_width(candidate) <= width as usize)
 }
 
 #[cfg(test)]
@@ -769,6 +808,80 @@ mod tests {
         assert!(
             text.contains("[ERROR]"),
             "should show [ERROR] when subprocess died, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn header_shows_full_update_badge_on_wide_terminal() {
+        let mut state = TuiState::new();
+        state.start_new_iteration();
+        state.update_status = UpdateStatus::Available {
+            latest: "2.8.0".to_string(),
+        };
+
+        let text = render_to_string_with_width(&state, 80);
+        assert!(
+            text.contains("[update 2.8.0]"),
+            "should show full update badge at wide widths, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn header_compresses_update_badge_on_medium_terminal() {
+        let mut state = TuiState::new();
+        state.start_new_iteration();
+        state.update_status = UpdateStatus::Available {
+            latest: "2.8.0".to_string(),
+        };
+
+        let text = render_to_string_with_width(&state, 65);
+        assert!(
+            text.contains("[↑ 2.8.0]"),
+            "should show compact update badge at medium widths, got: {}",
+            text
+        );
+        assert!(
+            !text.contains("[update 2.8.0]"),
+            "should not show full badge at medium widths, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn header_shows_update_icon_on_narrow_terminal() {
+        let mut state = TuiState::new();
+        state.start_new_iteration();
+        state.update_status = UpdateStatus::Available {
+            latest: "2.8.0".to_string(),
+        };
+
+        let text = render_to_string_with_width(&state, 45);
+        assert!(
+            text.contains('↑'),
+            "should show icon-only update indicator on narrow widths, got: {}",
+            text
+        );
+        assert!(
+            !text.contains("2.8.0"),
+            "should hide version text on narrow widths, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn header_hides_update_badge_when_too_narrow() {
+        let mut state = TuiState::new();
+        state.start_new_iteration();
+        state.update_status = UpdateStatus::Available {
+            latest: "2.8.0".to_string(),
+        };
+
+        let text = render_to_string_with_width(&state, 18);
+        assert!(
+            !text.contains('↑') && !text.contains("update"),
+            "should hide update indicator when terminal is too narrow, got: {}",
             text
         );
     }


### PR DESCRIPTION
## Summary
- add a background TUI update check against the latest GitHub release
- store update availability in `TuiState` and render a right-aligned header indicator
- make the indicator responsive: full label on wide terminals, compact label on medium widths, icon-only on narrow widths, hidden when space is too tight

## Demo
![Ralph TUI update indicator demo](https://gist.githubusercontent.com/mikeyobrien/bbee089953d3f2acb37a895e6d38bced/raw/d390c0b42f8c2cc093cca246a0eb2451f0a8501e/ralph_tui_update_indicator_demo.svg)

Responsive header behavior when an update is available:
- wide: `[update 2.8.0]`
- medium: `[↑ 2.8.0]`
- narrow: `↑`
- very narrow: hidden

The indicator is right-aligned in the header and only appears when the latest release is newer than the running version.

## Testing
- cargo test -p ralph-tui
- cargo test
- cargo test -p ralph-core smoke_runner
