### PR TITLE
fix: clear custom scratchpad path on fresh runs

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -131,7 +131,9 @@ pub async fn run_loop_impl(
 
         // Clear scratchpad for fresh objective start
         // Stale content from previous runs can confuse the agent about current task state
-        let scratchpad_path = ctx.scratchpad_path();
+        // Use the config's scratchpad path resolved against the workspace, not the
+        // hardcoded LoopContext default, so custom paths are properly cleared
+        let scratchpad_path = ctx.workspace().join(&config.core.scratchpad);
         if scratchpad_path.exists() {
             fs::remove_file(&scratchpad_path)
                 .with_context(|| format!("Failed to clear scratchpad: {:?}", scratchpad_path))?;

--- a/crates/ralph-cli/tests/integration_events_isolation.rs
+++ b/crates/ralph-cli/tests/integration_events_isolation.rs
@@ -606,6 +606,64 @@ fn test_new_run_ignores_stale_marker() -> Result<()> {
 }
 
 // =============================================================================
+// Scratchpad Cleanup Tests
+// =============================================================================
+
+#[test]
+fn test_fresh_run_clears_custom_scratchpad_path() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let temp_path = temp_dir.path();
+
+    // Config with a custom scratchpad path
+    let config = r#"
+event_loop:
+  prompt_file: "PROMPT.md"
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 1
+  max_runtime_seconds: 5
+
+cli:
+  backend: "custom"
+  command: "true"
+
+core:
+  scratchpad: ".ralph/debug/global.md"
+
+features:
+  preflight:
+    enabled: false
+"#;
+    fs::write(temp_path.join("ralph.yml"), config)?;
+    fs::write(temp_path.join("PROMPT.md"), "Test task")?;
+
+    // Create a stale scratchpad at the custom path
+    let custom_scratchpad = temp_path.join(".ralph/debug/global.md");
+    fs::create_dir_all(custom_scratchpad.parent().unwrap())?;
+    fs::write(&custom_scratchpad, "# Stale scratchpad\n- [ ] Old task\n")?;
+    assert!(
+        custom_scratchpad.exists(),
+        "Pre-condition: stale scratchpad should exist"
+    );
+
+    // Run ralph fresh
+    let _output = Command::new(ralph_bin())
+        .arg("run")
+        .arg("--config")
+        .arg(temp_path.join("ralph.yml"))
+        .current_dir(temp_path)
+        .output()?;
+
+    // The custom scratchpad should have been cleared
+    assert!(
+        !custom_scratchpad.exists(),
+        "Fresh run should clear the custom scratchpad at {:?}, but it still exists",
+        custom_scratchpad
+    );
+
+    Ok(())
+}
+
+// =============================================================================
 // Directory Structure Tests
 // =============================================================================
 


### PR DESCRIPTION
## What

Fix scratchpad cleanup at the start of `ralph run` to respect the configured `core.scratchpad` path instead of always targeting the hardcoded default (`.ralph/agent/scratchpad.md`).

## Why

When a user configures a custom scratchpad path (e.g., `core.scratchpad: ".ralph/debug/global.md"`), the cleanup code in `run_loop_impl` was using `LoopContext::scratchpad_path()`, which is hardcoded to `.ralph/agent/scratchpad.md`. This meant:

- The custom scratchpad was **never cleared** on fresh runs
- Stale content from previous runs would persist and confuse the agent
- Only the default path (which wasn't even being used) was deleted

## How

One-line change in `loop_runner.rs`: replace `ctx.scratchpad_path()` with `ctx.workspace().join(&config.core.scratchpad)`, which resolves the actual configured path against the workspace root.

Added an integration test that sets up a custom scratchpad path, writes stale content to it, runs `ralph run`, and verifies the file is properly cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)