### PR TITLE
[codex] add ralph mcp server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,6 +2766,7 @@ dependencies = [
  "jsonschema",
  "ralph-core",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2802,6 +2809,7 @@ dependencies = [
  "nix 0.29.0",
  "open",
  "ralph-adapters",
+ "ralph-api",
  "ralph-core",
  "ralph-proto",
  "ralph-telegram",
@@ -3232,6 +3240,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cb14cb9278a12eae884c9f3c0cfeca2cc28f361211206424a1d7abed95f090"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3394,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ crossterm = { version = "0.28", features = ["event-stream"] }
 # Async stream utilities
 futures = "0.3"
 tokio-util = { version = "0.7", features = ["compat"] }
+rmcp = { version = "1.1.0", default-features = false, features = ["server", "client", "transport-io"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/ralph-api/Cargo.toml
+++ b/crates/ralph-api/Cargo.toml
@@ -15,7 +15,7 @@ anyhow.workspace = true
 axum = { version = "0.8", features = ["ws", "macros", "json"] }
 chrono.workspace = true
 futures.workspace = true
-jsonschema = "0.18"
+jsonschema = { version = "0.18", features = ["draft202012"] }
 ralph-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -25,6 +25,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid = { version = "1.21.0", features = ["v4"] }
+rmcp.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true

--- a/crates/ralph-api/src/errors.rs
+++ b/crates/ralph-api/src/errors.rs
@@ -49,6 +49,31 @@ impl RpcErrorCode {
             Self::BackpressureDropped => "BACKPRESSURE_DROPPED",
         }
     }
+
+    pub fn from_contract(value: &str) -> Option<Self> {
+        match value {
+            "INVALID_REQUEST" => Some(Self::InvalidRequest),
+            "METHOD_NOT_FOUND" => Some(Self::MethodNotFound),
+            "INVALID_PARAMS" => Some(Self::InvalidParams),
+            "UNAUTHORIZED" => Some(Self::Unauthorized),
+            "FORBIDDEN" => Some(Self::Forbidden),
+            "NOT_FOUND" => Some(Self::NotFound),
+            "CONFLICT" => Some(Self::Conflict),
+            "PRECONDITION_FAILED" => Some(Self::PreconditionFailed),
+            "RATE_LIMITED" => Some(Self::RateLimited),
+            "TIMEOUT" => Some(Self::Timeout),
+            "SERVICE_UNAVAILABLE" => Some(Self::ServiceUnavailable),
+            "INTERNAL" => Some(Self::Internal),
+            "TASK_NOT_FOUND" => Some(Self::TaskNotFound),
+            "LOOP_NOT_FOUND" => Some(Self::LoopNotFound),
+            "PLANNING_SESSION_NOT_FOUND" => Some(Self::PlanningSessionNotFound),
+            "COLLECTION_NOT_FOUND" => Some(Self::CollectionNotFound),
+            "CONFIG_INVALID" => Some(Self::ConfigInvalid),
+            "IDEMPOTENCY_CONFLICT" => Some(Self::IdempotencyConflict),
+            "BACKPRESSURE_DROPPED" => Some(Self::BackpressureDropped),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/ralph-api/src/lib.rs
+++ b/crates/ralph-api/src/lib.rs
@@ -7,6 +7,7 @@ pub mod idempotency;
 pub mod loop_domain;
 pub mod loop_side_effects;
 pub mod loop_support;
+pub mod mcp;
 pub mod planning_domain;
 pub mod preset_domain;
 pub mod protocol;
@@ -16,5 +17,6 @@ pub mod task_domain;
 pub mod transport;
 
 pub use config::{ApiConfig, AuthMode};
+pub use mcp::serve_stdio;
 pub use runtime::RpcRuntime;
 pub use transport::{router, serve, serve_with_listener};

--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -1,0 +1,850 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use jsonschema::{Draft, JSONSchema};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ErrorCode, ErrorData, Implementation, InitializeResult,
+    ListToolsResult, PaginatedRequestParams, ServerCapabilities, Tool, ToolAnnotations,
+};
+use rmcp::service::{RequestContext, RoleServer};
+use rmcp::{ServerHandler, ServiceExt};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use tokio::sync::{Mutex as AsyncMutex, broadcast};
+
+use crate::config::ApiConfig;
+use crate::errors::ApiError;
+use crate::protocol::{KNOWN_METHODS, MUTATING_METHODS};
+use crate::runtime::RpcRuntime;
+use crate::stream_domain::StreamEventEnvelope;
+
+const MCP_PRINCIPAL: &str = "trusted_local";
+const TOOL_PAGE_SIZE: usize = 128;
+const DEFAULT_STREAM_NEXT_WAIT_MS: u64 = 30_000;
+const MAX_STREAM_NEXT_WAIT_MS: u64 = 120_000;
+const DEFAULT_STREAM_NEXT_EVENTS: u16 = 50;
+const MAX_STREAM_NEXT_EVENTS: u16 = 200;
+
+#[derive(Clone)]
+pub struct RalphMcpServer {
+    runtime: RpcRuntime,
+    catalog: Arc<ToolCatalog>,
+    subscriptions: Arc<AsyncMutex<HashMap<String, Arc<AsyncMutex<McpSubscriptionState>>>>>,
+}
+
+impl RalphMcpServer {
+    pub fn new(config: ApiConfig) -> Result<Self> {
+        let runtime = RpcRuntime::new(config)?;
+        let catalog = Arc::new(tool_catalog().clone());
+        Ok(Self {
+            runtime,
+            catalog,
+            subscriptions: Arc::new(AsyncMutex::new(HashMap::new())),
+        })
+    }
+
+    fn invoke_rpc_tool(
+        &self,
+        method: &str,
+        arguments: Value,
+        request_id: &str,
+        tool_name: &str,
+    ) -> Result<Value, ApiError> {
+        let idempotency_key = MUTATING_METHODS
+            .contains(&method)
+            .then(|| format!("mcp:{tool_name}:{request_id}"));
+        self.runtime.invoke_method(
+            request_id.to_string(),
+            method,
+            arguments,
+            MCP_PRINCIPAL,
+            idempotency_key,
+        )
+    }
+
+    fn call_rpc_tool(
+        &self,
+        method: &str,
+        arguments: Value,
+        request_id: &str,
+        tool_name: &str,
+    ) -> Result<CallToolResult, ApiError> {
+        let result = self.invoke_rpc_tool(method, arguments, request_id, tool_name)?;
+        Ok(CallToolResult::structured(result))
+    }
+
+    async fn call_stream_subscribe(
+        &self,
+        arguments: Value,
+        request_id: &str,
+        tool_name: &str,
+    ) -> Result<CallToolResult, ApiError> {
+        let live_rx = self.runtime.stream_domain().live_receiver();
+        let result = self.invoke_rpc_tool("stream.subscribe", arguments, request_id, tool_name)?;
+        let subscription_id = subscription_id_from_result(&result)
+            .ok_or_else(|| ApiError::internal("stream.subscribe result missing subscriptionId"))
+            .map_err(|error| {
+                error.with_context(request_id.to_string(), Some("stream.subscribe".to_string()))
+            })?;
+        self.subscriptions.lock().await.insert(
+            subscription_id.to_string(),
+            Arc::new(AsyncMutex::new(McpSubscriptionState { live_rx })),
+        );
+        Ok(CallToolResult::structured(result))
+    }
+
+    async fn call_stream_unsubscribe(
+        &self,
+        arguments: Value,
+        request_id: &str,
+        tool_name: &str,
+    ) -> Result<CallToolResult, ApiError> {
+        let subscription_id = subscription_id_from_arguments(&arguments)
+            .ok_or_else(|| ApiError::internal("stream.unsubscribe args missing subscriptionId"))
+            .map_err(|error| {
+                error.with_context(
+                    request_id.to_string(),
+                    Some("stream.unsubscribe".to_string()),
+                )
+            })?
+            .to_string();
+        let result =
+            self.invoke_rpc_tool("stream.unsubscribe", arguments, request_id, tool_name)?;
+        self.subscriptions.lock().await.remove(&subscription_id);
+        Ok(CallToolResult::structured(result))
+    }
+
+    async fn call_stream_next(
+        &self,
+        arguments: Value,
+        request_id: &str,
+    ) -> Result<CallToolResult, ApiError> {
+        let params: StreamNextParams = serde_json::from_value(arguments).map_err(|error| {
+            ApiError::invalid_params(format!("invalid params for method 'stream.next': {error}"))
+                .with_context(request_id.to_string(), Some("stream.next".to_string()))
+        })?;
+        let wait_ms = params
+            .wait_ms
+            .unwrap_or(DEFAULT_STREAM_NEXT_WAIT_MS)
+            .clamp(1, MAX_STREAM_NEXT_WAIT_MS);
+        let max_events = params
+            .max_events
+            .unwrap_or(DEFAULT_STREAM_NEXT_EVENTS)
+            .clamp(1, MAX_STREAM_NEXT_EVENTS) as usize;
+
+        let streams = self.runtime.stream_domain();
+        if !streams.has_subscription(&params.subscription_id) {
+            return Err(ApiError::not_found(format!(
+                "subscription '{}' not found",
+                params.subscription_id
+            ))
+            .with_context(request_id.to_string(), Some("stream.next".to_string()))
+            .with_details(json!({ "subscriptionId": params.subscription_id })));
+        }
+
+        let subscription = self.lookup_subscription(&params.subscription_id).await?;
+        let replay = streams
+            .replay_for_subscription(&params.subscription_id)
+            .map_err(|error| {
+                error.with_context(request_id.to_string(), Some("stream.next".to_string()))
+            })?;
+
+        let mut events = replay.events;
+        let mut dropped_count = replay.dropped_count;
+        if !events.is_empty() || dropped_count > 0 {
+            events.truncate(max_events);
+            return Ok(stream_next_result(events, false, dropped_count));
+        }
+
+        let mut live_state = subscription.lock().await;
+        let current_cursor = streams
+            .subscription_cursor(&params.subscription_id)
+            .map_err(|error| {
+                error.with_context(request_id.to_string(), Some("stream.next".to_string()))
+            })?;
+        let current_cursor_sequence = streams
+            .subscription_cursor_sequence(&params.subscription_id)
+            .map_err(|error| {
+                error.with_context(request_id.to_string(), Some("stream.next".to_string()))
+            })?;
+
+        if let Some(result) = collect_live_events(
+            &streams,
+            &params.subscription_id,
+            &current_cursor,
+            current_cursor_sequence,
+            &mut live_state.live_rx,
+            max_events,
+            dropped_count,
+        ) {
+            return Ok(stream_next_result(
+                result.events,
+                false,
+                result.dropped_count,
+            ));
+        }
+
+        let timer = tokio::time::sleep(Duration::from_millis(wait_ms));
+        tokio::pin!(timer);
+
+        loop {
+            tokio::select! {
+                _ = &mut timer => {
+                    return Ok(stream_next_result(Vec::new(), true, dropped_count));
+                }
+                message = live_state.live_rx.recv() => {
+                    match message {
+                        Ok(event) => {
+                            if is_pending_live_event(
+                                &streams,
+                                &params.subscription_id,
+                                &current_cursor,
+                                current_cursor_sequence,
+                                &event,
+                            ) {
+                                events.push(event);
+                                let drained = collect_live_events(
+                                    &streams,
+                                    &params.subscription_id,
+                                    &current_cursor,
+                                    current_cursor_sequence,
+                                    &mut live_state.live_rx,
+                                    max_events - events.len(),
+                                    dropped_count,
+                                );
+                                if let Some(drained) = drained {
+                                    dropped_count = drained.dropped_count;
+                                    events.extend(drained.events);
+                                }
+                                return Ok(stream_next_result(events, false, dropped_count));
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            dropped_count = dropped_count.saturating_add(skipped as usize);
+                            return Ok(stream_next_result(Vec::new(), false, dropped_count));
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            return Err(ApiError::service_unavailable("stream receiver closed")
+                                .with_context(request_id.to_string(), Some("stream.next".to_string())));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn lookup_subscription(
+        &self,
+        subscription_id: &str,
+    ) -> Result<Arc<AsyncMutex<McpSubscriptionState>>, ApiError> {
+        self.subscriptions
+            .lock()
+            .await
+            .get(subscription_id)
+            .cloned()
+            .ok_or_else(|| {
+                ApiError::not_found(format!(
+                    "subscription '{}' is not managed by this MCP server",
+                    subscription_id
+                ))
+                .with_details(json!({ "subscriptionId": subscription_id }))
+            })
+    }
+}
+
+impl ServerHandler for RalphMcpServer {
+    fn get_info(&self) -> InitializeResult {
+        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(
+                Implementation::new("ralph-mcp", env!("CARGO_PKG_VERSION"))
+                    .with_title("Ralph MCP Server"),
+            )
+            .with_instructions(
+                "Use the Ralph control-plane tools to inspect and manage local orchestration state.",
+            )
+    }
+
+    fn list_tools(
+        &self,
+        request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ListToolsResult, ErrorData>> + Send + '_ {
+        std::future::ready(
+            self.catalog
+                .list_tools(request.as_ref().and_then(|value| value.cursor.as_deref())),
+        )
+    }
+
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        self.catalog.lookup(name).map(|entry| entry.tool.clone())
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<CallToolResult, ErrorData>> + Send + '_ {
+        async move {
+            let request_id = context.id.to_string();
+            let Some(entry) = self.catalog.lookup(request.name.as_ref()) else {
+                return Err(ErrorData::new(
+                    ErrorCode::METHOD_NOT_FOUND,
+                    format!("tool '{}' is not available", request.name),
+                    None,
+                ));
+            };
+
+            let arguments = Value::Object(request.arguments.unwrap_or_default());
+            if let Err(errors) = entry.validate_input(&arguments) {
+                let error = ApiError::invalid_params(format!(
+                    "tool '{}' arguments do not match the published schema",
+                    request.name
+                ))
+                .with_context(request_id.clone(), Some(entry.method_name().to_string()))
+                .with_details(json!({ "errors": errors }));
+                return Ok(tool_error_result(error));
+            }
+
+            let result = match &entry.target {
+                ToolTarget::Rpc { method } => match method.as_str() {
+                    "stream.subscribe" => {
+                        self.call_stream_subscribe(arguments, &request_id, entry.tool.name.as_ref())
+                            .await
+                    }
+                    "stream.unsubscribe" => {
+                        self.call_stream_unsubscribe(
+                            arguments,
+                            &request_id,
+                            entry.tool.name.as_ref(),
+                        )
+                        .await
+                    }
+                    _ => {
+                        self.call_rpc_tool(method, arguments, &request_id, entry.tool.name.as_ref())
+                    }
+                },
+                ToolTarget::StreamNext => self.call_stream_next(arguments, &request_id).await,
+            };
+
+            match result {
+                Ok(result) => Ok(result),
+                Err(error) => Ok(tool_error_result(error)),
+            }
+        }
+    }
+}
+
+pub async fn serve_stdio(config: ApiConfig) -> Result<()> {
+    let server = RalphMcpServer::new(config)?;
+    let running = server.serve(rmcp::transport::stdio()).await?;
+    let _ = running.waiting().await?;
+    Ok(())
+}
+
+#[derive(Clone)]
+struct ToolCatalog {
+    entries: Vec<ToolEntry>,
+    by_name: HashMap<String, usize>,
+}
+
+impl ToolCatalog {
+    fn load() -> Result<Self> {
+        let root_schema: Value = serde_json::from_str(include_str!("../data/rpc-v1-schema.json"))
+            .context("embedded rpc-v1 schema must be valid JSON")?;
+        let request_variants = schema_method_map(&root_schema, "requestByMethod", "params")?;
+        let response_variants = schema_method_map(&root_schema, "responseByMethod", "result")?;
+
+        let mut entries = Vec::new();
+        for method in KNOWN_METHODS {
+            let name = rpc_method_to_tool_name(method);
+            let input_ref = request_variants
+                .get(*method)
+                .with_context(|| format!("missing params schema for method '{method}'"))?;
+            let output_ref = response_variants
+                .get(*method)
+                .with_context(|| format!("missing result schema for method '{method}'"))?;
+
+            let input_schema = schema_ref_object(&root_schema, input_ref)?;
+            let output_schema = schema_ref_object(&root_schema, output_ref)?;
+            let tool = build_tool(name, method, &input_schema, Some(&output_schema));
+            let input_validator = compile_validator(&input_schema)?;
+
+            entries.push(ToolEntry {
+                tool,
+                target: ToolTarget::Rpc {
+                    method: (*method).to_string(),
+                },
+                input_validator,
+            });
+        }
+
+        let stream_next_input = stream_next_input_schema();
+        entries.push(ToolEntry {
+            tool: build_tool(
+                "stream_next".to_string(),
+                "stream.next",
+                &stream_next_input,
+                Some(&stream_next_output_schema()),
+            ),
+            target: ToolTarget::StreamNext,
+            input_validator: compile_validator(&stream_next_input)?,
+        });
+
+        entries.sort_by(|left, right| left.tool.name.cmp(&right.tool.name));
+        let by_name = entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| (entry.tool.name.to_string(), index))
+            .collect();
+
+        Ok(Self { entries, by_name })
+    }
+
+    fn lookup(&self, name: &str) -> Option<&ToolEntry> {
+        self.by_name
+            .get(name)
+            .and_then(|index| self.entries.get(*index))
+    }
+
+    fn list_tools(&self, cursor: Option<&str>) -> Result<ListToolsResult, ErrorData> {
+        let offset = cursor
+            .map(|value| {
+                value.parse::<usize>().map_err(|_| {
+                    ErrorData::invalid_params(format!("invalid tools/list cursor '{value}'"), None)
+                })
+            })
+            .transpose()?
+            .unwrap_or(0);
+
+        if offset > self.entries.len() {
+            return Err(ErrorData::invalid_params(
+                format!("tools/list cursor '{}' is out of range", offset),
+                None,
+            ));
+        }
+
+        let end = (offset + TOOL_PAGE_SIZE).min(self.entries.len());
+        let mut result = ListToolsResult::with_all_items(
+            self.entries[offset..end]
+                .iter()
+                .map(|entry| entry.tool.clone())
+                .collect(),
+        );
+        if end < self.entries.len() {
+            result.next_cursor = Some(end.to_string());
+        }
+        Ok(result)
+    }
+}
+
+#[derive(Clone)]
+struct ToolEntry {
+    tool: Tool,
+    target: ToolTarget,
+    input_validator: Arc<JSONSchema>,
+}
+
+impl ToolEntry {
+    fn method_name(&self) -> &str {
+        match &self.target {
+            ToolTarget::Rpc { method } => method,
+            ToolTarget::StreamNext => "stream.next",
+        }
+    }
+
+    fn validate_input(&self, arguments: &Value) -> Result<(), Vec<String>> {
+        match self.input_validator.validate(arguments) {
+            Ok(()) => Ok(()),
+            Err(errors) => Err(errors.map(|error| error.to_string()).collect()),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum ToolTarget {
+    Rpc { method: String },
+    StreamNext,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamNextParams {
+    subscription_id: String,
+    wait_ms: Option<u64>,
+    max_events: Option<u16>,
+}
+
+struct McpSubscriptionState {
+    live_rx: broadcast::Receiver<StreamEventEnvelope>,
+}
+
+struct LiveEventBatch {
+    events: Vec<StreamEventEnvelope>,
+    dropped_count: usize,
+}
+
+fn subscription_id_from_result(result: &Value) -> Option<&str> {
+    result.get("subscriptionId").and_then(Value::as_str)
+}
+
+fn subscription_id_from_arguments(arguments: &Value) -> Option<&str> {
+    arguments.get("subscriptionId").and_then(Value::as_str)
+}
+
+fn is_pending_live_event(
+    streams: &crate::stream_domain::StreamDomain,
+    subscription_id: &str,
+    current_cursor: &str,
+    cursor_sequence: u64,
+    event: &StreamEventEnvelope,
+) -> bool {
+    streams.matches_subscription(subscription_id, event)
+        && (event.sequence > cursor_sequence
+            || (event.sequence == cursor_sequence && event.cursor != current_cursor))
+}
+
+fn collect_live_events(
+    streams: &crate::stream_domain::StreamDomain,
+    subscription_id: &str,
+    current_cursor: &str,
+    cursor_sequence: u64,
+    live_rx: &mut broadcast::Receiver<StreamEventEnvelope>,
+    max_events: usize,
+    dropped_count: usize,
+) -> Option<LiveEventBatch> {
+    if max_events == 0 {
+        return Some(LiveEventBatch {
+            events: Vec::new(),
+            dropped_count,
+        });
+    }
+
+    let mut events = Vec::new();
+    let mut dropped_count = dropped_count;
+    loop {
+        match live_rx.try_recv() {
+            Ok(event) => {
+                if is_pending_live_event(
+                    streams,
+                    subscription_id,
+                    current_cursor,
+                    cursor_sequence,
+                    &event,
+                ) {
+                    events.push(event);
+                    if events.len() >= max_events {
+                        break;
+                    }
+                }
+            }
+            Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                dropped_count = dropped_count.saturating_add(skipped as usize);
+                break;
+            }
+            Err(broadcast::error::TryRecvError::Empty)
+            | Err(broadcast::error::TryRecvError::Closed) => break,
+        }
+    }
+
+    (!events.is_empty() || dropped_count > 0).then_some(LiveEventBatch {
+        events,
+        dropped_count,
+    })
+}
+
+fn tool_catalog() -> &'static ToolCatalog {
+    static CATALOG: OnceLock<ToolCatalog> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        ToolCatalog::load().expect("embedded rpc-v1 schema must be convertible into an MCP catalog")
+    })
+}
+
+fn rpc_method_to_tool_name(method: &str) -> String {
+    method.replace('.', "_")
+}
+
+fn build_tool(
+    name: String,
+    method: &str,
+    input_schema: &Map<String, Value>,
+    output_schema: Option<&Map<String, Value>>,
+) -> Tool {
+    let description: Cow<'static, str> = match method {
+        "system.health" => "Return the Ralph control-plane health snapshot.".into(),
+        "system.version" => "Return the Ralph control-plane API and server version.".into(),
+        "system.capabilities" => {
+            "List supported Ralph control-plane methods and stream topics.".into()
+        }
+        "task.list" => "List Ralph tasks, with optional filters.".into(),
+        "task.ready" => "List open tasks that are ready to run.".into(),
+        "task.run_all" => "Enqueue every open or queued Ralph task.".into(),
+        "loop.status" => "Return the current primary loop and merge status.".into(),
+        "loop.trigger_merge_task" => "Create a merge task for a completed loop.".into(),
+        "planning.get_artifact" => "Read a generated planning artifact by filename.".into(),
+        "config.get" => "Read the current Ralph YAML configuration.".into(),
+        "config.update" => "Replace the Ralph YAML configuration after validation.".into(),
+        "preset.list" => "List all available Ralph presets.".into(),
+        "collection.import" => "Import a preset collection from YAML.".into(),
+        "collection.export" => "Export a preset collection to YAML.".into(),
+        "stream.subscribe" => "Create a Ralph event stream subscription.".into(),
+        "stream.unsubscribe" => "Close a Ralph event stream subscription.".into(),
+        "stream.ack" => "Advance a Ralph event stream subscription cursor.".into(),
+        "stream.next" => "Poll for the next batch of Ralph stream events.".into(),
+        _ => format!("Invoke Ralph control-plane method `{method}`.").into(),
+    };
+
+    let mut tool = Tool::new_with_raw(name, Some(description), Arc::new(input_schema.clone()));
+    tool.title = Some(method.to_string());
+    tool.output_schema = output_schema.cloned().map(Arc::new);
+    tool.annotations = Some(
+        ToolAnnotations::with_title(method)
+            .read_only(!MUTATING_METHODS.contains(&method))
+            .destructive(MUTATING_METHODS.contains(&method))
+            .open_world(false),
+    );
+    tool
+}
+
+fn schema_method_map(
+    root_schema: &Value,
+    def_name: &str,
+    property_name: &str,
+) -> Result<HashMap<String, String>> {
+    let variants = root_schema
+        .pointer(&format!("/$defs/{def_name}/oneOf"))
+        .and_then(Value::as_array)
+        .with_context(|| format!("schema def '{def_name}' must expose a oneOf array"))?;
+
+    let mut map = HashMap::new();
+    for variant in variants {
+        let method = variant
+            .pointer("/properties/method/const")
+            .and_then(Value::as_str)
+            .context("schema variant is missing properties.method.const")?;
+        let schema_ref = variant
+            .pointer(&format!("/properties/{property_name}/$ref"))
+            .and_then(Value::as_str)
+            .with_context(|| {
+                format!("schema variant '{method}' is missing {property_name}.$ref")
+            })?;
+        map.insert(method.to_string(), schema_ref.to_string());
+    }
+
+    Ok(map)
+}
+
+fn schema_ref_object(root_schema: &Value, schema_ref: &str) -> Result<Map<String, Value>> {
+    let defs = root_schema
+        .get("$defs")
+        .cloned()
+        .context("schema must expose $defs")?;
+    let schema = json!({
+        "$schema": root_schema
+            .get("$schema")
+            .cloned()
+            .unwrap_or_else(|| json!("https://json-schema.org/draft/2020-12/schema")),
+        "$defs": defs,
+        "$ref": schema_ref,
+    });
+    schema
+        .as_object()
+        .cloned()
+        .context("generated schema object must be a JSON object")
+}
+
+fn compile_validator(schema: &Map<String, Value>) -> Result<Arc<JSONSchema>> {
+    let schema_value = Value::Object(schema.clone());
+    let validator = JSONSchema::options()
+        .with_draft(Draft::Draft202012)
+        .compile(&schema_value)
+        .map_err(|error| anyhow!("tool schema must compile: {error}"))?;
+    Ok(Arc::new(validator))
+}
+
+fn stream_next_input_schema() -> Map<String, Value> {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "subscriptionId": {
+                "type": "string",
+                "minLength": 1
+            },
+            "waitMs": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_STREAM_NEXT_WAIT_MS
+            },
+            "maxEvents": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_STREAM_NEXT_EVENTS
+            }
+        },
+        "required": ["subscriptionId"]
+    })
+    .as_object()
+    .cloned()
+    .expect("stream.next input schema must be an object")
+}
+
+fn stream_next_output_schema() -> Map<String, Value> {
+    let event_schema: Value = serde_json::from_str(include_str!("../data/rpc-v1-events.json"))
+        .expect("embedded rpc-v1 event schema must be valid JSON");
+    let defs = event_schema
+        .get("$defs")
+        .cloned()
+        .expect("embedded rpc-v1 event schema must expose $defs");
+
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": defs,
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "events": {
+                "type": "array",
+                "items": { "$ref": "#/$defs/eventEnvelope" }
+            },
+            "timedOut": { "type": "boolean" },
+            "droppedCount": { "type": "integer", "minimum": 0 }
+        },
+        "required": ["events", "timedOut", "droppedCount"]
+    })
+    .as_object()
+    .cloned()
+    .expect("stream.next output schema must be an object")
+}
+
+fn stream_next_result(
+    events: Vec<StreamEventEnvelope>,
+    timed_out: bool,
+    dropped_count: usize,
+) -> CallToolResult {
+    CallToolResult::structured(json!({
+        "events": events,
+        "timedOut": timed_out,
+        "droppedCount": dropped_count,
+    }))
+}
+
+fn tool_error_result(error: ApiError) -> CallToolResult {
+    CallToolResult::structured_error(json!({
+        "code": error.code.as_str(),
+        "message": error.message,
+        "details": error.details,
+        "requestId": error.request_id,
+        "method": error.method,
+        "retryable": error.retryable,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn test_server() -> (RalphMcpServer, TempDir) {
+        let workspace = tempfile::tempdir().expect("workspace tempdir should be created");
+        let config = ApiConfig {
+            workspace_root: workspace.path().to_path_buf(),
+            ..ApiConfig::default()
+        };
+        (
+            RalphMcpServer::new(config).expect("MCP server should initialize"),
+            workspace,
+        )
+    }
+
+    #[test]
+    fn catalog_maps_known_tools() {
+        let catalog = tool_catalog();
+        assert!(catalog.lookup("task_list").is_some());
+        assert!(catalog.lookup("loop_trigger_merge_task").is_some());
+        assert!(catalog.lookup("stream_next").is_some());
+    }
+
+    #[test]
+    fn catalog_publishes_output_schemas() {
+        let catalog = tool_catalog();
+        let task_create = catalog.lookup("task_create").expect("task_create tool");
+        assert!(task_create.tool.output_schema.is_some());
+        let stream_next = catalog.lookup("stream_next").expect("stream_next tool");
+        assert!(stream_next.tool.output_schema.is_some());
+    }
+
+    #[tokio::test]
+    async fn stream_next_times_out_without_events() {
+        let (server, _workspace) = test_server();
+        let subscribed = server
+            .call_stream_subscribe(
+                json!({ "topics": ["task.status.changed"] }),
+                "req-stream-subscribe-1",
+                "stream_subscribe",
+            )
+            .await
+            .expect("stream.subscribe should succeed");
+        let subscription_id = subscribed.structured_content.unwrap()["subscriptionId"]
+            .as_str()
+            .expect("subscription id")
+            .to_string();
+        let result = server
+            .call_stream_next(
+                json!({
+                    "subscriptionId": subscription_id,
+                    "waitMs": 1,
+                }),
+                "req-stream-next-timeout-1",
+            )
+            .await
+            .expect("stream.next should succeed");
+
+        assert_eq!(result.structured_content.unwrap()["timedOut"], true);
+    }
+
+    #[tokio::test]
+    async fn stream_next_returns_matching_events() {
+        let (server, _workspace) = test_server();
+        let subscribed = server
+            .call_stream_subscribe(
+                json!({ "topics": ["task.status.changed"] }),
+                "req-stream-subscribe-2",
+                "stream_subscribe",
+            )
+            .await
+            .expect("stream.subscribe should succeed");
+        let subscription_id = subscribed.structured_content.unwrap()["subscriptionId"]
+            .as_str()
+            .expect("subscription id")
+            .to_string();
+
+        server.runtime.stream_domain().publish(
+            "task.status.changed",
+            "task",
+            "task-123",
+            json!({ "from": "open", "to": "running" }),
+        );
+
+        let result = server
+            .call_stream_next(
+                json!({
+                    "subscriptionId": subscription_id,
+                    "waitMs": 25,
+                    "maxEvents": 5,
+                }),
+                "req-stream-next-events-1",
+            )
+            .await
+            .expect("stream.next should succeed");
+
+        let payload = result.structured_content.expect("stream.next payload");
+        assert_eq!(payload["timedOut"], false);
+        assert_eq!(payload["events"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["events"][0]["topic"], "task.status.changed");
+    }
+}

--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -536,10 +536,9 @@ fn collect_live_events(
                 dropped_count = dropped_count.saturating_add(skipped as usize);
                 break;
             }
-            Err(
-                broadcast::error::TryRecvError::Empty
-                | broadcast::error::TryRecvError::Closed,
-            ) => break,
+            Err(broadcast::error::TryRecvError::Empty | broadcast::error::TryRecvError::Closed) => {
+                break;
+            }
         }
     }
 

--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -282,57 +282,49 @@ impl ServerHandler for RalphMcpServer {
         self.catalog.lookup(name).map(|entry| entry.tool.clone())
     }
 
-    fn call_tool(
+    async fn call_tool(
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<CallToolResult, ErrorData>> + Send + '_ {
-        async move {
-            let request_id = context.id.to_string();
-            let Some(entry) = self.catalog.lookup(request.name.as_ref()) else {
-                return Err(ErrorData::new(
-                    ErrorCode::METHOD_NOT_FOUND,
-                    format!("tool '{}' is not available", request.name),
-                    None,
-                ));
-            };
+    ) -> Result<CallToolResult, ErrorData> {
+        let request_id = context.id.to_string();
+        let Some(entry) = self.catalog.lookup(request.name.as_ref()) else {
+            return Err(ErrorData::new(
+                ErrorCode::METHOD_NOT_FOUND,
+                format!("tool '{}' is not available", request.name),
+                None,
+            ));
+        };
 
-            let arguments = Value::Object(request.arguments.unwrap_or_default());
-            if let Err(errors) = entry.validate_input(&arguments) {
-                let error = ApiError::invalid_params(format!(
-                    "tool '{}' arguments do not match the published schema",
-                    request.name
-                ))
-                .with_context(request_id.clone(), Some(entry.method_name().to_string()))
-                .with_details(json!({ "errors": errors }));
-                return Ok(tool_error_result(error));
-            }
+        let arguments = Value::Object(request.arguments.unwrap_or_default());
+        if let Err(errors) = entry.validate_input(&arguments) {
+            let error = ApiError::invalid_params(format!(
+                "tool '{}' arguments do not match the published schema",
+                request.name
+            ))
+            .with_context(request_id.clone(), Some(entry.method_name().to_string()))
+            .with_details(json!({ "errors": errors }));
+            return Ok(tool_error_result(error));
+        }
 
-            let result = match &entry.target {
-                ToolTarget::Rpc { method } => match method.as_str() {
-                    "stream.subscribe" => {
-                        self.call_stream_subscribe(arguments, &request_id, entry.tool.name.as_ref())
-                            .await
-                    }
-                    "stream.unsubscribe" => {
-                        self.call_stream_unsubscribe(
-                            arguments,
-                            &request_id,
-                            entry.tool.name.as_ref(),
-                        )
+        let result = match &entry.target {
+            ToolTarget::Rpc { method } => match method.as_str() {
+                "stream.subscribe" => {
+                    self.call_stream_subscribe(arguments, &request_id, entry.tool.name.as_ref())
                         .await
-                    }
-                    _ => {
-                        self.call_rpc_tool(method, arguments, &request_id, entry.tool.name.as_ref())
-                    }
-                },
-                ToolTarget::StreamNext => self.call_stream_next(arguments, &request_id).await,
-            };
+                }
+                "stream.unsubscribe" => {
+                    self.call_stream_unsubscribe(arguments, &request_id, entry.tool.name.as_ref())
+                        .await
+                }
+                _ => self.call_rpc_tool(method, arguments, &request_id, entry.tool.name.as_ref()),
+            },
+            ToolTarget::StreamNext => self.call_stream_next(arguments, &request_id).await,
+        };
 
-            match result {
-                Ok(result) => Ok(result),
-                Err(error) => Ok(tool_error_result(error)),
-            }
+        match result {
+            Ok(result) => Ok(result),
+            Err(error) => Ok(tool_error_result(error)),
         }
     }
 }
@@ -544,8 +536,10 @@ fn collect_live_events(
                 dropped_count = dropped_count.saturating_add(skipped as usize);
                 break;
             }
-            Err(broadcast::error::TryRecvError::Empty)
-            | Err(broadcast::error::TryRecvError::Closed) => break,
+            Err(
+                broadcast::error::TryRecvError::Empty
+                | broadcast::error::TryRecvError::Closed,
+            ) => break,
         }
     }
 

--- a/crates/ralph-api/src/runtime.rs
+++ b/crates/ralph-api/src/runtime.rs
@@ -13,7 +13,7 @@ use crate::auth::{Authenticator, from_config};
 use crate::collection_domain::CollectionDomain;
 use crate::config::ApiConfig;
 use crate::config_domain::ConfigDomain;
-use crate::errors::ApiError;
+use crate::errors::{ApiError, RpcErrorCode};
 use crate::idempotency::{
     IdempotencyCheck, IdempotencyStore, InMemoryIdempotencyStore, StoredResponse,
 };
@@ -113,6 +113,32 @@ impl RpcRuntime {
         })
     }
 
+    pub fn invoke_method(
+        &self,
+        request_id: impl Into<String>,
+        method: &str,
+        params: Value,
+        principal: &str,
+        idempotency_key: Option<String>,
+    ) -> Result<Value, ApiError> {
+        let request_id = request_id.into();
+        let mut raw = json!({
+            "apiVersion": API_VERSION,
+            "id": request_id,
+            "method": method,
+            "params": params,
+        });
+
+        if let Some(idempotency_key) = idempotency_key {
+            raw["meta"] = json!({
+                "idempotencyKey": idempotency_key,
+            });
+        }
+
+        let request = self.parse_and_validate_request_value(raw)?;
+        self.execute_request(&request, principal)
+    }
+
     pub fn handle_http_request(&self, body: &[u8], headers: &HeaderMap) -> (StatusCode, Value) {
         let request = match self.parse_and_validate_request(body) {
             Ok(request) => request,
@@ -135,80 +161,17 @@ impl RpcRuntime {
                 }
             };
 
-        let mut idempotency_context: Option<String> = None;
-        if is_mutating_method(&request.method) {
-            let key = match request
-                .meta
-                .as_ref()
-                .and_then(|meta| meta.idempotency_key.as_deref())
-            {
-                Some(key) => key,
-                None => {
-                    let error =
-                        ApiError::invalid_params("mutating methods require meta.idempotencyKey")
-                            .with_context(request.id.clone(), Some(request.method.clone()));
-                    let status = error.status;
-                    let envelope = error_envelope(&error, &self.config.served_by);
-                    return (status, envelope);
-                }
-            };
-
-            match self
-                .idempotency
-                .check(&request.method, key, &request.params)
-            {
-                IdempotencyCheck::Replay(response) => {
-                    debug!(
-                        method = %request.method,
-                        request_id = %request.id,
-                        "idempotency replay"
-                    );
-                    let status = StatusCode::from_u16(response.status).unwrap_or(StatusCode::OK);
-                    return (status, response.envelope);
-                }
-                IdempotencyCheck::Conflict => {
-                    let error = ApiError::idempotency_conflict(
-                        "idempotency key was already used with different parameters",
-                    )
-                    .with_context(request.id.clone(), Some(request.method.clone()))
-                    .with_details(json!({
-                        "method": request.method.clone(),
-                        "idempotencyKey": key
-                    }));
-                    let status = error.status;
-                    let envelope = error_envelope(&error, &self.config.served_by);
-                    return (status, envelope);
-                }
-                IdempotencyCheck::New => {
-                    idempotency_context = Some(key.to_string());
-                }
-            }
-        }
-
-        let (status, envelope) = match self.dispatch(&request, &principal) {
+        let (status, envelope) = match self.execute_request(&request, &principal) {
             Ok(result) => (
                 StatusCode::OK,
                 success_envelope(&request, result, &self.config.served_by),
             ),
             Err(error) => {
-                let error = error.with_context(request.id.clone(), Some(request.method.clone()));
                 let status = error.status;
                 let envelope = error_envelope(&error, &self.config.served_by);
                 (status, envelope)
             }
         };
-
-        if let Some(key) = idempotency_context {
-            self.idempotency.store(
-                &request.method,
-                &key,
-                &request.params,
-                &StoredResponse {
-                    status: status.as_u16(),
-                    envelope: envelope.clone(),
-                },
-            );
-        }
 
         (status, envelope)
     }
@@ -279,6 +242,10 @@ impl RpcRuntime {
 
     fn parse_and_validate_request(&self, body: &[u8]) -> Result<RpcRequestEnvelope, ApiError> {
         let raw = parse_json_value(body)?;
+        self.parse_and_validate_request_value(raw)
+    }
+
+    fn parse_and_validate_request_value(&self, raw: Value) -> Result<RpcRequestEnvelope, ApiError> {
         let (request_id, method) = request_context(&raw);
 
         if !raw.is_object() {
@@ -319,5 +286,120 @@ impl RpcRuntime {
         }
 
         Ok(request)
+    }
+
+    fn execute_request(
+        &self,
+        request: &RpcRequestEnvelope,
+        principal: &str,
+    ) -> Result<Value, ApiError> {
+        let mut idempotency_context: Option<String> = None;
+        if is_mutating_method(&request.method) {
+            let key = match request
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.idempotency_key.as_deref())
+            {
+                Some(key) => key,
+                None => {
+                    return Err(ApiError::invalid_params(
+                        "mutating methods require meta.idempotencyKey",
+                    )
+                    .with_context(request.id.clone(), Some(request.method.clone())));
+                }
+            };
+
+            match self
+                .idempotency
+                .check(&request.method, key, &request.params)
+            {
+                IdempotencyCheck::Replay(response) => {
+                    debug!(
+                        method = %request.method,
+                        request_id = %request.id,
+                        "idempotency replay"
+                    );
+                    return self.replay_stored_response(request, response);
+                }
+                IdempotencyCheck::Conflict => {
+                    return Err(ApiError::idempotency_conflict(
+                        "idempotency key was already used with different parameters",
+                    )
+                    .with_context(request.id.clone(), Some(request.method.clone()))
+                    .with_details(json!({
+                        "method": request.method.clone(),
+                        "idempotencyKey": key
+                    })));
+                }
+                IdempotencyCheck::New => {
+                    idempotency_context = Some(key.to_string());
+                }
+            }
+        }
+
+        let result = self
+            .dispatch(request, principal)
+            .map_err(|error| error.with_context(request.id.clone(), Some(request.method.clone())));
+
+        if let Some(key) = idempotency_context {
+            let (status, envelope) = match &result {
+                Ok(value) => (
+                    StatusCode::OK.as_u16(),
+                    success_envelope(request, value.clone(), &self.config.served_by),
+                ),
+                Err(error) => (
+                    error.status.as_u16(),
+                    error_envelope(error, &self.config.served_by),
+                ),
+            };
+            self.idempotency.store(
+                &request.method,
+                &key,
+                &request.params,
+                &StoredResponse { status, envelope },
+            );
+        }
+
+        result
+    }
+
+    fn replay_stored_response(
+        &self,
+        request: &RpcRequestEnvelope,
+        response: StoredResponse,
+    ) -> Result<Value, ApiError> {
+        if let Some(result) = response.envelope.get("result") {
+            return Ok(result.clone());
+        }
+
+        let error_body = response
+            .envelope
+            .get("error")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                ApiError::internal("stored idempotency response was missing an error payload")
+                    .with_context(request.id.clone(), Some(request.method.clone()))
+            })?;
+
+        let code = error_body
+            .get("code")
+            .and_then(Value::as_str)
+            .and_then(RpcErrorCode::from_contract)
+            .unwrap_or(RpcErrorCode::Internal);
+        let message = error_body
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("stored idempotency replay failed");
+        let retryable = error_body
+            .get("retryable")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        let mut error = ApiError::new(code, message)
+            .with_context(request.id.clone(), Some(request.method.clone()));
+        error.retryable = retryable;
+        error.details = error_body.get("details").cloned();
+        error.status = StatusCode::from_u16(response.status).unwrap_or(error.status);
+        Err(error)
     }
 }

--- a/crates/ralph-api/src/stream_domain/mod.rs
+++ b/crates/ralph-api/src/stream_domain/mod.rs
@@ -118,7 +118,7 @@ impl StreamDomain {
         let (live_tx, _) = broadcast::channel(LIVE_BUFFER_CAPACITY);
         Self {
             state: Arc::new(Mutex::new(StreamState {
-                sequence: 0,
+                sequence: 1,
                 subscription_counter: 0,
                 history: VecDeque::with_capacity(HISTORY_LIMIT),
                 subscriptions: HashMap::new(),
@@ -244,6 +244,32 @@ impl StreamDomain {
         subscription.matches(event)
     }
 
+    pub fn subscription_cursor_sequence(&self, subscription_id: &str) -> Result<u64, ApiError> {
+        let state = self.lock_state()?;
+        let Some(subscription) = state.subscriptions.get(subscription_id) else {
+            return Err(ApiError::not_found(format!(
+                "subscription '{}' not found",
+                subscription_id
+            ))
+            .with_details(json!({ "subscriptionId": subscription_id })));
+        };
+
+        cursor_sequence(&subscription.cursor)
+    }
+
+    pub fn subscription_cursor(&self, subscription_id: &str) -> Result<String, ApiError> {
+        let state = self.lock_state()?;
+        let Some(subscription) = state.subscriptions.get(subscription_id) else {
+            return Err(ApiError::not_found(format!(
+                "subscription '{}' not found",
+                subscription_id
+            ))
+            .with_details(json!({ "subscriptionId": subscription_id })));
+        };
+
+        Ok(subscription.cursor.clone())
+    }
+
     pub fn replay_for_subscription(&self, subscription_id: &str) -> Result<ReplayBatch, ApiError> {
         let state = self.lock_state()?;
         let Some(subscription) = state.subscriptions.get(subscription_id) else {
@@ -255,10 +281,14 @@ impl StreamDomain {
         };
 
         let cursor_sequence = cursor_sequence(&subscription.cursor)?;
+        let current_cursor = subscription.cursor.clone();
         let mut events = state
             .history
             .iter()
-            .filter(|event| event.sequence > cursor_sequence)
+            .filter(|event| {
+                event.sequence > cursor_sequence
+                    || (event.sequence == cursor_sequence && event.cursor != current_cursor)
+            })
             .filter(|event| subscription.matches(event))
             .cloned()
             .collect::<Vec<_>>();

--- a/crates/ralph-api/tests/mcp_server.rs
+++ b/crates/ralph-api/tests/mcp_server.rs
@@ -1,0 +1,246 @@
+use anyhow::Result;
+use rmcp::ServiceExt;
+use rmcp::model::{CallToolRequestParams, PaginatedRequestParams};
+use serde_json::{Map, Value, json};
+
+use ralph_api::{ApiConfig, mcp::RalphMcpServer};
+
+fn test_config(workspace_root: std::path::PathBuf) -> ApiConfig {
+    ApiConfig {
+        workspace_root,
+        ..ApiConfig::default()
+    }
+}
+
+fn obj(value: Value) -> Map<String, Value> {
+    value
+        .as_object()
+        .cloned()
+        .expect("tool arguments must be a JSON object")
+}
+
+#[tokio::test]
+async fn mcp_lists_expected_tools() -> Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_config = test_config(workspace.path().to_path_buf());
+
+    let server_handle = tokio::spawn(async move {
+        let server = RalphMcpServer::new(server_config)?;
+        let running = server.serve(server_transport).await?;
+        let _ = running.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = ().serve(client_transport).await?;
+    let tools = client.peer().list_all_tools().await?;
+    let names: Vec<_> = tools.iter().map(|tool| tool.name.as_ref()).collect();
+    assert!(names.contains(&"task_list"));
+    assert!(names.contains(&"loop_status"));
+    assert!(names.contains(&"planning_start"));
+    assert!(names.contains(&"config_get"));
+    assert!(names.contains(&"stream_next"));
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_call_tool_round_trips_structured_results() -> Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_config = test_config(workspace.path().to_path_buf());
+
+    let server_handle = tokio::spawn(async move {
+        let server = RalphMcpServer::new(server_config)?;
+        let running = server.serve(server_transport).await?;
+        let _ = running.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = ().serve(client_transport).await?;
+    let created = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("task_create").with_arguments(obj(json!({
+                "id": "task-mcp-1",
+                "title": "Created from MCP",
+                "autoExecute": false,
+            }))),
+        )
+        .await?;
+    assert_eq!(created.is_error, Some(false));
+    assert_eq!(
+        created.structured_content.as_ref().unwrap()["task"]["id"],
+        "task-mcp-1"
+    );
+
+    let listed = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("task_list").with_arguments(obj(json!({}))))
+        .await?;
+    assert_eq!(listed.is_error, Some(false));
+    assert_eq!(
+        listed.structured_content.as_ref().unwrap()["tasks"][0]["id"],
+        "task-mcp-1"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_returns_tool_errors_for_invalid_arguments() -> Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_config = test_config(workspace.path().to_path_buf());
+
+    let server_handle = tokio::spawn(async move {
+        let server = RalphMcpServer::new(server_config)?;
+        let running = server.serve(server_transport).await?;
+        let _ = running.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = ().serve(client_transport).await?;
+    let result = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("task_create")
+                .with_arguments(obj(json!({ "id": "task-bad" }))),
+        )
+        .await?;
+    assert_eq!(result.is_error, Some(true));
+    assert_eq!(
+        result.structured_content.as_ref().unwrap()["code"],
+        "INVALID_PARAMS"
+    );
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_stream_tools_support_polling() -> Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_config = test_config(workspace.path().to_path_buf());
+
+    let server_handle = tokio::spawn(async move {
+        let server = RalphMcpServer::new(server_config)?;
+        let running = server.serve(server_transport).await?;
+        let _ = running.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = ().serve(client_transport).await?;
+    let subscribed = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("stream_subscribe").with_arguments(obj(json!({
+                "topics": ["task.status.changed"],
+            }))),
+        )
+        .await?;
+    let subscription_id = subscribed.structured_content.as_ref().unwrap()["subscriptionId"]
+        .as_str()
+        .expect("subscription id")
+        .to_string();
+
+    let created = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("task_create").with_arguments(obj(json!({
+                "id": "task-stream-1",
+                "title": "Stream task",
+                "autoExecute": false,
+            }))),
+        )
+        .await?;
+    assert_eq!(created.is_error, Some(false));
+
+    let updated = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("task_update").with_arguments(obj(json!({
+                "id": "task-stream-1",
+                "status": "running",
+            }))),
+        )
+        .await?;
+    assert_eq!(updated.is_error, Some(false));
+
+    let next = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("stream_next").with_arguments(obj(json!({
+                "subscriptionId": subscription_id,
+                "waitMs": 100,
+            }))),
+        )
+        .await?;
+    assert_eq!(next.is_error, Some(false));
+    let events = next.structured_content.as_ref().unwrap()["events"]
+        .as_array()
+        .unwrap();
+    assert!(!events.is_empty());
+    let cursor = events[0]["cursor"]
+        .as_str()
+        .expect("stream event cursor")
+        .to_string();
+
+    let ack = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("stream_ack").with_arguments(obj(json!({
+                "subscriptionId": subscribed.structured_content.as_ref().unwrap()["subscriptionId"].as_str().unwrap(),
+                "cursor": cursor,
+            }))),
+        )
+        .await?;
+    assert_eq!(ack.is_error, Some(false));
+
+    let unsubscribe = client
+        .peer()
+        .call_tool(
+            CallToolRequestParams::new("stream_unsubscribe").with_arguments(obj(json!({
+                "subscriptionId": subscribed.structured_content.as_ref().unwrap()["subscriptionId"].as_str().unwrap(),
+            }))),
+        )
+        .await?;
+    assert_eq!(unsubscribe.is_error, Some(false));
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_accepts_paginated_tools_requests() -> Result<()> {
+    let workspace = tempfile::tempdir()?;
+    let (server_transport, client_transport) = tokio::io::duplex(64 * 1024);
+    let server_config = test_config(workspace.path().to_path_buf());
+
+    let server_handle = tokio::spawn(async move {
+        let server = RalphMcpServer::new(server_config)?;
+        let running = server.serve(server_transport).await?;
+        let _ = running.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = ().serve(client_transport).await?;
+    let result = client
+        .peer()
+        .list_tools(Some(
+            PaginatedRequestParams::default().with_cursor(Some("0".to_string())),
+        ))
+        .await?;
+    assert!(!result.tools.is_empty());
+
+    client.cancel().await?;
+    server_handle.await??;
+    Ok(())
+}

--- a/crates/ralph-cli/Cargo.toml
+++ b/crates/ralph-cli/Cargo.toml
@@ -24,6 +24,7 @@ ralph-core.workspace = true
 ralph-adapters.workspace = true
 ralph-telegram.workspace = true
 ralph-tui.workspace = true
+ralph-api.workspace = true
 
 tokio.workspace = true
 clap.workspace = true

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -23,6 +23,7 @@ mod init;
 mod interact;
 mod loop_runner;
 mod loops;
+mod mcp;
 mod memory;
 mod preflight;
 mod presets;
@@ -525,6 +526,9 @@ enum Commands {
     /// Run the web dashboard
     Web(web::WebArgs),
 
+    /// Run Ralph as an MCP server over stdio
+    Mcp(mcp::McpArgs),
+
     /// Manage Telegram bot setup and testing
     Bot(bot::BotArgs),
 
@@ -897,6 +901,7 @@ async fn main() -> Result<()> {
         Some(Commands::Resume(args)) => args.rpc,
         _ => false,
     };
+    let mcp_enabled = matches!(&cli.command, Some(Commands::Mcp(_)));
 
     // Initialize logging - suppress in TUI mode to avoid corrupting the display
     let filter = if cli.verbose { "debug" } else { "info" };
@@ -946,8 +951,8 @@ async fn main() -> Result<()> {
             }
         }
         // If log file creation fails, silently continue without logging
-    } else if rpc_enabled {
-        // RPC mode: logs must go to stderr to keep stdout clean for JSON-lines
+    } else if rpc_enabled || mcp_enabled {
+        // RPC/MCP mode: logs must go to stderr to keep stdout clean for protocol messages
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_writer(std::io::stderr)
@@ -1071,6 +1076,7 @@ async fn main() -> Result<()> {
         }
         Some(Commands::Tui(args)) => tui_command(args).await,
         Some(Commands::Web(args)) => web::execute(args).await,
+        Some(Commands::Mcp(args)) => mcp::execute(args).await,
         Some(Commands::Bot(args)) => {
             bot::execute(
                 args,
@@ -2802,6 +2808,12 @@ mod tests {
         let cli = Cli::try_parse_from(["ralph", "tutorial"]).expect("CLI parse failed");
 
         assert!(matches!(cli.command, Some(Commands::Tutorial(_))));
+    }
+
+    #[test]
+    fn test_mcp_serve_parses_command() {
+        let cli = Cli::try_parse_from(["ralph", "mcp", "serve"]).expect("CLI parse failed");
+        assert!(matches!(cli.command, Some(Commands::Mcp(_))));
     }
 
     #[test]

--- a/crates/ralph-cli/src/mcp.rs
+++ b/crates/ralph-cli/src/mcp.rs
@@ -1,0 +1,29 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+pub struct McpArgs {
+    #[command(subcommand)]
+    pub command: McpCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum McpCommands {
+    /// Run the Ralph control plane as an MCP server over stdio
+    Serve(ServeArgs),
+}
+
+#[derive(Parser, Debug, Default)]
+pub struct ServeArgs {}
+
+pub async fn execute(args: McpArgs) -> Result<()> {
+    match args.command {
+        McpCommands::Serve(_args) => {
+            let mut config = ralph_api::ApiConfig::from_env()?;
+            config.served_by = "ralph-mcp".to_string();
+            config.auth_mode = ralph_api::AuthMode::TrustedLocal;
+            config.token = None;
+            ralph_api::serve_stdio(config).await
+        }
+    }
+}

--- a/crates/ralph-cli/src/web.rs
+++ b/crates/ralph-cli/src/web.rs
@@ -80,6 +80,34 @@ fn run_command_with_retry(command: &OsStr, args: &[&str]) -> std::io::Result<std
     unreachable!("retry loop should always return before exhausting attempts")
 }
 
+async fn run_async_command_with_retry(
+    command: &OsStr,
+    args: &[&str],
+    current_dir: &Path,
+) -> std::io::Result<std::process::Output> {
+    const MAX_ATTEMPTS: usize = 5;
+
+    for attempt in 0..MAX_ATTEMPTS {
+        match AsyncCommand::new(command)
+            .args(args)
+            .current_dir(current_dir)
+            .output()
+            .await
+        {
+            Ok(output) => return Ok(output),
+            Err(err) => {
+                if is_transient_exec_error(&err) && attempt + 1 < MAX_ATTEMPTS {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    continue;
+                }
+                return Err(err);
+            }
+        }
+    }
+
+    unreachable!("retry loop should always return before exhausting attempts")
+}
+
 /// Check that Node.js is installed and >= 18. Returns the version string.
 fn check_node_with(node_cmd: &OsStr) -> Result<String> {
     let output = run_command_with_retry(node_cmd, &["--version"]).map_err(|_| {
@@ -156,10 +184,7 @@ async fn run_npm_install_with(root: &Path, npm_cmd: &OsStr) -> Result<()> {
     spinner.set_message(format!("Running npm {}...", install_cmd));
     spinner.enable_steady_tick(Duration::from_millis(100));
 
-    let output = AsyncCommand::new(npm_cmd)
-        .arg(install_cmd)
-        .current_dir(root)
-        .output()
+    let output = run_async_command_with_retry(npm_cmd, &[install_cmd], root)
         .await
         .context("Failed to run npm install")?;
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -335,6 +335,20 @@ ralph web [OPTIONS]
 | `--legacy-node-api` | Run deprecated Node tRPC backend instead of Rust RPC API |
 | `--no-open` | Do not open browser |
 
+### ralph mcp
+
+Run Ralph as a Model Context Protocol server over `stdio`.
+
+```bash
+ralph mcp serve
+```
+
+Notes:
+
+- v1 is tools-only and `stdio`-only.
+- Launch it from an MCP client configuration, not an interactive terminal workflow.
+- The server exposes Ralph control-plane methods as MCP tools, including polling stream tools such as `stream_next`.
+
 ### ralph bot
 
 Manage Telegram bot setup and testing.

--- a/frontend/ralph-web/src/components/tasks/ThreadList.test.tsx
+++ b/frontend/ralph-web/src/components/tasks/ThreadList.test.tsx
@@ -154,6 +154,10 @@ vi.mock("@/hooks", () => ({
   })),
 }));
 
+vi.mock("./LiveStatus", () => ({
+  LiveStatus: () => null,
+}));
+
 import { ThreadList } from "./ThreadList";
 
 function createTestWrapper() {


### PR DESCRIPTION
## Summary

This change adds a first-class MCP server for Ralph on top of the existing Rust control plane. Users can now launch `ralph mcp serve` and connect MCP clients to Ralph over stdio instead of relying on ad hoc prompting or shell-level conventions.

From a user perspective, this turns Ralph's control plane into a portable tool surface. MCP clients can enumerate Ralph tools, call task and loop operations directly, and poll Ralph stream events through MCP-native tool calls without needing to know the internal RPC transport.

## Problem

Before this change, Ralph had a canonical RPC and streaming control plane in `ralph-api`, but it did not expose that surface as an MCP server. That meant MCP-capable clients such as Codex or other editors could not discover or invoke Ralph operations directly. The practical effect was that Ralph remained usable only through its native CLI and API surfaces, while agents had to rely on custom instructions or shell workflows instead of a typed, reusable protocol.

The absence of an MCP adapter also meant stream behavior was locked to the existing transport assumptions. MCP clients need a polling-style interaction for event delivery, but Ralph only exposed subscribe and live-stream semantics through its existing API transport.

## Root Cause

The core issue was not missing control-plane logic; Ralph already had that in `ralph-api`. The missing piece was a transport adapter that could present the existing control plane as MCP tools while preserving the current validation, idempotency, persistence, and side effects.

There was also an integration hazard in the CLI runtime. Even after the MCP server was implemented, `ralph mcp serve` initially inherited the CLI's default stdout logging configuration. That polluted the MCP stdout channel with tracing output after initialization, which would break real MCP clients.

## Fix

The implementation adds an MCP adapter in `crates/ralph-api` using `rmcp` as the protocol and stdio transport layer. The adapter derives the tool catalog from the embedded RPC schema, maps Ralph RPC methods to MCP tool names, and routes tool calls through a new transport-neutral `RpcRuntime::invoke_method` entrypoint instead of looping back through HTTP.

For stream access, the change adds MCP polling support through `stream_subscribe`, `stream_next`, `stream_ack`, and `stream_unsubscribe`. The server keeps per-subscription receiver state so event delivery behaves correctly across subscribe, replay, and polling boundaries. Cursor handling in the stream domain was tightened to avoid ambiguous first-event delivery and to make replay behavior line up with MCP polling.

The CLI now exposes `ralph mcp serve`, and the `ralph-api` crate exports a reusable `serve_stdio` entrypoint. Documentation was also updated so the new command is visible in the CLI reference.

After implementing the adapter, the work also fixed the stdout logging bug in `ralph-cli` so MCP mode writes logs to stderr and keeps stdout protocol-clean for real clients.

## Validation

I validated the change at several levels:

- `cargo test -p ralph-api`
- `cargo test`
- `cargo test -p ralph-core smoke_runner`

The new `ralph-api` test coverage exercises MCP tool listing, representative read and write tool calls, invalid-argument error shaping, pagination, and stream polling lifecycle behavior.

I also verified the real stdio server process directly with a raw MCP transcript against `target/debug/ralph mcp serve`, including `initialize`, `tools/list`, `task_create`, `task_list`, invalid argument handling, `stream_subscribe`, `stream_next`, `stream_ack`, and `stream_unsubscribe`.

Finally, I verified the new surface with the real Codex CLI by temporarily registering `ralph mcp serve` as a Codex MCP server and confirming that Codex successfully invoked the `system_version` tool over MCP and received the expected structured result.
