### PR TITLE
Restrict hats event_loop overlays to non-runtime keys (completion_promise, starting_event)

### DIFF
--- a/crates/ralph-cli/src/preflight.rs
+++ b/crates/ralph-cli/src/preflight.rs
@@ -455,6 +455,7 @@ fn validate_core_config_shape(value: &Value, label: &str) -> Result<()> {
 }
 
 const ALLOWED_HATS_TOP_LEVEL: &[&str] = &["hats", "events", "event_loop", "name", "description"];
+const ALLOWED_HATS_EVENT_LOOP_OVERLAY_KEYS: &[&str] = &["completion_promise", "starting_event"];
 
 fn hats_disallowed_keys(mapping: &Mapping) -> Vec<String> {
     let mut disallowed = Vec::new();
@@ -532,7 +533,11 @@ fn merge_hats_overlay(mut core: Value, hats: Value) -> Result<Value> {
             .ok_or_else(|| anyhow::anyhow!("core.event_loop must be a mapping when provided"))?;
 
         for (key, value) in overlay_mapping {
-            event_loop_mapping.insert(key.clone(), value.clone());
+            if let Some(key_str) = key.as_str()
+                && ALLOWED_HATS_EVENT_LOOP_OVERLAY_KEYS.contains(&key_str)
+            {
+                event_loop_mapping.insert(key.clone(), value.clone());
+            }
         }
 
         mapping_insert(
@@ -717,6 +722,42 @@ hats:
         assert_eq!(config.event_loop.completion_promise, "REVIEW_COMPLETE");
         assert!(config.hats.contains_key("reviewer"));
         assert!(!config.hats.contains_key("builder"));
+    }
+
+    #[test]
+    fn merge_hats_overlay_ignores_runtime_limits_from_hats_event_loop() {
+        let core: Value = serde_yaml::from_str(
+            r"
+event_loop:
+  max_iterations: 100
+  max_runtime_seconds: 28800
+  completion_promise: LOOP_COMPLETE
+hats:
+  builder:
+    name: Builder
+",
+        )
+        .unwrap();
+
+        let hats: Value = serde_yaml::from_str(
+            r"
+event_loop:
+  completion_promise: REVIEW_COMPLETE
+  max_iterations: 150
+  max_runtime_seconds: 14400
+hats:
+  reviewer:
+    name: Reviewer
+",
+        )
+        .unwrap();
+
+        let merged = merge_hats_overlay(core, hats).unwrap();
+        let config: RalphConfig = serde_yaml::from_value(merged).unwrap();
+
+        assert_eq!(config.event_loop.max_iterations, 100);
+        assert_eq!(config.event_loop.max_runtime_seconds, 28800);
+        assert_eq!(config.event_loop.completion_promise, "REVIEW_COMPLETE");
     }
 
     #[tokio::test]

--- a/crates/ralph-cli/tests/integration_config_precedence.rs
+++ b/crates/ralph-cli/tests/integration_config_precedence.rs
@@ -244,6 +244,101 @@ fn test_hats_file_event_loop_completion_promise_overrides_combined_config() {
     );
 }
 
+/// Runtime limits (`max_iterations`, `max_runtime_seconds`) should come from
+/// core config (`-c`) and not be overridden by hats source (`-H`). Hats may
+/// override workflow keys like completion promise, but not runtime caps.
+#[test]
+fn test_hats_file_does_not_override_runtime_limits_from_combined_config() {
+    let dir = TempDir::new().expect("temp dir");
+    let config_path = dir.path().join("ralph.yml");
+    let hats_path = dir.path().join("hats.yml");
+
+    fs::write(
+        &config_path,
+        r#"cli:
+  backend: claude
+event_loop:
+  max_iterations: 10
+  max_runtime_seconds: 28800
+  completion_promise: "CORE_DONE"
+  prompt: "placeholder"
+core:
+  specs_dir: "./specs/"
+hats:
+  from_core:
+    name: "from_core"
+    description: "core hat"
+    triggers: ["design.start"]
+    publishes: ["CORE_DONE"]
+    default_publishes: "CORE_DONE"
+    instructions: |
+      Core hat
+"#,
+    )
+    .expect("write combined config");
+
+    fs::write(
+        &hats_path,
+        r#"event_loop:
+  starting_event: "design.start"
+  completion_promise: "HATS_DONE"
+  max_iterations: 150
+  max_runtime_seconds: 14400
+hats:
+  from_hats:
+    name: "from_hats"
+    description: "hats override"
+    triggers: ["design.start"]
+    publishes: ["HATS_DONE"]
+    default_publishes: "HATS_DONE"
+    instructions: |
+      Hats hat
+"#,
+    )
+    .expect("write hats file");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_ralph"))
+        .args([
+            "--color",
+            "never",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--hats",
+            hats_path.to_str().unwrap(),
+            "run",
+            "--dry-run",
+            "--skip-preflight",
+            "--prompt",
+            "test runtime precedence",
+            "--backend",
+            "claude",
+            "--no-tui",
+        ])
+        .current_dir(dir.path())
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("execute ralph");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "expected success; stderr: {stderr}\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Completion promise: HATS_DONE"),
+        "expected completion promise from hats; got stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Max iterations: 10"),
+        "expected max_iterations from core config; got stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Max runtime: 28800s"),
+        "expected max_runtime_seconds from core config; got stdout: {stdout}"
+    );
+}
+
 /// A `core.specs_dir=...` CLI override must be applied last (after both `-c`
 /// and `-H` are merged), overriding whatever value was in the combined config.
 #[test]


### PR DESCRIPTION
### Motivation
- Hats files were able to override `event_loop` runtime caps such as `max_iterations` and `max_runtime_seconds`, which should be controlled by core/combined config and CLI overrides. 
- The intent is to allow hats to adjust workflow-related behavior (e.g. which event completes the workflow) without changing safety/runtime limits. 
- Enforce a clear separation so runtime limits remain authoritative from core/combined config or CLI settings.

### Description
- Add `ALLOWED_HATS_EVENT_LOOP_OVERLAY_KEYS` and restrict merging of `hats.event_loop` so only keys in that allowlist (`completion_promise`, `starting_event`) are copied into the combined config. 
- Update `merge_hats_overlay` to filter overlayed `event_loop` keys and ignore any runtime-related keys such as `max_iterations` and `max_runtime_seconds`. 
- Add a unit test `merge_hats_overlay_ignores_runtime_limits_from_hats_event_loop` and an integration test `test_hats_file_does_not_override_runtime_limits_from_combined_config` to assert the new precedence behavior.

### Testing
- Ran the new unit test `merge_hats_overlay_ignores_runtime_limits_from_hats_event_loop`, which passed. 
- Ran the updated `crates/ralph-cli` integration tests including `test_hats_file_does_not_override_runtime_limits_from_combined_config`, which passed. 
- Ran the test suite (`cargo test`) locally to validate no regressions, and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acce38378c8333add88fff63197486)