### PR TITLE
docs: refresh CLI API docs with MCP server mode details

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ npm run dev:legacy-server  # deprecated Node backend (optional)
 npm run test             # all frontend/backend workspace tests
 ```
 
+## MCP Server Mode
+
+Ralph can run as an MCP server over stdio for MCP-compatible clients:
+
+```bash
+ralph mcp serve
+```
+
+Use this mode from an MCP client configuration rather than an interactive terminal workflow.
+
 ## What is Ralph?
 
 Ralph implements the [Ralph Wiggum technique](https://ghuntley.com/ralph/) — autonomous task completion through continuous iteration. It supports:

--- a/docs/api/ralph-cli.md
+++ b/docs/api/ralph-cli.md
@@ -7,216 +7,71 @@ Binary entry point and CLI parsing.
 `ralph-cli` is the main binary that:
 
 - Parses command-line arguments
-- Routes to appropriate commands
-- Handles global options
+- Routes to command handlers
+- Configures runtime logging/output behavior
 
-## Commands
+## Top-Level Commands
 
-### ralph run
+The `Commands` enum in `crates/ralph-cli/src/main.rs` currently includes:
 
-Execute the orchestration loop.
+- `run`
+- `preflight`
+- `hooks`
+- `doctor`
+- `tutorial`
+- `events`
+- `init`
+- `clean`
+- `emit`
+- `plan`
+- `code-task` (plus hidden legacy `task` alias)
+- `tools`
+- `loops`
+- `hats`
+- `tui`
+- `web`
+- `mcp`
+- `bot`
+- `completions`
 
-```rust
-pub struct RunCommand {
-    pub prompt: Option<String>,
-    pub prompt_file: Option<PathBuf>,
-    pub max_iterations: Option<usize>,
-    pub completion_promise: Option<String>,
-    pub dry_run: bool,
-    pub no_tui: bool,
-    pub autonomous: bool,
-    pub idle_timeout: Option<u64>,
-    pub record_session: Option<PathBuf>,
-    pub quiet: bool,
-    pub continue_: bool,
-}
-```
+For user-facing flags and examples, see the canonical CLI guide: `docs/guide/cli-reference.md`.
 
-### ralph init
+## MCP Server Mode (`ralph mcp`)
 
-Initialize configuration file.
+`ralph mcp serve` runs Ralph as a Model Context Protocol server over `stdio`.
 
-```rust
-pub struct InitCommand {
-    pub backend: Option<String>,
-    pub preset: Option<String>,
-    pub list_presets: bool,
-    pub force: bool,
-}
-```
+Notes:
 
-### ralph plan
+- Intended for MCP client configuration (non-interactive)
+- Uses stdout for protocol messages and stderr for logs
+- Exposes control-plane tools, including stream polling tools like `stream_next`
 
-Start PDD planning session.
+## Runtime Directories
 
-```rust
-pub struct PlanCommand {
-    pub idea: Option<String>,
-    pub backend: Option<String>,
-}
-```
+Ralph runtime artifacts are stored in `.ralph/` (for example `.ralph/agent`, `.ralph/tasks`, `.ralph/specs`), not `.agent/`.
 
-### ralph task
+## Command Dispatch
 
-Generate code task files.
-
-```rust
-pub struct TaskCommand {
-    pub input: Option<String>,
-    pub backend: Option<String>,
-}
-```
-
-### ralph events
-
-View event history.
-
-```rust
-pub struct EventsCommand {
-    pub limit: Option<usize>,
-    pub format: OutputFormat,
-}
-```
-
-### ralph emit
-
-Emit an event.
-
-```rust
-pub struct EmitCommand {
-    pub topic: String,
-    pub payload: Option<String>,
-    pub json: Option<String>,
-}
-```
-
-### ralph clean
-
-Clean up `.agent/` directory.
-
-```rust
-pub struct CleanCommand {
-    pub diagnostics: bool,
-    pub all: bool,
-}
-```
-
-### ralph tools
-
-Runtime tools subcommands.
-
-```rust
-pub enum ToolsCommand {
-    Memory(MemoryCommand),
-    Task(TaskCliCommand),
-}
-```
+Dispatch is handled in `run()` via a `match` on `cli.command`, delegating to each submodule (for example `web::execute(args).await`, `mcp::execute(args).await`, `bot::execute(...)`).
 
 ## Global Options
 
-```rust
-pub struct GlobalOptions {
-    pub config: PathBuf,
-    pub verbose: bool,
-    pub color: ColorMode,
-}
-```
+Global CLI options include:
 
-## Implementation
-
-### Command Dispatch
-
-```rust
-pub async fn run() -> Result<()> {
-    let cli = Cli::parse();
-
-    match cli.command {
-        Command::Run(cmd) => run_command(cmd, &cli.global).await,
-        Command::Init(cmd) => init_command(cmd, &cli.global).await,
-        Command::Plan(cmd) => plan_command(cmd, &cli.global).await,
-        Command::Task(cmd) => task_command(cmd, &cli.global).await,
-        Command::Events(cmd) => events_command(cmd, &cli.global).await,
-        Command::Emit(cmd) => emit_command(cmd, &cli.global).await,
-        Command::Clean(cmd) => clean_command(cmd, &cli.global).await,
-        Command::Tools(cmd) => tools_command(cmd, &cli.global).await,
-    }
-}
-```
-
-### Error Handling
-
-```rust
-fn main() {
-    if let Err(e) = ralph_cli::run() {
-        eprintln!("Error: {}", e);
-        std::process::exit(1);
-    }
-}
-```
+- `--config <PATH>`
+- `--verbose`
+- `--color <auto|always|never>`
 
 ## Shell Completions
 
-Generate shell completions:
+`ralph completions <shell>` outputs completion scripts.
 
-```rust
-pub fn generate_completions(shell: Shell) -> String {
-    let mut cmd = Cli::command();
-    let mut buf = Vec::new();
-    generate(shell, &mut cmd, "ralph", &mut buf);
-    String::from_utf8(buf).unwrap()
-}
-```
-
-**Usage:**
+Example:
 
 ```bash
 ralph completions bash > ~/.local/share/bash-completion/completions/ralph
-ralph completions zsh > ~/.zfunc/_ralph
-ralph completions fish > ~/.config/fish/completions/ralph.fish
 ```
 
 ## Exit Codes
 
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | General error |
-| 2 | Configuration error |
-| 3 | Backend not found |
-| 4 | Interrupted |
-
-## Example: Adding a New Command
-
-1. Define command struct:
-
-```rust
-#[derive(Parser)]
-pub struct MyCommand {
-    #[arg(short, long)]
-    pub option: Option<String>,
-}
-```
-
-2. Add to command enum:
-
-```rust
-pub enum Command {
-    // ...
-    MyCommand(MyCommand),
-}
-```
-
-3. Implement handler:
-
-```rust
-pub async fn my_command(cmd: MyCommand, global: &GlobalOptions) -> Result<()> {
-    // Implementation
-    Ok(())
-}
-```
-
-4. Add to dispatch:
-
-```rust
-Command::MyCommand(cmd) => my_command(cmd, &cli.global).await,
-```
+Command handlers return process errors via `anyhow::Result`, surfaced by the binary entry point.


### PR DESCRIPTION
### Motivation
- Recent commits added MCP server support and related CLI handlers, and the published CLI API docs were missing those changes. 
- The README did not surface the new `ralph mcp serve` entrypoint, so users might miss the MCP server mode when scanning top-level docs.

### Description
- Added an `MCP Server Mode` section to `README.md` documenting `ralph mcp serve` and its intended usage. 
- Rewrote `docs/api/ralph-cli.md` to reflect the current `Commands` enum, list top-level subcommands (including `mcp`), and clarify runtime directories (`.ralph/`) and command dispatch behavior. 
- Ensured local formatting/validation tooling was exercised (`./scripts/setup-hooks.sh`) to keep docs and repo checks consistent.

### Testing
- Ran `./scripts/setup-hooks.sh` successfully to install the repository pre-commit checks. 
- Ran `cargo fmt --all -- --check` which passed. 
- Ran `cargo clippy --all-targets --all-features -- -D warnings` which passed. 
- Ran `cargo test` which exercised the workspace but reported failures in existing integration tests in `crates/ralph-adapters/tests/acp_process_cleanup.rs` (two failing tests); these failures are unrelated to the docs-only changes. 
- Ran `cargo test -p ralph-core smoke_runner` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acaea1d5948333b9b507c0f3728f0f)