### PR TITLE
feat(cli): add user-scoped Ralph config defaults

### DIFF
--- a/crates/ralph-cli/src/config_resolution.rs
+++ b/crates/ralph-cli/src/config_resolution.rs
@@ -1,0 +1,194 @@
+use anyhow::{Context, Result};
+use ralph_core::RalphConfig;
+use serde_yaml::Value;
+use std::path::{Path, PathBuf};
+
+use crate::ConfigSource;
+
+pub(crate) fn default_user_config_path() -> Option<PathBuf> {
+    user_config_path_from_home(home_dir_from_env().as_deref())
+}
+
+pub(crate) fn user_config_label_if_exists() -> Option<String> {
+    let path = default_user_config_path()?;
+    path.exists().then(|| path.display().to_string())
+}
+
+pub(crate) fn load_optional_user_config_value() -> Result<Option<(Value, String)>> {
+    let path = default_user_config_path();
+    load_optional_user_config_value_from(path.as_deref())
+}
+
+pub(crate) fn load_optional_user_config_value_from(
+    path: Option<&Path>,
+) -> Result<Option<(Value, String)>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let label = path.display().to_string();
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to load config from {}", label))?;
+    let value = parse_yaml_value(&content, &label)?;
+    Ok(Some((value, label)))
+}
+
+pub(crate) fn parse_yaml_value(content: &str, label: &str) -> Result<Value> {
+    serde_yaml::from_str(content).with_context(|| format!("Failed to parse YAML from {}", label))
+}
+
+pub(crate) fn default_core_value() -> Result<Value> {
+    let mut value = serde_yaml::to_value(RalphConfig::default())
+        .context("Failed to build default core config")?;
+
+    if let Some(mapping) = value.as_mapping_mut() {
+        let hats_key = Value::String("hats".to_string());
+        let events_key = Value::String("events".to_string());
+        mapping.remove(&hats_key);
+        mapping.remove(&events_key);
+    }
+
+    Ok(value)
+}
+
+pub(crate) fn merge_yaml_values(base: Value, overlay: Value) -> Result<Value> {
+    match (base, overlay) {
+        (Value::Mapping(mut base_map), Value::Mapping(overlay_map)) => {
+            for (key, overlay_value) in overlay_map {
+                let merged_value = if let Some(base_value) = base_map.remove(&key) {
+                    merge_yaml_values(base_value, overlay_value)?
+                } else {
+                    overlay_value
+                };
+                base_map.insert(key, merged_value);
+            }
+            Ok(Value::Mapping(base_map))
+        }
+        (_, overlay) => Ok(overlay),
+    }
+}
+
+pub(crate) fn compose_core_label(
+    user_label: Option<&str>,
+    primary_label: &str,
+    primary_uses_defaults: bool,
+) -> String {
+    match user_label {
+        Some(user) if primary_uses_defaults => format!("{user} + defaults"),
+        Some(user) => format!("{user} + {primary_label}"),
+        None => primary_label.to_string(),
+    }
+}
+
+pub(crate) fn split_config_sources(
+    config_sources: &[ConfigSource],
+) -> (Vec<ConfigSource>, Vec<ConfigSource>) {
+    config_sources
+        .iter()
+        .cloned()
+        .partition(|source| !matches!(source, ConfigSource::Override { .. }))
+}
+
+pub(crate) fn find_workspace_config_path(root: &Path) -> Option<PathBuf> {
+    ["ralph.yml", "ralph.yaml"]
+        .iter()
+        .map(|candidate| root.join(candidate))
+        .find(|path| path.exists())
+}
+
+fn user_config_path_from_home(home: Option<&Path>) -> Option<PathBuf> {
+    Some(home?.join(".ralph").join("config.yml"))
+}
+
+fn home_dir_from_env() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+        .or_else(|| {
+            let drive = std::env::var_os("HOMEDRIVE")?;
+            let path = std::env::var_os("HOMEPATH")?;
+            let mut joined = PathBuf::from(drive);
+            joined.push(path);
+            Some(joined)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_yaml::Value;
+
+    #[test]
+    fn user_config_path_uses_ralph_home_convention() {
+        let path = user_config_path_from_home(Some(Path::new("/tmp/test-home")))
+            .expect("path should exist");
+        assert_eq!(path, PathBuf::from("/tmp/test-home/.ralph/config.yml"));
+    }
+
+    #[test]
+    fn merge_yaml_values_recursively_merges_maps_and_replaces_arrays() {
+        let base: Value = serde_yaml::from_str(
+            r"
+hooks:
+  events:
+    pre.loop.start:
+      - name: user-hook
+        command: [./user.sh]
+event_loop:
+  max_iterations: 10
+  tags: [one, two]
+",
+        )
+        .unwrap();
+        let overlay: Value = serde_yaml::from_str(
+            r"
+hooks:
+  events:
+    pre.loop.start:
+      - name: local-hook
+        command: [./local.sh]
+event_loop:
+  completion_promise: LOOP_COMPLETE
+  tags: [three]
+",
+        )
+        .unwrap();
+
+        let merged = merge_yaml_values(base, overlay).unwrap();
+        let hooks = merged["hooks"]["events"]["pre.loop.start"]
+            .as_sequence()
+            .expect("hook sequence");
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0]["name"].as_str(), Some("local-hook"));
+        assert_eq!(merged["event_loop"]["max_iterations"].as_i64(), Some(10));
+        assert_eq!(
+            merged["event_loop"]["completion_promise"].as_str(),
+            Some("LOOP_COMPLETE")
+        );
+        let tags = merged["event_loop"]["tags"].as_sequence().expect("tags");
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].as_str(), Some("three"));
+    }
+
+    #[test]
+    fn compose_core_label_uses_defaults_suffix_only_for_user_only_resolution() {
+        assert_eq!(
+            compose_core_label(Some("/home/test/.ralph/config.yml"), "ralph.yml", true,),
+            "/home/test/.ralph/config.yml + defaults"
+        );
+        assert_eq!(
+            compose_core_label(
+                Some("/home/test/.ralph/config.yml"),
+                "repo/ralph.yml",
+                false,
+            ),
+            "/home/test/.ralph/config.yml + repo/ralph.yml"
+        );
+        assert_eq!(compose_core_label(None, "ralph.yml", true), "ralph.yml");
+    }
+}

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -15,6 +15,7 @@
 
 mod backend_support;
 mod bot;
+mod config_resolution;
 mod display;
 mod doctor;
 mod hats;
@@ -393,34 +394,71 @@ pub(crate) fn ensure_scratchpad_directory(config: &RalphConfig) -> anyhow::Resul
 pub(crate) fn load_config_with_overrides(
     config_sources: &[ConfigSource],
 ) -> anyhow::Result<RalphConfig> {
-    // Partition sources: file sources vs overrides
-    let (primary_sources, overrides): (Vec<_>, Vec<_>) = config_sources
-        .iter()
-        .partition(|s| !matches!(s, ConfigSource::Override { .. }));
+    let (primary_sources, overrides) = config_resolution::split_config_sources(config_sources);
+    if primary_sources.len() > 1 {
+        warn!("Multiple config sources specified, using first one. Others ignored.");
+    }
 
-    // Load configuration from first file source, or default ralph.yml
-    let mut config = if let Some(ConfigSource::File(path)) = primary_sources.first() {
-        if path.exists() {
-            RalphConfig::from_file(path)
-                .with_context(|| format!("Failed to load config from {:?}", path))?
-        } else {
-            warn!("Config file {:?} not found, using defaults", path);
-            RalphConfig::default()
+    let (primary_value, primary_label, primary_uses_defaults) = match primary_sources.first() {
+        Some(ConfigSource::File(path)) => {
+            if path.exists() {
+                let label = path.display().to_string();
+                let content = std::fs::read_to_string(path)
+                    .with_context(|| format!("Failed to load config from {}", label))?;
+                let value = config_resolution::parse_yaml_value(&content, &label)?;
+                (Some(value), label, false)
+            } else {
+                warn!("Config file {:?} not found, using defaults", path);
+                (None, path.display().to_string(), false)
+            }
         }
-    } else {
-        // Only overrides specified - load default path as base
-        let default_path = default_config_path();
-        if default_path.exists() {
-            RalphConfig::from_file(&default_path)
-                .with_context(|| format!("Failed to load config from {}", default_path.display()))?
-        } else {
-            warn!(
-                "Config file {} not found, using defaults",
-                default_path.display()
+        Some(ConfigSource::Builtin(name)) => {
+            anyhow::bail!(
+                "`-c builtin:{name}` is no longer supported.\n\nBuiltin presets are now hat collections.\nUse:\n  ralph run -c ralph.yml -H builtin:{name}"
             );
-            RalphConfig::default()
+        }
+        Some(ConfigSource::Remote(url)) => {
+            anyhow::bail!(
+                "Remote core config sources are not supported for this command: {}",
+                url
+            );
+        }
+        Some(ConfigSource::Override { .. }) => unreachable!("Overrides are partitioned out"),
+        None => {
+            let default_path = default_config_path();
+            if default_path.exists() {
+                let label = default_path.display().to_string();
+                let content = std::fs::read_to_string(&default_path)
+                    .with_context(|| format!("Failed to load config from {}", label))?;
+                let value = config_resolution::parse_yaml_value(&content, &label)?;
+                (Some(value), label, false)
+            } else {
+                warn!(
+                    "Config file {} not found, using defaults",
+                    default_path.display()
+                );
+                (None, default_path.display().to_string(), true)
+            }
         }
     };
+
+    let user_layer = config_resolution::load_optional_user_config_value()?;
+    let mut merged_value = config_resolution::default_core_value()?;
+    if let Some((user_value, _)) = &user_layer {
+        merged_value = config_resolution::merge_yaml_values(merged_value, user_value.clone())?;
+    }
+    if let Some(primary_value) = primary_value {
+        merged_value = config_resolution::merge_yaml_values(merged_value, primary_value)?;
+    }
+
+    let merged_label = config_resolution::compose_core_label(
+        user_layer.as_ref().map(|(_, label)| label.as_str()),
+        &primary_label,
+        primary_uses_defaults,
+    );
+
+    let mut config: RalphConfig = serde_yaml::from_value(merged_value)
+        .with_context(|| format!("Failed to parse merged core config from {}", merged_label))?;
 
     config.normalize();
 
@@ -429,8 +467,7 @@ pub(crate) fn load_config_with_overrides(
         std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
 
     // Apply CLI config overrides
-    let override_sources: Vec<_> = overrides.into_iter().cloned().collect();
-    apply_config_overrides(&mut config, &override_sources)?;
+    apply_config_overrides(&mut config, &overrides)?;
 
     Ok(config)
 }
@@ -3322,8 +3359,7 @@ core:
 
         let config = load_config_with_overrides(&sources).unwrap();
 
-        let default = RalphConfig::default();
-        assert_eq!(config.core.scratchpad, default.core.scratchpad);
+        assert!(!config.core.scratchpad.is_empty());
         let expected_root = std::fs::canonicalize(temp_dir.path())
             .unwrap_or_else(|_| temp_dir.path().to_path_buf());
         let actual_root = std::fs::canonicalize(&config.core.workspace_root)

--- a/crates/ralph-cli/src/preflight.rs
+++ b/crates/ralph-cli/src/preflight.rs
@@ -6,7 +6,7 @@ use ralph_core::{CheckResult, CheckStatus, PreflightReport, PreflightRunner, Ral
 use serde_yaml::{Mapping, Value};
 use tracing::{info, warn};
 
-use crate::{ConfigSource, HatsSource, presets};
+use crate::{ConfigSource, HatsSource, config_resolution, presets};
 
 #[derive(Parser, Debug)]
 pub struct PreflightArgs {
@@ -237,14 +237,23 @@ pub(crate) fn config_source_label(
         .iter()
         .find(|source| !matches!(source, ConfigSource::Override { .. }));
 
-    let core_label = match primary {
-        Some(ConfigSource::File(path)) => path.display().to_string(),
-        Some(ConfigSource::Builtin(name)) => format!("builtin:{}", name),
-        Some(ConfigSource::Remote(url)) => url.clone(),
-        Some(ConfigSource::Override { .. }) | None => {
-            crate::default_config_path().to_string_lossy().to_string()
+    let (primary_label, primary_uses_defaults) = match primary {
+        Some(ConfigSource::File(path)) => (path.display().to_string(), false),
+        Some(ConfigSource::Builtin(name)) => (format!("builtin:{}", name), false),
+        Some(ConfigSource::Remote(url)) => (url.clone(), false),
+        Some(ConfigSource::Override { .. }) => unreachable!("Overrides are filtered out"),
+        None => {
+            let default_path = crate::default_config_path();
+            let uses_defaults = !default_path.exists();
+            (default_path.display().to_string(), uses_defaults)
         }
     };
+
+    let core_label = config_resolution::compose_core_label(
+        config_resolution::user_config_label_if_exists().as_deref(),
+        &primary_label,
+        primary_uses_defaults,
+    );
 
     if let Some(source) = hats_source {
         format!("{} + hats:{}", core_label, source.label())
@@ -256,26 +265,28 @@ pub(crate) fn config_source_label(
 async fn load_core_value(
     config_sources: &[ConfigSource],
 ) -> Result<(Value, Vec<ConfigSource>, String)> {
-    let (primary_sources, overrides): (Vec<_>, Vec<_>) = config_sources
-        .iter()
-        .partition(|source| !matches!(source, ConfigSource::Override { .. }));
-    let overrides: Vec<ConfigSource> = overrides.into_iter().cloned().collect();
+    let (primary_sources, overrides) = config_resolution::split_config_sources(config_sources);
 
     if primary_sources.len() > 1 {
         warn!("Multiple config sources specified, using first one. Others ignored.");
     }
 
-    if let Some(source) = primary_sources.first() {
+    let user_layer = config_resolution::load_optional_user_config_value()?;
+
+    let (primary_value, primary_label, primary_uses_defaults) = if let Some(source) =
+        primary_sources.first()
+    {
         match source {
             ConfigSource::File(path) => {
                 if path.exists() {
+                    let label = path.display().to_string();
                     let content = std::fs::read_to_string(path)
-                        .with_context(|| format!("Failed to load config from {:?}", path))?;
-                    let value = parse_yaml_value(&content, &path.display().to_string())?;
-                    Ok((value, overrides, path.display().to_string()))
+                        .with_context(|| format!("Failed to load config from {}", label))?;
+                    let value = config_resolution::parse_yaml_value(&content, &label)?;
+                    (Some(value), label, false)
                 } else {
                     warn!("Config file {:?} not found, using defaults", path);
-                    Ok((default_core_value()?, overrides, path.display().to_string()))
+                    (None, path.display().to_string(), false)
                 }
             }
             ConfigSource::Builtin(name) => {
@@ -302,31 +313,43 @@ async fn load_core_value(
                     .await
                     .with_context(|| format!("Failed to read core config content from {}", url))?;
 
-                let value = parse_yaml_value(&content, url)?;
-                Ok((value, overrides, url.clone()))
+                let value = config_resolution::parse_yaml_value(&content, url)?;
+                (Some(value), url.clone(), false)
             }
             ConfigSource::Override { .. } => unreachable!("Partitioned out overrides"),
         }
     } else {
         let default_path = crate::default_config_path();
         if default_path.exists() {
-            let content = std::fs::read_to_string(&default_path).with_context(|| {
-                format!("Failed to load config from {}", default_path.display())
-            })?;
-            let value = parse_yaml_value(&content, &default_path.display().to_string())?;
-            Ok((value, overrides, default_path.display().to_string()))
+            let label = default_path.display().to_string();
+            let content = std::fs::read_to_string(&default_path)
+                .with_context(|| format!("Failed to load config from {}", label))?;
+            let value = config_resolution::parse_yaml_value(&content, &label)?;
+            (Some(value), label, false)
         } else {
             warn!(
                 "Config file {} not found, using defaults",
                 default_path.display()
             );
-            Ok((
-                default_core_value()?,
-                overrides,
-                default_path.display().to_string(),
-            ))
+            (None, default_path.display().to_string(), true)
         }
+    };
+
+    let mut merged = config_resolution::default_core_value()?;
+    if let Some((user_value, _)) = &user_layer {
+        merged = config_resolution::merge_yaml_values(merged, user_value.clone())?;
     }
+    if let Some(primary_value) = primary_value {
+        merged = config_resolution::merge_yaml_values(merged, primary_value)?;
+    }
+
+    let merged_label = config_resolution::compose_core_label(
+        user_layer.as_ref().map(|(_, label)| label.as_str()),
+        &primary_label,
+        primary_uses_defaults,
+    );
+
+    Ok((merged, overrides, merged_label))
 }
 
 async fn load_hats_value(source: &HatsSource) -> Result<Value> {
@@ -337,7 +360,7 @@ async fn load_hats_value(source: &HatsSource) -> Result<Value> {
             }
             let content = std::fs::read_to_string(path)
                 .with_context(|| format!("Failed to load hats from {:?}", path))?;
-            let value = parse_yaml_value(&content, &path.display().to_string())?;
+            let value = config_resolution::parse_yaml_value(&content, &path.display().to_string())?;
             normalize_hats_source_value(value, &path.display().to_string())
         }
         HatsSource::Remote(url) => {
@@ -359,7 +382,7 @@ async fn load_hats_value(source: &HatsSource) -> Result<Value> {
                 .await
                 .with_context(|| format!("Failed to read hats config content from {}", url))?;
 
-            let value = parse_yaml_value(&content, url)?;
+            let value = config_resolution::parse_yaml_value(&content, url)?;
             normalize_hats_source_value(value, url)
         }
         HatsSource::Builtin(name) => {
@@ -372,14 +395,11 @@ async fn load_hats_value(source: &HatsSource) -> Result<Value> {
                 )
             })?;
 
-            let preset_value = parse_yaml_value(preset.content, &format!("builtin:{}", name))?;
+            let preset_value =
+                config_resolution::parse_yaml_value(preset.content, &format!("builtin:{}", name))?;
             extract_hat_overlay_from_preset(preset_value)
         }
     }
-}
-
-fn parse_yaml_value(content: &str, label: &str) -> Result<Value> {
-    serde_yaml::from_str(content).with_context(|| format!("Failed to parse YAML from {}", label))
 }
 
 fn normalize_hats_source_value(value: Value, label: &str) -> Result<Value> {
@@ -411,20 +431,6 @@ fn normalize_hats_source_value(value: Value, label: &str) -> Result<Value> {
         label,
         disallowed.join(", ")
     )
-}
-
-fn default_core_value() -> Result<Value> {
-    let mut value = serde_yaml::to_value(RalphConfig::default())
-        .context("Failed to build default core config")?;
-
-    if let Some(mapping) = value.as_mapping_mut() {
-        let hats_key = Value::String("hats".to_string());
-        let events_key = Value::String("events".to_string());
-        mapping.remove(&hats_key);
-        mapping.remove(&events_key);
-    }
-
-    Ok(value)
 }
 
 fn mapping_get<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Value> {
@@ -573,11 +579,22 @@ mod tests {
             ))],
             None,
         );
-        assert_eq!(file_label, "/tmp/ralph.yml");
+        let user_label = crate::config_resolution::user_config_label_if_exists();
+        let expected_file_label = crate::config_resolution::compose_core_label(
+            user_label.as_deref(),
+            "/tmp/ralph.yml",
+            false,
+        );
+        assert_eq!(file_label, expected_file_label);
 
         let builtin_label =
             config_source_label(&[ConfigSource::Builtin("starter".to_string())], None);
-        assert_eq!(builtin_label, "builtin:starter");
+        let expected_builtin_label = crate::config_resolution::compose_core_label(
+            user_label.as_deref(),
+            "builtin:starter",
+            false,
+        );
+        assert_eq!(builtin_label, expected_builtin_label);
 
         let remote_label = config_source_label(
             &[ConfigSource::Remote(
@@ -585,7 +602,12 @@ mod tests {
             )],
             None,
         );
-        assert_eq!(remote_label, "https://example.com/ralph.yml");
+        let expected_remote_label = crate::config_resolution::compose_core_label(
+            user_label.as_deref(),
+            "https://example.com/ralph.yml",
+            false,
+        );
+        assert_eq!(remote_label, expected_remote_label);
 
         let override_label = config_source_label(
             &[ConfigSource::Override {
@@ -594,13 +616,24 @@ mod tests {
             }],
             None,
         );
-        assert_eq!(override_label, "ralph.yml");
+        let default_label = crate::default_config_path().to_string_lossy().to_string();
+        let expected_override_label = crate::config_resolution::compose_core_label(
+            user_label.as_deref(),
+            &default_label,
+            !crate::default_config_path().exists(),
+        );
+        assert_eq!(override_label, expected_override_label);
 
         let with_hats_label = config_source_label(
             &[ConfigSource::File(std::path::PathBuf::from("ralph.yml"))],
             Some(&HatsSource::Builtin("feature".to_string())),
         );
-        assert_eq!(with_hats_label, "ralph.yml + hats:builtin:feature");
+        let expected_core =
+            crate::config_resolution::compose_core_label(user_label.as_deref(), "ralph.yml", false);
+        assert_eq!(
+            with_hats_label,
+            format!("{expected_core} + hats:builtin:feature")
+        );
     }
 
     #[test]

--- a/crates/ralph-cli/src/skill_cli.rs
+++ b/crates/ralph-cli/src/skill_cli.rs
@@ -10,6 +10,8 @@ use ralph_core::{RalphConfig, SkillRegistry};
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
+use crate::config_resolution;
+
 /// Output format for skill list command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
 pub enum OutputFormat {
@@ -202,7 +204,7 @@ fn resolve_root(explicit_root: Option<PathBuf>) -> Result<PathBuf> {
 fn find_workspace_root(start: &Path) -> Option<PathBuf> {
     let mut current = Some(start);
     while let Some(dir) = current {
-        if dir.join("ralph.yml").exists() || dir.join("ralph.yaml").exists() {
+        if config_resolution::find_workspace_config_path(dir).is_some() {
             return Some(dir.to_path_buf());
         }
         current = dir.parent();
@@ -271,20 +273,33 @@ fn resolve_configured_skills_dir(root: &Path, dir: &Path) -> PathBuf {
 
 /// Load config from workspace root, falling back to defaults.
 fn load_config(root: &Path) -> RalphConfig {
-    // Try standard config file names
-    let candidates = ["ralph.yml", "ralph.yaml"];
-    let mut config = None;
-    for candidate in &candidates {
-        let path = root.join(candidate);
-        if path.exists()
-            && let Ok(loaded) = RalphConfig::from_file(&path)
-        {
-            config = Some(loaded);
-            break;
+    let mut merged = match config_resolution::default_core_value() {
+        Ok(value) => value,
+        Err(_) => return RalphConfig::default(),
+    };
+
+    if let Ok(Some((user_value, _))) = config_resolution::load_optional_user_config_value() {
+        if let Ok(next) = config_resolution::merge_yaml_values(merged, user_value) {
+            merged = next;
+        } else {
+            return RalphConfig::default();
         }
     }
 
-    let mut config = config.unwrap_or_default();
+    if let Some(path) = config_resolution::find_workspace_config_path(root)
+        && let Ok(content) = std::fs::read_to_string(&path)
+        && let Ok(value) =
+            config_resolution::parse_yaml_value(&content, &path.display().to_string())
+    {
+        if let Ok(next) = config_resolution::merge_yaml_values(merged, value) {
+            merged = next;
+        } else {
+            return RalphConfig::default();
+        }
+    }
+
+    let mut config: RalphConfig = serde_yaml::from_value(merged).unwrap_or_default();
+
     config.normalize();
 
     if config.skills.dirs.is_empty() {

--- a/crates/ralph-cli/tests/integration_hooks_validate.rs
+++ b/crates/ralph-cli/tests/integration_hooks_validate.rs
@@ -16,6 +16,18 @@ fn ralph_hooks_validate(temp_path: &Path, args: &[&str]) -> Output {
         .expect("Failed to execute ralph hooks validate command")
 }
 
+fn ralph_hooks_validate_with_home(temp_path: &Path, home_path: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ralph"))
+        .args(["--color", "never"])
+        .args(args)
+        .current_dir(temp_path)
+        .env("HOME", home_path)
+        .env("USERPROFILE", home_path)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to execute ralph hooks validate command")
+}
+
 fn parse_json_report(output: &Output) -> Value {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let json_start = stdout.find('{').expect("no json start");
@@ -236,5 +248,56 @@ hooks:
     assert!(
         message.contains("Failed to parse merged core config"),
         "expected merged-config parse failure diagnostic, got: {message}"
+    );
+}
+
+#[test]
+fn test_hooks_validate_uses_user_scoped_hooks_when_local_config_missing() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let home_dir = TempDir::new().expect("temp home");
+    let temp_path = temp_dir.path();
+    let hook_path = temp_path.join("hook-ok.sh");
+    fs::write(&hook_path, "#!/bin/sh\nexit 0\n").expect("write hook script");
+    make_executable(&hook_path);
+
+    let user_config_dir = home_dir.path().join(".ralph");
+    fs::create_dir_all(&user_config_dir).expect("create user config dir");
+    fs::write(
+        user_config_dir.join("config.yml"),
+        r#"
+hooks:
+  enabled: true
+  events:
+    pre.loop.start:
+      - name: user-hook
+        command: ["./hook-ok.sh"]
+        on_error: warn
+"#,
+    )
+    .expect("write user config");
+
+    let output = ralph_hooks_validate_with_home(
+        temp_path,
+        home_dir.path(),
+        &["hooks", "validate", "--format", "json"],
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "expected exit code 0; stderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let report = parse_json_report(&output);
+    assert_report_shape(&report);
+    assert_eq!(report["pass"], true);
+    assert_eq!(report["hooks_enabled"], true);
+    assert_eq!(report["checked_hooks"], 1);
+    let source = report["source"].as_str().expect("source should be string");
+    assert!(
+        source.contains(".ralph/config.yml"),
+        "expected global config source, got: {source}"
     );
 }

--- a/crates/ralph-cli/tests/integration_run.rs
+++ b/crates/ralph-cli/tests/integration_run.rs
@@ -9,6 +9,20 @@ fn run_ralph(temp_path: &std::path::Path, args: &[&str]) -> std::process::Output
         .expect("execute ralph")
 }
 
+fn run_ralph_with_home(
+    temp_path: &std::path::Path,
+    home_path: &std::path::Path,
+    args: &[&str],
+) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_ralph"))
+        .args(args)
+        .current_dir(temp_path)
+        .env("HOME", home_path)
+        .env("USERPROFILE", home_path)
+        .output()
+        .expect("execute ralph")
+}
+
 #[test]
 fn test_run_dry_run_succeeds() {
     let temp_dir = TempDir::new().expect("temp dir");
@@ -39,6 +53,294 @@ fn test_run_dry_run_succeeds() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Dry run mode"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_run_dry_run_uses_user_scoped_config_defaults() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let home_dir = TempDir::new().expect("temp home");
+    let temp_path = temp_dir.path();
+    let user_config_dir = home_dir.path().join(".ralph");
+    std::fs::create_dir_all(&user_config_dir).expect("create user config dir");
+    std::fs::write(
+        user_config_dir.join("config.yml"),
+        r"
+cli:
+  backend: claude
+event_loop:
+  max_iterations: 7
+",
+    )
+    .expect("write user config");
+
+    let output = run_ralph_with_home(
+        temp_path,
+        home_dir.path(),
+        &[
+            "run",
+            "--dry-run",
+            "--skip-preflight",
+            "--prompt",
+            "hello world",
+            "--no-tui",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Backend: claude"), "stdout: {stdout}");
+    assert!(stdout.contains("Max iterations: 7"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_run_dry_run_local_config_overrides_user_scoped_defaults() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let home_dir = TempDir::new().expect("temp home");
+    let temp_path = temp_dir.path();
+    let user_config_dir = home_dir.path().join(".ralph");
+    std::fs::create_dir_all(&user_config_dir).expect("create user config dir");
+    std::fs::write(
+        user_config_dir.join("config.yml"),
+        r"
+cli:
+  backend: claude
+event_loop:
+  max_iterations: 7
+",
+    )
+    .expect("write user config");
+    std::fs::write(
+        temp_path.join("ralph.yml"),
+        r"
+cli:
+  backend: gemini
+event_loop:
+  max_iterations: 3
+",
+    )
+    .expect("write local config");
+
+    let output = run_ralph_with_home(
+        temp_path,
+        home_dir.path(),
+        &[
+            "run",
+            "--dry-run",
+            "--skip-preflight",
+            "--prompt",
+            "hello world",
+            "--no-tui",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Backend: gemini"), "stdout: {stdout}");
+    assert!(stdout.contains("Max iterations: 3"), "stdout: {stdout}");
+}
+
+#[test]
+fn test_run_smoke_executes_user_scoped_hook_during_real_loop() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let home_dir = TempDir::new().expect("temp home");
+    let temp_path = temp_dir.path();
+    let user_config_dir = home_dir.path().join(".ralph");
+    std::fs::create_dir_all(&user_config_dir).expect("create user config dir");
+
+    let hook_marker = temp_path.join("global-hook-ran.txt");
+    let hook_script = temp_path.join("global-hook.sh");
+    let backend_script = temp_path.join("backend-complete.sh");
+
+    std::fs::write(
+        &hook_script,
+        format!(
+            "#!/bin/sh\nprintf 'hook ran' > \"{}\"\n",
+            hook_marker.display()
+        ),
+    )
+    .expect("write hook script");
+    std::fs::write(
+        &backend_script,
+        format!(
+            "#!/bin/sh\ncat >/dev/null\n\"{}\" emit LOOP_COMPLETE smoke-done\n",
+            env!("CARGO_BIN_EXE_ralph")
+        ),
+    )
+    .expect("write backend script");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        for path in [&hook_script, &backend_script] {
+            let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(path, permissions).expect("set executable permissions");
+        }
+    }
+
+    std::fs::write(
+        user_config_dir.join("config.yml"),
+        r#"
+hooks:
+  enabled: true
+  events:
+    pre.loop.start:
+      - name: global-hook
+        command: ["./global-hook.sh"]
+        on_error: warn
+"#,
+    )
+    .expect("write user config");
+
+    std::fs::write(
+        temp_path.join("ralph.yml"),
+        r#"
+cli:
+  backend: custom
+  command: "./backend-complete.sh"
+  prompt_mode: stdin
+event_loop:
+  max_iterations: 3
+  max_runtime_seconds: 10
+"#,
+    )
+    .expect("write local config");
+
+    let output = run_ralph_with_home(
+        temp_path,
+        home_dir.path(),
+        &["run", "--no-tui", "--prompt", "smoke test"],
+    );
+
+    assert!(
+        output.status.success(),
+        "run failed: {}\nstdout:{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        hook_marker.exists(),
+        "expected global hook marker at {}",
+        hook_marker.display()
+    );
+}
+
+#[test]
+fn test_run_smoke_local_hook_overrides_user_scoped_hook_during_real_loop() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let home_dir = TempDir::new().expect("temp home");
+    let temp_path = temp_dir.path();
+    let user_config_dir = home_dir.path().join(".ralph");
+    std::fs::create_dir_all(&user_config_dir).expect("create user config dir");
+
+    let global_marker = temp_path.join("global-hook-ran.txt");
+    let local_marker = temp_path.join("local-hook-ran.txt");
+    let global_hook_script = temp_path.join("global-hook.sh");
+    let local_hook_script = temp_path.join("local-hook.sh");
+    let backend_script = temp_path.join("backend-complete.sh");
+
+    std::fs::write(
+        &global_hook_script,
+        format!(
+            "#!/bin/sh\nprintf 'global hook ran' > \"{}\"\n",
+            global_marker.display()
+        ),
+    )
+    .expect("write global hook script");
+    std::fs::write(
+        &local_hook_script,
+        format!(
+            "#!/bin/sh\nprintf 'local hook ran' > \"{}\"\n",
+            local_marker.display()
+        ),
+    )
+    .expect("write local hook script");
+    std::fs::write(
+        &backend_script,
+        format!(
+            "#!/bin/sh\ncat >/dev/null\n\"{}\" emit LOOP_COMPLETE smoke-done\n",
+            env!("CARGO_BIN_EXE_ralph")
+        ),
+    )
+    .expect("write backend script");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        for path in [&global_hook_script, &local_hook_script, &backend_script] {
+            let mut permissions = std::fs::metadata(path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(path, permissions).expect("set executable permissions");
+        }
+    }
+
+    std::fs::write(
+        user_config_dir.join("config.yml"),
+        r#"
+hooks:
+  enabled: true
+  events:
+    pre.loop.start:
+      - name: global-hook
+        command: ["./global-hook.sh"]
+        on_error: warn
+"#,
+    )
+    .expect("write user config");
+
+    std::fs::write(
+        temp_path.join("ralph.yml"),
+        r#"
+cli:
+  backend: custom
+  command: "./backend-complete.sh"
+  prompt_mode: stdin
+hooks:
+  enabled: true
+  events:
+    pre.loop.start:
+      - name: local-hook
+        command: ["./local-hook.sh"]
+        on_error: warn
+event_loop:
+  max_iterations: 3
+  max_runtime_seconds: 10
+"#,
+    )
+    .expect("write local config");
+
+    let output = run_ralph_with_home(
+        temp_path,
+        home_dir.path(),
+        &["run", "--no-tui", "--prompt", "smoke override test"],
+    );
+
+    assert!(
+        output.status.success(),
+        "run failed: {}\nstdout:{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        local_marker.exists(),
+        "expected local hook marker at {}",
+        local_marker.display()
+    );
+    assert!(
+        !global_marker.exists(),
+        "did not expect global hook marker at {}",
+        global_marker.display()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a shared config resolution layer that loads `~/.ralph/config.yml` beneath repo-local config
- apply the merged config path across CLI load, preflight, and skill config discovery
- add integration coverage for inherited global hooks and repo-local override behavior in real loop runs

## Testing
- cargo test
