### PR TITLE
fix(core): prefer progressed hat over stale start event

### DIFF
--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -1449,6 +1449,8 @@ impl EventLoop {
     /// Returns the first active hat, or "ralph" if no specific hat is active.
     /// BTreeMap iteration is already sorted by key.
     pub fn get_active_hat_id(&self) -> HatId {
+        let mut entrypoint_hat = None;
+
         // Peek at pending events (don't consume them)
         for hat_id in self.bus.hat_ids() {
             let Some(events) = self.bus.peek_pending(hat_id) else {
@@ -1458,10 +1460,21 @@ impl EventLoop {
                 continue;
             };
             if let Some(active_hat) = self.registry.get_for_topic(event.topic.as_str()) {
+                if self.is_entrypoint_topic(event.topic.as_str()) {
+                    entrypoint_hat.get_or_insert_with(|| active_hat.id.clone());
+                    continue;
+                }
                 return active_hat.id.clone();
             }
         }
-        HatId::new("ralph")
+
+        entrypoint_hat.unwrap_or_else(|| HatId::new("ralph"))
+    }
+
+    fn is_entrypoint_topic(&self, topic: &str) -> bool {
+        topic == "task.start"
+            || topic == "task.resume"
+            || self.config.event_loop.starting_event.as_deref() == Some(topic)
     }
 
     /// Injects a default event for a hat when the agent wrote no events.

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -1826,6 +1826,65 @@ hats:
 }
 
 #[test]
+fn test_get_active_hat_id_prefers_progressed_hat_over_stale_start_event() {
+    // Repro for issue #225:
+    // after the initial build.start has already been consumed, a stray build.start
+    // can remain pending alongside the correct downstream event. The next visible
+    // hat should be the progressed hat (unit_test_writer), not the stale starter.
+    let yaml = r#"
+event_loop:
+  starting_event: "build.start"
+hats:
+  unit_test_researcher:
+    name: "🔬 Unit Test Researcher"
+    triggers: ["build.start"]
+    publishes: ["unit_test_research.complete"]
+  unit_test_writer:
+    name: "🧪 Unit Test Writer"
+    triggers: ["unit_test_research.complete"]
+    publishes: ["unit_tests.written"]
+"#;
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+
+    event_loop.initialize("Spec: specs/example/spec.md");
+
+    // Iteration 1 starts on the researcher via the initial build.start.
+    assert_eq!(
+        event_loop.get_active_hat_id().as_str(),
+        "unit_test_researcher",
+        "Initial build.start should activate the researcher"
+    );
+
+    // Ralph then consumes that initial build.start during prompt construction.
+    let _prompt = event_loop.build_prompt(&HatId::new("ralph")).unwrap();
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("unit_test_researcher"))
+            .is_none_or(|events| events.is_empty()),
+        "Initial build.start should be consumed before the next iteration"
+    );
+
+    // Reproduce the issue comment's state: a stray build.start is present alongside
+    // the correct downstream completion event for the next hat.
+    event_loop
+        .bus
+        .publish(Event::new("build.start", "Spec: specs/example/spec.md"));
+    event_loop.bus.publish(Event::new(
+        "unit_test_research.complete",
+        "Research document written",
+    ));
+
+    let active_hat_id = event_loop.get_active_hat_id();
+    assert_eq!(
+        active_hat_id.as_str(),
+        "unit_test_writer",
+        "Display should advance to unit_test_writer once unit_test_research.complete is pending, even if a stale build.start is also present"
+    );
+}
+
+#[test]
 fn test_check_for_user_prompt_detects_user_prompt_event() {
     // Create EventLoop
     let config: RalphConfig = serde_yaml::from_str("hats: {}").unwrap();

--- a/crates/ralph-core/src/hatless_ralph.rs
+++ b/crates/ralph-core/src/hatless_ralph.rs
@@ -290,7 +290,7 @@ impl HatlessRalph {
             .any(|h| !h.instructions.trim().is_empty());
 
         if !has_custom_workflow {
-            prompt.push_str(&self.workflow_section());
+            prompt.push_str(&self.workflow_section(!active_hats.is_empty()));
         }
 
         if let Some(topology) = &self.hat_topology {
@@ -334,9 +334,15 @@ You MUST NOT get distracted by workflow mechanics — they serve this goal.
     ///
     /// Used to enable fast path delegation that skips the PLAN step
     /// when immediate delegation to specialized hats is appropriate.
-    fn is_fresh_start(&self) -> bool {
+    fn is_fresh_start(&self, has_active_hats: bool) -> bool {
         // Fast path only applies when starting_event is configured
         if self.starting_event.is_none() {
+            return false;
+        }
+
+        // Active hats mean we are already inside the workflow. Re-seeding the
+        // starting event would duplicate kickoff events and misroute hat display.
+        if has_active_hats {
             return false;
         }
 
@@ -480,11 +486,11 @@ Its content is auto-injected in `<scratchpad>` tags at the top of your context e
         prompt
     }
 
-    fn workflow_section(&self) -> String {
+    fn workflow_section(&self, has_active_hats: bool) -> String {
         // Different workflow for solo mode vs multi-hat mode
         if self.hat_topology.is_some() {
             // Check for fast path: starting_event set AND no scratchpad
-            if self.is_fresh_start() {
+            if self.is_fresh_start(has_active_hats) {
                 // Fast path: immediate delegation without planning
                 return format!(
                     r"## WORKFLOW
@@ -1222,6 +1228,44 @@ hats:
         );
     }
 
+    #[test]
+    fn test_fast_path_disabled_when_workflow_already_active() {
+        // Even without scratchpad, active hats mean workflow already started,
+        // so Ralph must not re-emit the starting event fast-path instruction.
+        let yaml = r#"
+hats:
+  researcher:
+    name: "Researcher"
+    triggers: ["build.start"]
+    publishes: ["research.complete"]
+  writer:
+    name: "Writer"
+    triggers: ["research.complete"]
+    publishes: ["tests.written"]
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        let registry = HatRegistry::from_config(&config);
+        let ralph = HatlessRalph::new(
+            "LOOP_COMPLETE",
+            config.core.clone(),
+            &registry,
+            Some("build.start".to_string()),
+        );
+
+        let researcher = registry
+            .get(&ralph_proto::HatId::new("researcher"))
+            .unwrap();
+        let prompt = ralph.build_prompt("[research.complete] done", &[researcher]);
+
+        assert!(
+            !prompt.contains("FAST PATH"),
+            "Prompt should not indicate fast path after workflow has active hats"
+        );
+        assert!(
+            prompt.contains("### 1. PLAN"),
+            "Prompt should use normal multi-hat workflow once active hats exist"
+        );
+    }
     #[test]
     fn test_fast_path_with_starting_event() {
         // When starting_event is configured AND scratchpad doesn't exist,

--- a/crates/ralph-core/src/hatless_ralph.rs
+++ b/crates/ralph-core/src/hatless_ralph.rs
@@ -290,7 +290,7 @@ impl HatlessRalph {
             .any(|h| !h.instructions.trim().is_empty());
 
         if !has_custom_workflow {
-            prompt.push_str(&self.workflow_section(!active_hats.is_empty()));
+            prompt.push_str(&self.workflow_section());
         }
 
         if let Some(topology) = &self.hat_topology {
@@ -334,15 +334,9 @@ You MUST NOT get distracted by workflow mechanics — they serve this goal.
     ///
     /// Used to enable fast path delegation that skips the PLAN step
     /// when immediate delegation to specialized hats is appropriate.
-    fn is_fresh_start(&self, has_active_hats: bool) -> bool {
+    fn is_fresh_start(&self) -> bool {
         // Fast path only applies when starting_event is configured
         if self.starting_event.is_none() {
-            return false;
-        }
-
-        // Active hats mean we are already inside the workflow. Re-seeding the
-        // starting event would duplicate kickoff events and misroute hat display.
-        if has_active_hats {
             return false;
         }
 
@@ -486,11 +480,11 @@ Its content is auto-injected in `<scratchpad>` tags at the top of your context e
         prompt
     }
 
-    fn workflow_section(&self, has_active_hats: bool) -> String {
+    fn workflow_section(&self) -> String {
         // Different workflow for solo mode vs multi-hat mode
         if self.hat_topology.is_some() {
             // Check for fast path: starting_event set AND no scratchpad
-            if self.is_fresh_start(has_active_hats) {
+            if self.is_fresh_start() {
                 // Fast path: immediate delegation without planning
                 return format!(
                     r"## WORKFLOW
@@ -1228,44 +1222,6 @@ hats:
         );
     }
 
-    #[test]
-    fn test_fast_path_disabled_when_workflow_already_active() {
-        // Even without scratchpad, active hats mean workflow already started,
-        // so Ralph must not re-emit the starting event fast-path instruction.
-        let yaml = r#"
-hats:
-  researcher:
-    name: "Researcher"
-    triggers: ["build.start"]
-    publishes: ["research.complete"]
-  writer:
-    name: "Writer"
-    triggers: ["research.complete"]
-    publishes: ["tests.written"]
-"#;
-        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
-        let registry = HatRegistry::from_config(&config);
-        let ralph = HatlessRalph::new(
-            "LOOP_COMPLETE",
-            config.core.clone(),
-            &registry,
-            Some("build.start".to_string()),
-        );
-
-        let researcher = registry
-            .get(&ralph_proto::HatId::new("researcher"))
-            .unwrap();
-        let prompt = ralph.build_prompt("[research.complete] done", &[researcher]);
-
-        assert!(
-            !prompt.contains("FAST PATH"),
-            "Prompt should not indicate fast path after workflow has active hats"
-        );
-        assert!(
-            prompt.contains("### 1. PLAN"),
-            "Prompt should use normal multi-hat workflow once active hats exist"
-        );
-    }
     #[test]
     fn test_fast_path_with_starting_event() {
         // When starting_event is configured AND scratchpad doesn't exist,


### PR DESCRIPTION
### Motivation
Issue #225 reports that after `unit_test_research.complete`, Ralph behaves like the next hat but the TUI still shows `Unit Test Researcher`.

The actual repro is a stale entry event such as `build.start` remaining pending alongside the real downstream event. In that state, display selection was still preferring the stale starter hat.

### Description
- Add a regression test that reproduces the issue-reported state: stale `build.start` plus `unit_test_research.complete` pending together.
- Update `EventLoop::get_active_hat_id()` to treat entrypoint topics (`task.start`, `task.resume`, and the configured `starting_event`) as fallback-only for display when downstream work is also pending.
- Preserve the existing deterministic behavior when only entrypoint work is pending or when there are no pending hat events.

### Testing
- `cargo fmt --all -- --check`
- `cargo test -p ralph-core get_active_hat_id -- --nocapture`
- `cargo test -p ralph-core test_initialization_routes_to_ralph_in_multihat_mode -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb82c803c8333a77fb1daef642058)
