### PR TITLE
fix: improve preset loop hygiene and fresh-run bootstrap

### DIFF
--- a/.claude/skills/code-task-generator/SKILL.md
+++ b/.claude/skills/code-task-generator/SKILL.md
@@ -3,8 +3,6 @@ name: code-task-generator
 description: Generates structured .code-task.md files from descriptions or PDD implementation plans. Auto-detects input type, creates properly formatted tasks with Given-When-Then acceptance criteria.
 type: anthropic-skill
 version: "1.1"
-metadata:
-  internal: true
 ---
 
 # Code Task Generator

--- a/crates/ralph-cli/presets/code-assist.yml
+++ b/crates/ralph-cli/presets/code-assist.yml
@@ -87,6 +87,9 @@ hats:
       - `task_id`
       - `task_key`
       - artifact path when the work is backed by a `.code-task.md` file
+      Emit `tasks.ready` with explicit JSON, for example:
+      - `ralph emit --json "tasks.ready" '{"task_id":"<task_id>","task_key":"<task_key>","artifact_path":"<artifact_path>"}'`
+      Never emit `tasks.ready` as a prose summary because the Builder needs the exact runtime-task identity from the payload.
 
       ### Read State
       On every activation:
@@ -133,15 +136,15 @@ hats:
       5. Choose Step 1 as the current step
       6. Ensure ONLY Step 1's runtime tasks using `ralph tools task ensure --description "..."`
       7. Write `progress.md` with the current step, the active wave's task keys, and empty completed-steps section
-      8. Pick exactly one ready runtime task from the Step 1 wave and publish `tasks.ready`
+      8. Pick exactly one ready runtime task from the Step 1 wave and publish `tasks.ready` with that task's `task_id`, `task_key`, and artifact path when applicable
       9. Once one ready runtime task exists and the shared docs are written, emit `tasks.ready` immediately. Do NOT keep refining later steps in the same turn.
 
       ### On Subsequent Activation (`queue.advance`)
       1. Re-read `<ready-tasks>`, `plan.md`, `progress.md`, and `.ralph/agent/tasks.jsonl`
       2. Identify the current step from `progress.md`
-      3. If ready or open tasks already exist for the current step, publish `tasks.ready` for the next one in that same wave
+      3. If ready or open tasks already exist for the current step, publish `tasks.ready` with the next task's `task_id`, `task_key`, and artifact path when applicable
       4. If the current step's wave is fully closed, move that step to `## Completed Steps`
-      5. If another numbered step remains, update `## Current Step`, ensure ONLY that next step's runtime tasks, refresh `## Active Wave`, and publish `tasks.ready`
+      5. If another numbered step remains, update `## Current Step`, ensure ONLY that next step's runtime tasks, refresh `## Active Wave`, and publish `tasks.ready` with the selected task identity
       6. If no numbered steps remain, do not invent more tasks; leave the queue empty so the Finalizer can terminate after the last reviewed task
       7. Do not spend the turn polishing docs once a ready task exists; emit immediately.
 
@@ -281,7 +284,8 @@ hats:
          - Save concise command/result notes in `progress.md`
          - Save substantive command output in `logs/` when useful
          - If this turn runs long, send `ralph tools interact progress`
-         - Then hand the increment to the Critic with `task_id`, `task_key`, and artifact path
+         - Then hand the increment to the Critic with `task_id`, `task_key`, and artifact path using `ralph emit --json "review.ready" '{"task_id":"<task_id>","task_key":"<task_key>","artifact_path":"<artifact_path>"}'`
+         - Leave the runtime task `open` while it is under review; Finalizer owns `task close` / `task reopen`
          - Once the task description is satisfied and the focused checks pass, emit promptly. Do not spend the rest of the turn narrating the work.
          - If a setup or test command fails once, inspect the files it wrote and move to the next concrete action. Do not spend the rest of the turn retrying environment probes.
 
@@ -298,6 +302,7 @@ hats:
       - You MUST implement the runtime task from the current payload, not the next thing in `progress.md`
       - You MUST NOT write implementation before tests
       - You MUST NOT add features not in the task/description
+      - You MUST NOT close or reopen the runtime task yourself; Finalizer owns completion state after review
       - You MUST follow codebase patterns when available
       - You MUST keep implementation code out of the shared docs directory
       - You MUST update `progress.md` as evidence/logging, not as the scheduler
@@ -391,7 +396,10 @@ hats:
       - or over-engineering/material style mismatch worth fixing now.
 
       Publish `review.passed` only when the increment looks correct enough for the Finalizer to evaluate overall completion.
-      In both pass/reject cases, include the same `task_id` and `task_key` in the payload.
+      Emit exactly one of `review.passed` or `review.rejected` yourself for every review turn.
+      In both pass/reject cases, include the same `task_id`, `task_key`, and artifact path from `review.ready` in the payload plus a concise evidence summary.
+      `default_publishes: "review.rejected"` is only a crash guard. It is NOT a valid success path because its empty payload loses runtime-task ownership on retry.
+      If you reject the increment, make the rejection actionable and preserve task identity so the Builder retries the same runtime task instead of drifting to a different one.
       For scaffold/setup slices, judge the task against its own acceptance criteria. Do not reject because future tasks have not been implemented yet.
 
       If you discover a durable repo-wide pattern or recurring fix, record it with `ralph tools memory add`.

--- a/crates/ralph-cli/presets/pdd-to-code-assist.yml
+++ b/crates/ralph-cli/presets/pdd-to-code-assist.yml
@@ -95,6 +95,7 @@ hats:
       Ask questions that address the specific concerns raised.
 
       Every `question.asked` and `requirements.complete` payload MUST include the active `task_id` and `task_key`.
+      For custom workflows, prefer an explicit `workflow_key` (or `phase_key`) in the payload. When absent, Ralph falls back to deriving the workflow lane from `task_key`.
 
       ### Constraints
       - You MUST NOT ask multiple questions at once because this overwhelms users and leads to incomplete responses
@@ -130,7 +131,7 @@ hats:
       3. Research if needed (explore codebase, check patterns)
       4. Provide a clear, specific answer
       5. Append the answer to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
-      6. Publish `answer.proposed` with the active `task_id` and `task_key`
+      6. Publish `answer.proposed` with the active `task_id`, `task_key`, and preferably an explicit `workflow_key` (or `phase_key`) for custom workflows
 
       ### When Triggered by requirements.complete
       Synthesize all Q&A into a detailed design document.

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -56,6 +56,29 @@ struct RpcSharedState {
     total_cost_usd: Arc<std::sync::Mutex<f64>>,
 }
 
+fn reset_scratchpad_for_fresh_run(scratchpad_path: &Path) -> Result<()> {
+    if let Some(parent) = scratchpad_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create scratchpad parent directory: {:?}",
+                parent
+            )
+        })?;
+    }
+
+    fs::write(scratchpad_path, "").with_context(|| {
+        format!(
+            "Failed to reset scratchpad for fresh objective: {:?}",
+            scratchpad_path
+        )
+    })?;
+    debug!(
+        "Reset scratchpad for fresh objective: {:?}",
+        scratchpad_path
+    );
+    Ok(())
+}
+
 /// Core loop implementation supporting both fresh start and continue modes.
 ///
 /// # Arguments
@@ -152,17 +175,9 @@ pub async fn run_loop_impl(
 
         debug!("Created events file for this run: {}", relative_events_path);
 
-        // Clear scratchpad for fresh objective start
-        // Stale content from previous runs can confuse the agent about current task state
-        let scratchpad_path = ctx.scratchpad_path();
-        if scratchpad_path.exists() {
-            fs::remove_file(&scratchpad_path)
-                .with_context(|| format!("Failed to clear scratchpad: {:?}", scratchpad_path))?;
-            debug!(
-                "Cleared scratchpad for fresh objective: {:?}",
-                scratchpad_path
-            );
-        }
+        // Reset scratchpad for fresh objective start while preserving the planner artifact.
+        // Stale content from previous runs can confuse the agent about current task state.
+        reset_scratchpad_for_fresh_run(&ctx.scratchpad_path())?;
     }
 
     // Initialize event loop with context for proper path resolution
@@ -8904,5 +8919,29 @@ hats:
             r#"[Tool] Bash: ralph emit "hypothesis.test" "payload""#
         ));
         assert!(!output_mentions_ralph_emit("[Tool] Bash: cargo test"));
+    }
+
+    #[test]
+    fn test_reset_scratchpad_for_fresh_run_clears_existing_content() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let scratchpad_path = temp_dir.path().join(".ralph/agent/scratchpad.md");
+        std::fs::create_dir_all(scratchpad_path.parent().expect("parent")).expect("create parent");
+        std::fs::write(&scratchpad_path, "stale content").expect("seed scratchpad");
+
+        reset_scratchpad_for_fresh_run(&scratchpad_path).expect("reset scratchpad");
+
+        assert!(scratchpad_path.exists());
+        assert_eq!(std::fs::read_to_string(&scratchpad_path).unwrap(), "");
+    }
+
+    #[test]
+    fn test_reset_scratchpad_for_fresh_run_creates_missing_file() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let scratchpad_path = temp_dir.path().join(".ralph/agent/scratchpad.md");
+
+        reset_scratchpad_for_fresh_run(&scratchpad_path).expect("create scratchpad");
+
+        assert!(scratchpad_path.exists());
+        assert_eq!(std::fs::read_to_string(&scratchpad_path).unwrap(), "");
     }
 }

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -59,10 +59,7 @@ struct RpcSharedState {
 fn reset_scratchpad_for_fresh_run(scratchpad_path: &Path) -> Result<()> {
     if let Some(parent) = scratchpad_path.parent() {
         fs::create_dir_all(parent).with_context(|| {
-            format!(
-                "Failed to create scratchpad parent directory: {:?}",
-                parent
-            )
+            format!("Failed to create scratchpad parent directory: {:?}", parent)
         })?;
     }
 

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -481,15 +481,18 @@ fn bootstrap_prompt_artifacts_for_worktree(
 
     let target_prompt_path = target_workspace_root.join(relative_prompt_path);
 
-    let implementation_root = Path::new(".agents").join("scratchpad").join("implementation");
+    let implementation_root = Path::new(".agents")
+        .join("scratchpad")
+        .join("implementation");
     let source_copy_root = relative_prompt_path
         .strip_prefix(&implementation_root)
         .ok()
         .and_then(|suffix| {
-            suffix
-                .components()
-                .next()
-                .map(|component| source_workspace_root.join(&implementation_root).join(component))
+            suffix.components().next().map(|component| {
+                source_workspace_root
+                    .join(&implementation_root)
+                    .join(component)
+            })
         })
         .unwrap_or(source_prompt_path.clone());
 
@@ -3558,15 +3561,18 @@ core:
             .join(".agents/scratchpad/implementation/preset-loop-hygiene");
 
         std::fs::create_dir_all(&implementation_dir).unwrap();
-        std::fs::write(implementation_dir.join("next-slice.md"), "restore bootstrap").unwrap();
+        std::fs::write(
+            implementation_dir.join("next-slice.md"),
+            "restore bootstrap",
+        )
+        .unwrap();
         std::fs::write(implementation_dir.join("context.md"), "context").unwrap();
         std::fs::write(implementation_dir.join("plan.md"), "plan").unwrap();
         std::fs::write(implementation_dir.join("progress.md"), "progress").unwrap();
 
         let mut config = RalphConfig::default();
-        config.event_loop.prompt = Some(
-            ".agents/scratchpad/implementation/preset-loop-hygiene/next-slice.md".to_string(),
-        );
+        config.event_loop.prompt =
+            Some(".agents/scratchpad/implementation/preset-loop-hygiene/next-slice.md".to_string());
 
         bootstrap_prompt_artifacts_for_worktree(source_root.path(), target_root.path(), &config)
             .expect("copy implementation packet");

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -429,6 +429,115 @@ pub(crate) fn ensure_scratchpad_directory(config: &RalphConfig) -> anyhow::Resul
     Ok(())
 }
 
+fn ensure_file_exists(path: &Path) -> anyhow::Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent()
+        && !parent.exists()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    std::fs::write(path, "")?;
+    Ok(())
+}
+
+fn maybe_resolve_bootstrap_prompt_path(
+    workspace_root: &Path,
+    config: &RalphConfig,
+) -> Option<PathBuf> {
+    let inline_prompt = config.event_loop.prompt.as_deref()?.trim();
+    if inline_prompt.is_empty() || inline_prompt.contains('\n') {
+        return None;
+    }
+
+    let candidate = Path::new(inline_prompt);
+    let resolved = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        workspace_root.join(candidate)
+    };
+
+    resolved.is_file().then_some(resolved)
+}
+
+fn bootstrap_prompt_artifacts_for_worktree(
+    source_workspace_root: &Path,
+    target_workspace_root: &Path,
+    config: &RalphConfig,
+) -> anyhow::Result<()> {
+    let Some(source_prompt_path) =
+        maybe_resolve_bootstrap_prompt_path(source_workspace_root, config)
+    else {
+        return Ok(());
+    };
+
+    let relative_prompt_path = match source_prompt_path.strip_prefix(source_workspace_root) {
+        Ok(path) => path,
+        Err(_) => return Ok(()),
+    };
+
+    let target_prompt_path = target_workspace_root.join(relative_prompt_path);
+
+    let implementation_root = Path::new(".agents").join("scratchpad").join("implementation");
+    let source_copy_root = relative_prompt_path
+        .strip_prefix(&implementation_root)
+        .ok()
+        .and_then(|suffix| {
+            suffix
+                .components()
+                .next()
+                .map(|component| source_workspace_root.join(&implementation_root).join(component))
+        })
+        .unwrap_or(source_prompt_path.clone());
+
+    if source_copy_root.is_dir() {
+        copy_dir_recursive(
+            &source_copy_root,
+            &target_workspace_root.join(
+                source_copy_root
+                    .strip_prefix(source_workspace_root)
+                    .expect("copy root is under workspace"),
+            ),
+        )?;
+    } else {
+        if let Some(parent) = target_prompt_path.parent()
+            && !parent.exists()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(&source_prompt_path, &target_prompt_path)?;
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dst)?;
+
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let source_path = entry.path();
+        let target_path = dst.join(entry.file_name());
+
+        if file_type.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else {
+            if let Some(parent) = target_path.parent()
+                && !parent.exists()
+            {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(&source_path, &target_path)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Loads configuration from file sources with override support.
 ///
 /// This is the common sync path used by resume_command and clean_command.
@@ -1539,7 +1648,7 @@ async fn run_command(
     // Try to acquire the loop lock for multi-loop concurrency support
     // This implements the lock detection flow from the multi-loop spec
     // Skip lock acquisition in subprocess TUI mode - let the child acquire it
-    let workspace_root = &config.core.workspace_root;
+    let workspace_root = config.core.workspace_root.clone();
     let (loop_context, _lock_guard) = if use_subprocess_tui {
         // In subprocess TUI mode, don't acquire lock here - the child RPC process will do it
         // This avoids the self-lock contention where parent holds lock and child sees it,
@@ -1548,7 +1657,7 @@ async fn run_command(
         let context = LoopContext::primary(workspace_root.clone());
         (context, None)
     } else {
-        match LoopLock::try_acquire(workspace_root, &prompt_summary) {
+        match LoopLock::try_acquire(&workspace_root, &prompt_summary) {
             Ok(guard) => {
                 // We're the primary loop - run in place
                 debug!("Acquired loop lock, running as primary loop");
@@ -1563,7 +1672,7 @@ async fn run_command(
                         "Loop lock held by PID {} (started {}), waiting for lock (--exclusive mode)...",
                         existing.pid, existing.started
                     );
-                    let guard = LoopLock::acquire_blocking(workspace_root, &prompt_summary)
+                    let guard = LoopLock::acquire_blocking(&workspace_root, &prompt_summary)
                         .context("Failed to acquire loop lock in exclusive mode")?;
                     debug!("Acquired loop lock after waiting");
                     let context = LoopContext::primary(workspace_root.clone());
@@ -1592,15 +1701,15 @@ async fn run_command(
                     let name_generator =
                         ralph_core::LoopNameGenerator::from_config(&config.features.loop_naming);
                     let loop_id = name_generator.generate_memorable_unique(|name| {
-                        ralph_core::worktree_exists(workspace_root, name, &worktree_config)
+                        ralph_core::worktree_exists(&workspace_root, name, &worktree_config)
                     });
 
                     // Ensure worktree directory is in .gitignore
-                    ensure_gitignore(workspace_root, ".worktrees")
+                    ensure_gitignore(&workspace_root, ".worktrees")
                         .context("Failed to update .gitignore for worktrees")?;
 
                     // Create the worktree
-                    let worktree = create_worktree(workspace_root, &loop_id, &worktree_config)
+                    let worktree = create_worktree(&workspace_root, &loop_id, &worktree_config)
                         .context("Failed to create worktree for parallel loop")?;
 
                     info!(
@@ -1671,6 +1780,13 @@ async fn run_command(
     loop_context
         .ensure_directories()
         .context("Failed to create loop directories")?;
+    ensure_file_exists(&loop_context.scratchpad_path())
+        .context("Failed to bootstrap loop scratchpad")?;
+
+    if !loop_context.is_primary() {
+        bootstrap_prompt_artifacts_for_worktree(&workspace_root, loop_context.workspace(), &config)
+            .context("Failed to bootstrap worktree prompt artifacts")?;
+    }
 
     if let Err(err) = run_auto_preflight(
         &config,
@@ -2973,7 +3089,8 @@ mod tests {
         std::fs::create_dir_all(&nested).expect("nested dir");
         let _cwd = CwdGuard::set(&nested);
 
-        assert_eq!(resolve_workspace_root(None), temp_dir.path().to_path_buf());
+        let expected_root = std::fs::canonicalize(temp_dir.path()).expect("canonical root");
+        assert_eq!(resolve_workspace_root(None), expected_root);
     }
 
     #[test]
@@ -3419,6 +3536,121 @@ core:
 
         // Assert: returns "[no prompt]" for missing file
         assert_eq!(prompt_summary, "[no prompt]");
+    }
+
+    #[test]
+    fn test_ensure_file_exists_bootstraps_missing_scratchpad_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let scratchpad_path = temp_dir.path().join(".ralph/agent/scratchpad.md");
+
+        ensure_file_exists(&scratchpad_path).expect("bootstrap scratchpad");
+
+        assert!(scratchpad_path.exists());
+        assert_eq!(std::fs::read_to_string(&scratchpad_path).unwrap(), "");
+    }
+
+    #[test]
+    fn test_bootstrap_prompt_artifacts_for_worktree_copies_implementation_packet() {
+        let source_root = tempfile::tempdir().unwrap();
+        let target_root = tempfile::tempdir().unwrap();
+        let implementation_dir = source_root
+            .path()
+            .join(".agents/scratchpad/implementation/preset-loop-hygiene");
+
+        std::fs::create_dir_all(&implementation_dir).unwrap();
+        std::fs::write(implementation_dir.join("next-slice.md"), "restore bootstrap").unwrap();
+        std::fs::write(implementation_dir.join("context.md"), "context").unwrap();
+        std::fs::write(implementation_dir.join("plan.md"), "plan").unwrap();
+        std::fs::write(implementation_dir.join("progress.md"), "progress").unwrap();
+
+        let mut config = RalphConfig::default();
+        config.event_loop.prompt = Some(
+            ".agents/scratchpad/implementation/preset-loop-hygiene/next-slice.md".to_string(),
+        );
+
+        bootstrap_prompt_artifacts_for_worktree(source_root.path(), target_root.path(), &config)
+            .expect("copy implementation packet");
+
+        let copied_dir = target_root
+            .path()
+            .join(".agents/scratchpad/implementation/preset-loop-hygiene");
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("next-slice.md")).unwrap(),
+            "restore bootstrap"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("context.md")).unwrap(),
+            "context"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("plan.md")).unwrap(),
+            "plan"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("progress.md")).unwrap(),
+            "progress"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_prompt_artifacts_for_worktree_copies_packet_for_numbered_slice_prompt() {
+        let source_root = tempfile::tempdir().unwrap();
+        let target_root = tempfile::tempdir().unwrap();
+        let implementation_dir = source_root
+            .path()
+            .join(".agents/scratchpad/implementation/preset-loop-hygiene");
+
+        std::fs::create_dir_all(&implementation_dir).unwrap();
+        std::fs::write(implementation_dir.join("next-slice.md"), "slice 1").unwrap();
+        std::fs::write(implementation_dir.join("next-slice-2.md"), "slice 2").unwrap();
+        std::fs::write(implementation_dir.join("context.md"), "context").unwrap();
+        std::fs::write(implementation_dir.join("plan.md"), "plan").unwrap();
+        std::fs::write(implementation_dir.join("progress.md"), "progress").unwrap();
+
+        let mut config = RalphConfig::default();
+        config.event_loop.prompt = Some(
+            ".agents/scratchpad/implementation/preset-loop-hygiene/next-slice-2.md".to_string(),
+        );
+
+        bootstrap_prompt_artifacts_for_worktree(source_root.path(), target_root.path(), &config)
+            .expect("copy implementation packet");
+
+        let copied_dir = target_root
+            .path()
+            .join(".agents/scratchpad/implementation/preset-loop-hygiene");
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("next-slice.md")).unwrap(),
+            "slice 1"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("next-slice-2.md")).unwrap(),
+            "slice 2"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("context.md")).unwrap(),
+            "context"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("plan.md")).unwrap(),
+            "plan"
+        );
+        assert_eq!(
+            std::fs::read_to_string(copied_dir.join("progress.md")).unwrap(),
+            "progress"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_prompt_artifacts_for_worktree_ignores_freeform_prompt_text() {
+        let source_root = tempfile::tempdir().unwrap();
+        let target_root = tempfile::tempdir().unwrap();
+        let mut config = RalphConfig::default();
+        config.event_loop.prompt = Some("Implement the missing bootstrap".to_string());
+
+        bootstrap_prompt_artifacts_for_worktree(source_root.path(), target_root.path(), &config)
+            .expect("ignore non-path prompt");
+
+        assert!(!target_root.path().join(".agents").exists());
     }
 
     #[test]

--- a/crates/ralph-cli/src/mcp.rs
+++ b/crates/ralph-cli/src/mcp.rs
@@ -59,6 +59,10 @@ mod tests {
     use anyhow::Result;
     use std::path::PathBuf;
 
+    fn normalize_test_path(path: &std::path::Path) -> String {
+        path.to_string_lossy().replace("/private/var/", "/var/")
+    }
+
     #[test]
     fn resolve_workspace_root_returns_none_when_unset() -> Result<()> {
         assert_eq!(resolve_workspace_root(None)?, None);
@@ -78,7 +82,11 @@ mod tests {
         let _guard = CwdGuard::set(temp_dir.path());
 
         let resolved = resolve_workspace_root(Some(PathBuf::from("nested/workspace")))?;
-        assert_eq!(resolved, Some(temp_dir.path().join("nested/workspace")));
+        let expected = temp_dir.path().join("nested/workspace");
+        assert_eq!(
+            resolved.as_deref().map(normalize_test_path),
+            Some(normalize_test_path(&expected))
+        );
         Ok(())
     }
 }

--- a/crates/ralph-cli/src/presets.rs
+++ b/crates/ralph-cli/src/presets.rs
@@ -91,7 +91,9 @@ pub fn preset_names() -> Vec<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ralph_core::RalphConfig;
+    use ralph_core::{EventLoop, RalphConfig};
+    use ralph_proto::{Event, HatId};
+    use serde_json::Value;
 
     fn assert_public_preset_has_completion_path(preset: &EmbeddedPreset) {
         let config =
@@ -257,9 +259,17 @@ mod tests {
     #[test]
     fn test_code_assist_matches_autonomous_task_loop_contract() {
         let preset = get_preset("code-assist").expect("code-assist should exist");
-        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
-        assert_hats_exist(&config, preset.name, &["planner", "builder", "critic", "finalizer"]);
-        assert_eq!(config.event_loop.starting_event.as_deref(), Some("build.start"));
+        let config =
+            RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        assert_hats_exist(
+            &config,
+            preset.name,
+            &["planner", "builder", "critic", "finalizer"],
+        );
+        assert_eq!(
+            config.event_loop.starting_event.as_deref(),
+            Some("build.start")
+        );
         assert_eq!(config.event_loop.completion_promise, "LOOP_COMPLETE");
         assert_only_hat_publishes_completion(&config, preset.name, "LOOP_COMPLETE", "finalizer");
     }
@@ -267,9 +277,13 @@ mod tests {
     #[test]
     fn test_review_matches_autonomous_review_loop_contract() {
         let preset = get_preset("review").expect("review should exist");
-        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        let config =
+            RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
         assert_hats_exist(&config, preset.name, &["reviewer", "analyzer", "closer"]);
-        assert_eq!(config.event_loop.starting_event.as_deref(), Some("review.start"));
+        assert_eq!(
+            config.event_loop.starting_event.as_deref(),
+            Some("review.start")
+        );
         assert_eq!(config.event_loop.completion_promise, "REVIEW_COMPLETE");
         assert_only_hat_publishes_completion(&config, preset.name, "REVIEW_COMPLETE", "closer");
     }
@@ -277,21 +291,43 @@ mod tests {
     #[test]
     fn test_debug_matches_autonomous_debug_loop_contract() {
         let preset = get_preset("debug").expect("debug should exist");
-        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
-        assert_hats_exist(&config, preset.name, &["investigator", "tester", "fixer", "verifier"]);
-        assert_eq!(config.event_loop.starting_event.as_deref(), Some("debug.start"));
+        let config =
+            RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        assert_hats_exist(
+            &config,
+            preset.name,
+            &["investigator", "tester", "fixer", "verifier"],
+        );
+        assert_eq!(
+            config.event_loop.starting_event.as_deref(),
+            Some("debug.start")
+        );
         assert_eq!(config.event_loop.completion_promise, "DEBUG_COMPLETE");
-        assert_only_hat_publishes_completion(&config, preset.name, "DEBUG_COMPLETE", "investigator");
+        assert_only_hat_publishes_completion(
+            &config,
+            preset.name,
+            "DEBUG_COMPLETE",
+            "investigator",
+        );
     }
 
     #[test]
     fn test_research_matches_autonomous_research_loop_contract() {
         let preset = get_preset("research").expect("research should exist");
-        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        let config =
+            RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
         assert_hats_exist(&config, preset.name, &["researcher", "synthesizer"]);
-        assert_eq!(config.event_loop.starting_event.as_deref(), Some("research.start"));
+        assert_eq!(
+            config.event_loop.starting_event.as_deref(),
+            Some("research.start")
+        );
         assert_eq!(config.event_loop.completion_promise, "RESEARCH_COMPLETE");
-        assert_only_hat_publishes_completion(&config, preset.name, "RESEARCH_COMPLETE", "synthesizer");
+        assert_only_hat_publishes_completion(
+            &config,
+            preset.name,
+            "RESEARCH_COMPLETE",
+            "synthesizer",
+        );
     }
 
     #[test]
@@ -367,6 +403,12 @@ mod tests {
                 .instructions
                 .contains("ralph tools task show <task_id> --format json")
         );
+        assert!(critic.instructions.contains(
+            "Emit exactly one of `review.passed` or `review.rejected` yourself for every review turn."
+        ));
+        assert!(critic.instructions.contains(
+            "its empty payload loses runtime-task ownership on retry"
+        ));
         assert!(critic.instructions.contains("ralph tools memory add"));
 
         let finalizer = config
@@ -468,6 +510,64 @@ mod tests {
     }
 
     #[test]
+    fn test_pdd_to_code_assist_preserves_review_identity_on_critic_timeout_fallback() {
+        let preset = get_preset("pdd-to-code-assist").expect("pdd-to-code-assist should exist");
+        let config =
+            RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+
+        let mut event_loop = EventLoop::new(config);
+        event_loop.initialize("Test prompt");
+        let _ = event_loop.bus().take_pending(&HatId::new("ralph"));
+
+        event_loop.bus().publish(Event::new(
+            "review.ready",
+            serde_json::json!({
+                "task_id": "task-1773251265-ef7f",
+                "task_key": "preset-contract-alignment:step-03:pdd-build-review",
+                "workflow_key": "preset-contract-alignment:step-03",
+                "artifact_path": ".agents/scratchpad/implementation/cli-status-checker/implementation.md",
+                "summary": "Ready for critic review."
+            })
+            .to_string(),
+        ));
+
+        event_loop
+            .build_prompt(&HatId::new("ralph"))
+            .expect("prompt should build for critic review");
+
+        event_loop.check_default_publishes(&HatId::new("critic"));
+
+        let builder_events = event_loop.bus().take_pending(&HatId::new("builder"));
+        let fallback = builder_events
+            .iter()
+            .find(|event| event.topic.as_str() == "review.rejected")
+            .expect("critic fallback should publish review.rejected");
+
+        assert_eq!(
+            fallback.source.as_ref().map(HatId::as_str),
+            Some("critic"),
+            "fallback reject should be attributed to the critic hat"
+        );
+
+        let payload: Value = serde_json::from_str(&fallback.payload)
+            .expect("fallback review payload should be valid JSON");
+        assert_eq!(payload["task_id"], serde_json::json!("task-1773251265-ef7f"));
+        assert_eq!(
+            payload["task_key"],
+            serde_json::json!("preset-contract-alignment:step-03:pdd-build-review")
+        );
+        assert_eq!(
+            payload["workflow_key"],
+            serde_json::json!("preset-contract-alignment:step-03")
+        );
+        assert_eq!(
+            payload["fallback_reason"],
+            serde_json::json!("agent_idle_timeout")
+        );
+        assert_eq!(payload["source_topic"], serde_json::json!("review.ready"));
+    }
+
+    #[test]
     fn test_code_assist_uses_upstream_artifact_layout_and_builder_workflow() {
         let preset = get_preset("code-assist").expect("code-assist should exist");
         let config =
@@ -519,6 +619,14 @@ mod tests {
         );
         assert!(planner.instructions.contains("`task_id`"));
         assert!(planner.instructions.contains("`task_key`"));
+        assert!(planner.instructions.contains(
+            "ralph emit --json \"tasks.ready\" '{\"task_id\":\"<task_id>\",\"task_key\":\"<task_key>\",\"artifact_path\":\"<artifact_path>\"}'"
+        ));
+        assert!(
+            planner
+                .instructions
+                .contains("Never emit `tasks.ready` as a prose summary")
+        );
         assert!(planner.instructions.contains("context.md"));
         assert!(planner.instructions.contains("plan.md"));
         assert!(planner.instructions.contains("progress.md"));
@@ -570,6 +678,14 @@ mod tests {
         ));
         assert!(builder.instructions.contains("VALIDATE THE INCREMENT"));
         assert!(
+            builder.instructions.contains(
+                "ralph emit --json \"review.ready\" '{\"task_id\":\"<task_id>\",\"task_key\":\"<task_key>\",\"artifact_path\":\"<artifact_path>\"}'"
+            )
+        );
+        assert!(builder.instructions.contains(
+            "Leave the runtime task `open` while it is under review; Finalizer owns `task close` / `task reopen`"
+        ));
+        assert!(
             builder
                 .instructions
                 .contains("You MUST keep implementation code out of the shared docs directory")
@@ -584,6 +700,9 @@ mod tests {
                 .instructions
                 .contains("You MUST implement the runtime task from the current payload")
         );
+        assert!(builder.instructions.contains(
+            "You MUST NOT close or reopen the runtime task yourself; Finalizer owns completion state after review"
+        ));
         assert!(builder.instructions.contains(
             "finish with a minimally runnable skeleton that satisfies the task description"
         ));
@@ -941,6 +1060,15 @@ mod tests {
                 .instructions
                 .contains("On `debug.start` or `hypothesis.rejected`:")
         );
+        assert!(investigator.instructions.contains(
+            "During investigation you may add only the minimal failing scaffold and failing-or-observational reproduction coverage needed to make the current bug visible."
+        ));
+        assert!(investigator.instructions.contains(
+            "Do not add fixed-path implementations, alternate \"correct\" functions, or regression coverage for the intended fix in this phase."
+        ));
+        assert!(investigator.instructions.contains(
+            "Do not write `.eval-sandbox/debug/counter.md` or any root-cause note in this phase; that belongs with the fix once the hypothesis is confirmed."
+        ));
         assert!(investigator
             .instructions
             .contains("If the bug is already fixed, cannot be reproduced, or an existing debug note already captures the answer"));
@@ -994,6 +1122,14 @@ mod tests {
             investigator
                 .instructions
                 .contains("❌ Skip the event chain by doing fix or verification work inline")
+        );
+        assert!(investigator.instructions.contains(
+            "❌ Add fixed-path code, \"fixed\" helper functions, or fix-oriented regression tests before `hypothesis.confirmed`"
+        ));
+        assert!(
+            investigator
+                .instructions
+                .contains("❌ Write the root-cause/debug note before the fix phase")
         );
 
         let tester = config.hats.get("tester").expect("tester hat should exist");

--- a/crates/ralph-cli/src/presets.rs
+++ b/crates/ralph-cli/src/presets.rs
@@ -125,6 +125,36 @@ mod tests {
         );
     }
 
+    fn assert_hats_exist(config: &RalphConfig, preset_name: &str, hats: &[&str]) {
+        for hat in hats {
+            assert!(
+                config.hats.contains_key(*hat),
+                "Preset '{}' should define hat '{}'",
+                preset_name,
+                hat
+            );
+        }
+    }
+
+    fn assert_only_hat_publishes_completion(
+        config: &RalphConfig,
+        preset_name: &str,
+        completion_topic: &str,
+        owner_hat: &str,
+    ) {
+        for (hat_id, hat) in &config.hats {
+            let publishes_completion = hat.publishes.iter().any(|topic| topic == completion_topic)
+                || hat.default_publishes.as_deref() == Some(completion_topic);
+            if publishes_completion {
+                assert_eq!(
+                    hat_id, owner_hat,
+                    "Preset '{}' should have completion topic '{}' owned by '{}', not '{}'",
+                    preset_name, completion_topic, owner_hat, hat_id
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_list_presets_returns_all() {
         let presets = list_presets();
@@ -222,6 +252,46 @@ mod tests {
         for preset in PRESETS.iter().filter(|preset| preset.public) {
             assert_public_preset_has_required_events(preset);
         }
+    }
+
+    #[test]
+    fn test_code_assist_matches_autonomous_task_loop_contract() {
+        let preset = get_preset("code-assist").expect("code-assist should exist");
+        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        assert_hats_exist(&config, preset.name, &["planner", "builder", "critic", "finalizer"]);
+        assert_eq!(config.event_loop.starting_event.as_deref(), Some("build.start"));
+        assert_eq!(config.event_loop.completion_promise, "LOOP_COMPLETE");
+        assert_only_hat_publishes_completion(&config, preset.name, "LOOP_COMPLETE", "finalizer");
+    }
+
+    #[test]
+    fn test_review_matches_autonomous_review_loop_contract() {
+        let preset = get_preset("review").expect("review should exist");
+        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        assert_hats_exist(&config, preset.name, &["reviewer", "analyzer", "closer"]);
+        assert_eq!(config.event_loop.starting_event.as_deref(), Some("review.start"));
+        assert_eq!(config.event_loop.completion_promise, "REVIEW_COMPLETE");
+        assert_only_hat_publishes_completion(&config, preset.name, "REVIEW_COMPLETE", "closer");
+    }
+
+    #[test]
+    fn test_debug_matches_autonomous_debug_loop_contract() {
+        let preset = get_preset("debug").expect("debug should exist");
+        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        assert_hats_exist(&config, preset.name, &["investigator", "tester", "fixer", "verifier"]);
+        assert_eq!(config.event_loop.starting_event.as_deref(), Some("debug.start"));
+        assert_eq!(config.event_loop.completion_promise, "DEBUG_COMPLETE");
+        assert_only_hat_publishes_completion(&config, preset.name, "DEBUG_COMPLETE", "investigator");
+    }
+
+    #[test]
+    fn test_research_matches_autonomous_research_loop_contract() {
+        let preset = get_preset("research").expect("research should exist");
+        let config = RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+        assert_hats_exist(&config, preset.name, &["researcher", "synthesizer"]);
+        assert_eq!(config.event_loop.starting_event.as_deref(), Some("research.start"));
+        assert_eq!(config.event_loop.completion_promise, "RESEARCH_COMPLETE");
+        assert_only_hat_publishes_completion(&config, preset.name, "RESEARCH_COMPLETE", "synthesizer");
     }
 
     #[test]

--- a/crates/ralph-cli/src/presets.rs
+++ b/crates/ralph-cli/src/presets.rs
@@ -406,9 +406,11 @@ mod tests {
         assert!(critic.instructions.contains(
             "Emit exactly one of `review.passed` or `review.rejected` yourself for every review turn."
         ));
-        assert!(critic.instructions.contains(
-            "its empty payload loses runtime-task ownership on retry"
-        ));
+        assert!(
+            critic
+                .instructions
+                .contains("its empty payload loses runtime-task ownership on retry")
+        );
         assert!(critic.instructions.contains("ralph tools memory add"));
 
         let finalizer = config
@@ -551,7 +553,10 @@ mod tests {
 
         let payload: Value = serde_json::from_str(&fallback.payload)
             .expect("fallback review payload should be valid JSON");
-        assert_eq!(payload["task_id"], serde_json::json!("task-1773251265-ef7f"));
+        assert_eq!(
+            payload["task_id"],
+            serde_json::json!("task-1773251265-ef7f")
+        );
         assert_eq!(
             payload["task_key"],
             serde_json::json!("preset-contract-alignment:step-03:pdd-build-review")

--- a/crates/ralph-cli/src/task_cli.rs
+++ b/crates/ralph-cli/src/task_cli.rs
@@ -819,6 +819,11 @@ fn execute_reopen(args: ReopenArgs, root: Option<&PathBuf>, use_colors: bool) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn normalize_test_path(path: &std::path::Path) -> String {
+        path.to_string_lossy().replace("/private/var/", "/var/")
+    }
+
     use crate::test_support::CwdGuard;
     use std::path::Path;
     use tempfile::TempDir;
@@ -903,6 +908,8 @@ mod tests {
         std::fs::create_dir_all(&nested).expect("nested dir");
         let _cwd = CwdGuard::set(&nested);
 
-        assert_eq!(get_tasks_path(None), root.join(".ralph/agent/tasks.jsonl"));
+        let actual = get_tasks_path(None);
+        let expected = root.join(".ralph/agent/tasks.jsonl");
+        assert_eq!(normalize_test_path(&actual), normalize_test_path(&expected));
     }
 }

--- a/crates/ralph-core/src/event_loop/loop_state.rs
+++ b/crates/ralph-core/src/event_loop/loop_state.rs
@@ -17,6 +17,12 @@ pub struct EventSignature {
     pub payload_fingerprint: u64,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PhaseLockState {
+    pub requirements_locked: bool,
+    pub design_locked: bool,
+}
+
 /// Current state of the event loop.
 #[derive(Debug)]
 pub struct LoopState {
@@ -70,6 +76,12 @@ pub struct LoopState {
 
     /// Set to true when a loop.cancel event is detected.
     pub cancellation_requested: bool,
+
+    /// Last accepted handoff signature per logical handoff lane (`topic:task_key`).
+    pub handoff_signatures: HashMap<String, u64>,
+
+    /// Monotonic workflow phase locks keyed by shared task-key prefix.
+    pub phase_locks: HashMap<String, PhaseLockState>,
 }
 
 impl Default for LoopState {
@@ -95,6 +107,8 @@ impl Default for LoopState {
             last_emitted_signature: None,
             consecutive_same_signature: 0,
             cancellation_requested: false,
+            handoff_signatures: HashMap::new(),
+            phase_locks: HashMap::new(),
         }
     }
 }

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -1859,6 +1859,13 @@ impl EventLoop {
     }
 
     fn extract_phase_workflow_key(payload: &str) -> Option<String> {
+        if let Some(explicit_key) =
+            Self::extract_task_field(payload, &["workflow_key", "phase_key"])
+            && !explicit_key.is_empty()
+        {
+            return Some(explicit_key);
+        }
+
         let task_key = Self::extract_task_key(payload)?;
         if let Some((prefix, _)) = task_key.rsplit_once(':')
             && !prefix.is_empty()

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -19,7 +19,7 @@ use crate::memory_store::{MarkdownMemoryStore, format_memories_as_markdown, trun
 use crate::skill_registry::SkillRegistry;
 use crate::text::floor_char_boundary;
 use ralph_proto::{CheckinContext, Event, EventBus, Hat, HatId, RobotService};
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -1729,6 +1729,310 @@ impl EventLoop {
             .to_string()
     }
 
+    fn validate_handoff_event(&mut self, topic: &str, payload: &str) -> Option<Event> {
+        match topic {
+            "question.asked" => {
+                let Some(question) = Self::extract_question_text(payload) else {
+                    return Some(Self::handoff_diagnostic_event(
+                        "handoff.invalid",
+                        topic,
+                        payload,
+                        "empty_question",
+                    ));
+                };
+
+                if self.is_duplicate_handoff(topic, payload, Some(&question)) {
+                    return Some(Self::handoff_diagnostic_event(
+                        "handoff.ignored",
+                        topic,
+                        payload,
+                        "duplicate_question",
+                    ));
+                }
+
+                Some(Event::new(topic, payload))
+            }
+            "answer.proposed" | "requirements.complete" | "design.drafted" => {
+                if let Some(reason) = self.phase_lock_reason(topic, payload) {
+                    return Some(Self::handoff_diagnostic_event(
+                        "handoff.ignored",
+                        topic,
+                        payload,
+                        reason,
+                    ));
+                }
+
+                if self.is_duplicate_handoff(topic, payload, None) {
+                    return Some(Self::handoff_diagnostic_event(
+                        "handoff.ignored",
+                        topic,
+                        payload,
+                        "duplicate_handoff",
+                    ));
+                }
+
+                self.record_phase_progress(topic, payload);
+                Some(Event::new(topic, payload))
+            }
+            "design.approved" => {
+                self.record_phase_progress(topic, payload);
+                Some(Event::new(topic, payload))
+            }
+            "design.rejected" => {
+                if Self::is_actionable_design_rejection(payload) {
+                    self.reopen_phase_progress(payload);
+                    Some(Event::new(topic, payload))
+                } else if self.is_phase_locked(payload) {
+                    Some(Self::handoff_diagnostic_event(
+                        "handoff.ignored",
+                        topic,
+                        payload,
+                        "missing_actionable_delta",
+                    ))
+                } else {
+                    Some(Event::new(topic, payload))
+                }
+            }
+            _ => Some(Event::new(topic, payload)),
+        }
+    }
+
+    fn phase_lock_reason(&self, topic: &str, payload: &str) -> Option<&'static str> {
+        let workflow_key = Self::extract_phase_workflow_key(payload)?;
+        let lock = self.state.phase_locks.get(&workflow_key)?;
+
+        if lock.design_locked && matches!(topic, "answer.proposed" | "requirements.complete" | "design.drafted") {
+            return Some("design_locked");
+        }
+
+        if lock.requirements_locked && matches!(topic, "answer.proposed" | "requirements.complete") {
+            return Some("requirements_locked");
+        }
+
+        None
+    }
+
+    fn record_phase_progress(&mut self, topic: &str, payload: &str) {
+        let Some(workflow_key) = Self::extract_phase_workflow_key(payload) else {
+            return;
+        };
+
+        let lock = self.state.phase_locks.entry(workflow_key).or_default();
+        match topic {
+            "requirements.complete" => {
+                lock.requirements_locked = true;
+            }
+            "design.approved" => {
+                lock.requirements_locked = true;
+                lock.design_locked = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn reopen_phase_progress(&mut self, payload: &str) {
+        let Some(workflow_key) = Self::extract_phase_workflow_key(payload) else {
+            return;
+        };
+
+        if let Some(lock) = self.state.phase_locks.get_mut(&workflow_key) {
+            lock.requirements_locked = false;
+            lock.design_locked = false;
+        }
+    }
+
+    fn is_phase_locked(&self, payload: &str) -> bool {
+        let Some(workflow_key) = Self::extract_phase_workflow_key(payload) else {
+            return false;
+        };
+
+        self.state
+            .phase_locks
+            .get(&workflow_key)
+            .is_some_and(|lock| lock.requirements_locked || lock.design_locked)
+    }
+
+    fn extract_phase_workflow_key(payload: &str) -> Option<String> {
+        let task_key = Self::extract_task_key(payload)?;
+        if let Some((prefix, _)) = task_key.rsplit_once(':')
+            && !prefix.is_empty()
+        {
+            return Some(prefix.to_string());
+        }
+
+        Some(task_key)
+    }
+
+    fn is_actionable_design_rejection(payload: &str) -> bool {
+        if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(payload) {
+            for field in ["delta", "feedback", "reason", "questions", "issues", "critique"] {
+                if let Some(value) = map.get(field)
+                    && Self::json_value_has_actionable_delta(value)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        let trimmed = payload.trim();
+        !trimmed.is_empty()
+    }
+
+    fn json_value_has_actionable_delta(value: &Value) -> bool {
+        match value {
+            Value::String(text) => !text.trim().is_empty(),
+            Value::Array(values) => values.iter().any(Self::json_value_has_actionable_delta),
+            Value::Object(map) => !map.is_empty(),
+            Value::Null => false,
+            _ => true,
+        }
+    }
+
+    fn is_duplicate_handoff(
+        &mut self,
+        topic: &str,
+        payload: &str,
+        semantic_text: Option<&str>,
+    ) -> bool {
+        let task_key = Self::extract_task_key(payload).unwrap_or_else(|| "unknown".to_string());
+        let artifact_hash = Self::extract_artifact_hash(payload);
+        let state_version = Self::extract_state_version(payload);
+        let lane_key = format!("{topic}:{task_key}");
+        let signature = Self::fingerprint_handoff_payload(
+            payload,
+            semantic_text,
+            artifact_hash.as_deref(),
+            state_version.as_deref(),
+        );
+
+        match self.state.handoff_signatures.insert(lane_key, signature) {
+            Some(previous) => previous == signature,
+            None => false,
+        }
+    }
+
+    fn handoff_diagnostic_event(kind: &str, topic: &str, payload: &str, reason: &str) -> Event {
+        let task_key = Self::extract_task_key(payload);
+        let task_id = Self::extract_task_field(payload, &["task_id"]);
+        Event::new(
+            kind,
+            json!({
+                "topic": topic,
+                "reason": reason,
+                "task_id": task_id,
+                "task_key": task_key,
+                "payload": payload,
+            })
+            .to_string(),
+        )
+    }
+
+    fn fingerprint_handoff_payload(
+        payload: &str,
+        semantic_text: Option<&str>,
+        artifact_hash: Option<&str>,
+        state_version: Option<&str>,
+    ) -> u64 {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        let mut hasher = DefaultHasher::new();
+        semantic_text.unwrap_or(payload).trim().hash(&mut hasher);
+        artifact_hash.unwrap_or("").trim().hash(&mut hasher);
+        state_version.unwrap_or("").trim().hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn extract_question_text(payload: &str) -> Option<String> {
+        if let Ok(value) = serde_json::from_str::<Value>(payload) {
+            match value {
+                Value::Object(map) => {
+                    if let Some(question) = map
+                        .get("question")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                    {
+                        return Some(question.to_string());
+                    }
+                }
+                Value::String(text) => {
+                    let text = text.trim();
+                    if !text.is_empty() {
+                        return Some(text.to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let keyed = Self::extract_task_field(payload, &["question", "prompt"]);
+        if let Some(text) = keyed {
+            let text = text.trim();
+            if !text.is_empty() {
+                return Some(text.to_string());
+            }
+        }
+
+        let trimmed = payload.trim();
+        if trimmed.is_empty() {
+            None
+        } else if Self::extract_task_key(payload).is_some()
+            || Self::extract_task_field(payload, &["task_id"]).is_some()
+        {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn extract_task_key(payload: &str) -> Option<String> {
+        Self::extract_task_field(payload, &["task_key"])
+    }
+
+    fn extract_artifact_hash(payload: &str) -> Option<String> {
+        Self::extract_task_field(payload, &["artifact_hash", "hash"])
+    }
+
+    fn extract_state_version(payload: &str) -> Option<String> {
+        Self::extract_task_field(payload, &["state_version", "version"])
+    }
+
+    fn extract_task_field(payload: &str, field_names: &[&str]) -> Option<String> {
+        if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(payload) {
+            for field_name in field_names {
+                if let Some(value) = map.get(*field_name) {
+                    let normalized = match value {
+                        Value::String(text) => text.trim().to_string(),
+                        Value::Number(number) => number.to_string(),
+                        Value::Bool(boolean) => boolean.to_string(),
+                        _ => continue,
+                    };
+                    if !normalized.is_empty() {
+                        return Some(normalized);
+                    }
+                }
+            }
+        }
+
+        for line in payload.lines() {
+            let trimmed = line.trim();
+            for field_name in field_names {
+                for separator in ["=", ":"] {
+                    let prefix = format!("{field_name}{separator}");
+                    if let Some(value) = trimmed.strip_prefix(&prefix) {
+                        let normalized = value.trim().trim_matches('"').trim_matches('\'');
+                        if !normalized.is_empty() {
+                            return Some(normalized.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
     /// Adds cost to the cumulative total.
     pub fn add_cost(&mut self, cost: f64) {
         self.state.cumulative_cost += cost;
@@ -2042,7 +2346,7 @@ impl EventLoop {
 
         // Validate and transform events (apply backpressure for build.done)
         let mut validated_events = Vec::new();
-        let completion_topic = self.config.event_loop.completion_promise.as_str();
+        let completion_topic = self.config.event_loop.completion_promise.clone();
         let cancellation_topic = self.config.event_loop.cancellation_promise.clone();
         let total_events = events.len();
         for (index, event) in events.into_iter().enumerate() {
@@ -2259,9 +2563,10 @@ impl EventLoop {
                     warn!("verify.failed missing quality report");
                 }
                 validated_events.push(Event::new(event.topic.as_str(), &payload));
-            } else {
-                // Non-backpressure events pass through unchanged
-                validated_events.push(Event::new(event.topic.as_str(), &payload));
+            } else if let Some(validated) =
+                self.validate_handoff_event(event.topic.as_str(), &payload)
+            {
+                validated_events.push(validated);
             }
         }
 

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -1801,11 +1801,17 @@ impl EventLoop {
         let workflow_key = Self::extract_phase_workflow_key(payload)?;
         let lock = self.state.phase_locks.get(&workflow_key)?;
 
-        if lock.design_locked && matches!(topic, "answer.proposed" | "requirements.complete" | "design.drafted") {
+        if lock.design_locked
+            && matches!(
+                topic,
+                "answer.proposed" | "requirements.complete" | "design.drafted"
+            )
+        {
             return Some("design_locked");
         }
 
-        if lock.requirements_locked && matches!(topic, "answer.proposed" | "requirements.complete") {
+        if lock.requirements_locked && matches!(topic, "answer.proposed" | "requirements.complete")
+        {
             return Some("requirements_locked");
         }
 
@@ -1865,7 +1871,14 @@ impl EventLoop {
 
     fn is_actionable_design_rejection(payload: &str) -> bool {
         if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(payload) {
-            for field in ["delta", "feedback", "reason", "questions", "issues", "critique"] {
+            for field in [
+                "delta",
+                "feedback",
+                "reason",
+                "questions",
+                "issues",
+                "critique",
+            ] {
                 if let Some(value) = map.get(field)
                     && Self::json_value_has_actionable_delta(value)
                 {
@@ -1975,11 +1988,10 @@ impl EventLoop {
         }
 
         let trimmed = payload.trim();
-        if trimmed.is_empty() {
-            None
-        } else if Self::extract_task_key(payload).is_some()
-            || Self::extract_task_field(payload, &["task_id"]).is_some()
-        {
+        let has_only_task_identity = Self::extract_task_key(payload).is_some()
+            || Self::extract_task_field(payload, &["task_id"]).is_some();
+
+        if trimmed.is_empty() || has_only_task_identity {
             None
         } else {
             Some(trimmed.to_string())

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -1083,6 +1083,67 @@ fn test_actionable_design_rejection_reopens_phase_locks() {
 }
 
 #[test]
+fn test_explicit_workflow_key_locks_custom_workflows() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_phase_lock_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "design.approved",
+        &serde_json::json!({
+            "task_id": "task-custom-review",
+            "task_key": "custom:totally-different-key-shape",
+            "workflow_key": "custom-workflow-alpha",
+            "summary": "Custom workflow design approved."
+        })
+        .to_string(),
+    );
+    let approved = event_loop.process_events_from_jsonl().unwrap();
+    assert!(approved.had_events);
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "design.drafted",
+        &serde_json::json!({
+            "task_id": "task-custom-draft",
+            "task_key": "custom:another-shape",
+            "workflow_key": "custom-workflow-alpha",
+            "artifact_hash": "custom-design-1",
+            "state_version": 9,
+            "summary": "Stale design draft for the same custom workflow."
+        })
+        .to_string(),
+    );
+
+    let replay = event_loop.process_events_from_jsonl().unwrap();
+    assert!(replay.had_events);
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("design_critic"))
+            .is_none_or(|events| events.is_empty()),
+        "explicit workflow_key should suppress stale design handoffs for custom workflows"
+    );
+
+    let ralph_events = event_loop.bus.take_pending(&HatId::new("ralph"));
+    assert_eq!(ralph_events.len(), 1);
+    assert_eq!(ralph_events[0].topic.as_str(), "handoff.ignored");
+    assert!(
+        ralph_events[0]
+            .payload
+            .contains("\"reason\":\"design_locked\"")
+    );
+}
+
+#[test]
 fn test_thrashing_counter_increments_on_blocked_events() {
     // Events now come from JSONL file via `ralph emit`, not from text output.
     // Per-hat tracking is removed since events don't carry hat context.

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -596,6 +596,44 @@ fn write_event_to_jsonl(path: &std::path::Path, topic: &str, payload: &str) {
     writeln!(file, "{}", event_json).unwrap();
 }
 
+fn pdd_handoff_test_config() -> RalphConfig {
+    serde_yaml::from_str(
+        r#"
+hats:
+  inquisitor:
+    name: "Inquisitor"
+    triggers: ["answer.proposed"]
+    publishes: ["question.asked", "requirements.complete"]
+  architect:
+    name: "Architect"
+    triggers: ["question.asked", "requirements.complete"]
+    publishes: ["answer.proposed", "design.drafted"]
+"#,
+    )
+    .unwrap()
+}
+
+fn pdd_phase_lock_test_config() -> RalphConfig {
+    serde_yaml::from_str(
+        r#"
+hats:
+  inquisitor:
+    name: "Inquisitor"
+    triggers: ["design.start", "answer.proposed", "design.rejected"]
+    publishes: ["question.asked", "requirements.complete"]
+  architect:
+    name: "Architect"
+    triggers: ["question.asked", "requirements.complete"]
+    publishes: ["answer.proposed", "design.drafted"]
+  design_critic:
+    name: "Design Critic"
+    triggers: ["design.drafted"]
+    publishes: ["design.approved", "design.rejected"]
+"#,
+    )
+    .unwrap()
+}
+
 #[test]
 fn test_loop_thrashing_detection() {
     use tempfile::tempdir;
@@ -629,6 +667,418 @@ fn test_loop_thrashing_detection() {
             .abandoned_tasks
             .contains(&"Fix bug".to_string()),
         "Task should be abandoned after 3 blocks"
+    );
+}
+
+#[test]
+fn test_empty_question_handoff_is_quarantined() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_handoff_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "question.asked",
+        &serde_json::json!({
+            "task_id": "task-1",
+            "task_key": "pdd:spec:requirements",
+            "question": "   "
+        })
+        .to_string(),
+    );
+
+    let processed = event_loop.process_events_from_jsonl().unwrap();
+    assert!(
+        processed.had_events,
+        "invalid handoff should surface as a containment event"
+    );
+    assert!(
+        processed.has_orphans,
+        "containment event should route through Ralph"
+    );
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("architect"))
+            .is_none_or(|events| events.is_empty()),
+        "empty question.asked should not reach the architect"
+    );
+
+    let ralph_events = event_loop
+        .bus
+        .peek_pending(&HatId::new("ralph"))
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(ralph_events.len(), 1);
+    assert_eq!(ralph_events[0].topic.as_str(), "handoff.invalid");
+    assert!(
+        ralph_events[0]
+            .payload
+            .contains("\"reason\":\"empty_question\"")
+    );
+}
+
+#[test]
+fn test_question_handoff_uses_prompt_fallback_for_json_payloads() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_handoff_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "question.asked",
+        &serde_json::json!({
+            "task_id": "task-1b",
+            "task_key": "pdd:spec:requirements",
+            "prompt": "What requirement is still unclear?"
+        })
+        .to_string(),
+    );
+
+    let processed = event_loop.process_events_from_jsonl().unwrap();
+    assert!(processed.had_events);
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("ralph"))
+            .is_none_or(|events| events.is_empty()),
+        "valid question.asked payload should not be quarantined"
+    );
+
+    let architect_events = event_loop.bus.take_pending(&HatId::new("architect"));
+    assert_eq!(architect_events.len(), 1);
+    assert_eq!(architect_events[0].topic.as_str(), "question.asked");
+    assert!(
+        architect_events[0]
+            .payload
+            .contains("\"prompt\":\"What requirement is still unclear?\"")
+    );
+}
+
+#[test]
+fn test_duplicate_answer_proposed_handoff_is_suppressed() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_handoff_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+
+    let payload = serde_json::json!({
+        "task_id": "task-2",
+        "task_key": "pdd:spec:requirements-answering",
+        "artifact_hash": "abc123",
+        "state_version": 1,
+        "answer": "Use the existing queue implementation."
+    })
+    .to_string();
+
+    write_event_to_jsonl(&events_path, "answer.proposed", &payload);
+    let first = event_loop.process_events_from_jsonl().unwrap();
+    assert!(first.had_events);
+    let first_inquisitor_events = event_loop.bus.take_pending(&HatId::new("inquisitor"));
+    assert_eq!(first_inquisitor_events.len(), 1);
+    assert_eq!(first_inquisitor_events[0].topic.as_str(), "answer.proposed");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(&events_path, "answer.proposed", &payload);
+    let second = event_loop.process_events_from_jsonl().unwrap();
+    assert!(
+        second.had_events,
+        "duplicate should surface as ignored rather than re-route"
+    );
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("inquisitor"))
+            .is_none_or(|events| events.is_empty()),
+        "duplicate answer.proposed should not retrigger the inquisitor"
+    );
+
+    let ralph_events = event_loop.bus.take_pending(&HatId::new("ralph"));
+    assert_eq!(ralph_events.len(), 1);
+    assert_eq!(ralph_events[0].topic.as_str(), "handoff.ignored");
+    assert!(
+        ralph_events[0]
+            .payload
+            .contains("\"reason\":\"duplicate_handoff\"")
+    );
+}
+
+#[test]
+fn test_duplicate_requirements_complete_handoff_is_suppressed() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_handoff_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+
+    let payload = serde_json::json!({
+        "task_id": "task-3",
+        "task_key": "pdd:spec:requirements",
+        "artifact_hash": "req-lock-1",
+        "state_version": 2,
+        "summary": "Requirements are complete."
+    })
+    .to_string();
+
+    write_event_to_jsonl(&events_path, "requirements.complete", &payload);
+    let first = event_loop.process_events_from_jsonl().unwrap();
+    assert!(first.had_events);
+    let first_architect_events = event_loop.bus.take_pending(&HatId::new("architect"));
+    assert_eq!(first_architect_events.len(), 1);
+    assert_eq!(
+        first_architect_events[0].topic.as_str(),
+        "requirements.complete"
+    );
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(&events_path, "requirements.complete", &payload);
+    let second = event_loop.process_events_from_jsonl().unwrap();
+    assert!(second.had_events);
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("architect"))
+            .is_none_or(|events| events.is_empty()),
+        "duplicate requirements.complete should not retrigger design drafting"
+    );
+
+    let ralph_events = event_loop.bus.take_pending(&HatId::new("ralph"));
+    assert_eq!(ralph_events.len(), 1);
+    assert_eq!(ralph_events[0].topic.as_str(), "handoff.ignored");
+}
+
+#[test]
+fn test_completed_requirements_ignore_stale_answer_handoffs() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_phase_lock_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "requirements.complete",
+        &serde_json::json!({
+            "task_id": "task-req",
+            "task_key": "pdd:spec:requirements",
+            "artifact_hash": "req-lock-1",
+            "state_version": 2,
+            "summary": "Requirements are complete."
+        })
+        .to_string(),
+    );
+    let first = event_loop.process_events_from_jsonl().unwrap();
+    assert!(first.had_events);
+    let _ = event_loop.bus.take_pending(&HatId::new("architect"));
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "answer.proposed",
+        &serde_json::json!({
+            "task_id": "task-answer",
+            "task_key": "pdd:spec:requirements-answering",
+            "artifact_hash": "answer-lock-2",
+            "state_version": 3,
+            "answer": "Use the existing queue implementation."
+        })
+        .to_string(),
+    );
+
+    let second = event_loop.process_events_from_jsonl().unwrap();
+    assert!(second.had_events);
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("inquisitor"))
+            .is_none_or(|events| events.is_empty()),
+        "stale answer.proposed should not reopen requirements"
+    );
+
+    let ralph_events = event_loop.bus.take_pending(&HatId::new("ralph"));
+    assert_eq!(ralph_events.len(), 1);
+    assert_eq!(ralph_events[0].topic.as_str(), "handoff.ignored");
+    assert!(
+        ralph_events[0]
+            .payload
+            .contains("\"reason\":\"requirements_locked\"")
+    );
+}
+
+#[test]
+fn test_completed_design_ignores_stale_requirements_and_design_handoffs() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_phase_lock_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "design.approved",
+        &serde_json::json!({
+            "task_id": "task-design-review",
+            "task_key": "pdd:spec:design-review",
+            "summary": "Design approved."
+        })
+        .to_string(),
+    );
+    let first = event_loop.process_events_from_jsonl().unwrap();
+    assert!(first.had_events);
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "requirements.complete",
+        &serde_json::json!({
+            "task_id": "task-req",
+            "task_key": "pdd:spec:requirements",
+            "artifact_hash": "req-lock-3",
+            "state_version": 5,
+            "summary": "Requirements are complete."
+        })
+        .to_string(),
+    );
+    write_event_to_jsonl(
+        &events_path,
+        "design.drafted",
+        &serde_json::json!({
+            "task_id": "task-design-draft",
+            "task_key": "pdd:spec:design-draft",
+            "artifact_hash": "design-lock-3",
+            "state_version": 6,
+            "summary": "Re-emitted design draft."
+        })
+        .to_string(),
+    );
+
+    let second = event_loop.process_events_from_jsonl().unwrap();
+    assert!(second.had_events);
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("architect"))
+            .is_none_or(|events| events.is_empty()),
+        "stale requirements.complete should not reopen design drafting"
+    );
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("design_critic"))
+            .is_none_or(|events| events.is_empty()),
+        "stale design.drafted should not reopen design review"
+    );
+
+    let ralph_events = event_loop.bus.take_pending(&HatId::new("ralph"));
+    assert_eq!(ralph_events.len(), 2);
+    assert_eq!(ralph_events[0].topic.as_str(), "handoff.ignored");
+    assert_eq!(ralph_events[1].topic.as_str(), "handoff.ignored");
+    assert!(
+        ralph_events[0]
+            .payload
+            .contains("\"reason\":\"design_locked\"")
+    );
+    assert!(
+        ralph_events[1]
+            .payload
+            .contains("\"reason\":\"design_locked\"")
+    );
+}
+
+#[test]
+fn test_actionable_design_rejection_reopens_phase_locks() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(pdd_phase_lock_test_config());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "design.approved",
+        &serde_json::json!({
+            "task_id": "task-design-review",
+            "task_key": "pdd:spec:design-review",
+            "summary": "Design approved."
+        })
+        .to_string(),
+    );
+    let approved = event_loop.process_events_from_jsonl().unwrap();
+    assert!(approved.had_events);
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "design.rejected",
+        &serde_json::json!({
+            "task_id": "task-design-review",
+            "task_key": "pdd:spec:design-review",
+            "feedback": "Add a concrete failure-handling path for queue timeouts."
+        })
+        .to_string(),
+    );
+    let rejected = event_loop.process_events_from_jsonl().unwrap();
+    assert!(rejected.had_events);
+    let inquisitor_events = event_loop.bus.take_pending(&HatId::new("inquisitor"));
+    assert_eq!(inquisitor_events.len(), 1);
+    assert_eq!(inquisitor_events[0].topic.as_str(), "design.rejected");
+    let _ = event_loop.bus.take_pending(&HatId::new("ralph"));
+
+    write_event_to_jsonl(
+        &events_path,
+        "answer.proposed",
+        &serde_json::json!({
+            "task_id": "task-answer",
+            "task_key": "pdd:spec:requirements-answering",
+            "artifact_hash": "answer-lock-4",
+            "state_version": 7,
+            "answer": "We should retry once and surface timeout telemetry."
+        })
+        .to_string(),
+    );
+    let replay = event_loop.process_events_from_jsonl().unwrap();
+    assert!(replay.had_events);
+
+    let reopened_events = event_loop.bus.take_pending(&HatId::new("inquisitor"));
+    assert_eq!(reopened_events.len(), 1);
+    assert_eq!(reopened_events[0].topic.as_str(), "answer.proposed");
+    assert!(
+        event_loop
+            .bus
+            .peek_pending(&HatId::new("ralph"))
+            .is_none_or(|events| events.is_empty()),
+        "actionable design.rejected should unlock the workflow instead of being quarantined"
     );
 }
 

--- a/crates/ralph-core/src/summary_writer.rs
+++ b/crates/ralph-core/src/summary_writer.rs
@@ -327,6 +327,8 @@ mod tests {
             last_emitted_signature: None,
             consecutive_same_signature: 0,
             cancellation_requested: false,
+            handoff_signatures: std::collections::HashMap::new(),
+            phase_locks: std::collections::HashMap::new(),
         }
     }
 

--- a/docs/advanced/preset-contracts.md
+++ b/docs/advanced/preset-contracts.md
@@ -1,0 +1,85 @@
+# Preset Contracts
+
+These are the shared behavioral contracts the shipped presets are expected to follow.
+
+The goal is not to force every preset into identical YAML, but to keep the preset family coherent enough that runs can be evaluated and trusted consistently.
+
+## Core principle
+A preset should make autonomous forward progress without relying on accidental behavior.
+
+That means each preset should have:
+- clear hat ownership
+- clear terminal semantics
+- clear review / follow-up semantics
+- explicit separation between artifact success and loop success
+
+## Autonomous task loop contract
+Used by implementation-style presets such as `code-assist`.
+
+Expected roles:
+- `planner`
+- `builder`
+- `critic`
+- `finalizer`
+
+Expected shape:
+- planner scopes and advances work
+- builder implements one bounded task at a time
+- critic performs adversarial review
+- finalizer decides continue vs complete
+- completion event is owned by the finalizer, not emitted ad hoc by builder/critic
+
+## Autonomous review loop contract
+Used by `review`.
+
+Expected roles:
+- `reviewer`
+- `analyzer`
+- `closer`
+
+Expected shape:
+- reviewer produces the next review wave
+- analyzer deepens the highest-risk findings
+- closer decides follow-up vs `REVIEW_COMPLETE`
+
+## Autonomous debug loop contract
+Used by `debug`.
+
+Expected roles:
+- `investigator`
+- `tester`
+- `fixer`
+- `verifier`
+
+Expected shape:
+- investigator frames one falsifiable hypothesis at a time
+- tester validates or rejects the hypothesis
+- fixer applies the minimal change
+- verifier confirms the bug is gone
+- only investigator should emit `DEBUG_COMPLETE`, and only after verified fix state
+
+## Autonomous research loop contract
+Used by `research`.
+
+Expected roles:
+- `researcher`
+- `synthesizer`
+
+Expected shape:
+- researcher gathers bounded evidence for one wave
+- synthesizer decides follow-up vs `RESEARCH_COMPLETE`
+- only synthesizer should emit `RESEARCH_COMPLETE`
+
+## PDD-to-code-assist contract
+Used by `pdd-to-code-assist`.
+
+Expected shape:
+- requirements/design/planning/task-writing/build/review/finalize/validate stages stay distinct
+- clarifications should resolve sanely for autonomous operation; the workflow must not pretend a human replied when no human path exists
+- implementation completion must be driven by the designated late-stage hats, not by early-stage hats re-emitting stale completion-like events
+
+## Why this file exists
+This page documents the intended preset family shape so we can:
+- test for drift
+- judge conformance runs correctly
+- keep shipped presets coherent as the runtime evolves

--- a/docs/advanced/preset-contracts/autonomous-debug-loop.yml
+++ b/docs/advanced/preset-contracts/autonomous-debug-loop.yml
@@ -1,0 +1,65 @@
+name: autonomous-debug-loop
+
+description: "Shared contract for autonomous debug presets: investigate, test, fix, verify, then terminate cleanly."
+
+events:
+  debug.start:
+    description: Debug work begins.
+  hypothesis.test:
+    description: A falsifiable hypothesis is ready for testing.
+  hypothesis.confirmed:
+    description: The hypothesis was confirmed.
+  hypothesis.rejected:
+    description: The hypothesis was rejected.
+  fix.propose:
+    description: A concrete fix direction is ready.
+  fix.applied:
+    description: The fix has been implemented.
+  fix.verified:
+    description: The original bug is fixed and validated.
+  fix.blocked:
+    description: The fix path is blocked.
+
+event_loop:
+  starting_event: debug.start
+  completion_promise: DEBUG_COMPLETE
+
+hats:
+  investigator:
+    name: Investigator
+    description: Produces one falsifiable hypothesis at a time and decides when a confirmed hypothesis should move into fixing.
+    triggers: [debug.start, hypothesis.rejected, hypothesis.confirmed, fix.verified]
+    publishes: [hypothesis.test, fix.propose, DEBUG_COMPLETE]
+    instructions: |
+      If the bug is unresolved, emit exactly one falsifiable hypothesis.
+      On hypothesis.confirmed, emit fix.propose with the minimal fix direction.
+      If the bug is already fixed and verified, emit DEBUG_COMPLETE and stop.
+      Never emit repeated completion after completion criteria are already satisfied.
+
+  tester:
+    name: Tester
+    description: Tests one hypothesis directly.
+    triggers: [hypothesis.test]
+    publishes: [hypothesis.confirmed, hypothesis.rejected]
+    instructions: |
+      Test the hypothesis with one direct and one adversarial check.
+
+  fixer:
+    name: Fixer
+    description: Applies the minimal fix for a confirmed hypothesis.
+    triggers: [fix.propose, fix.blocked]
+    publishes: [fix.applied, fix.blocked]
+    default_publishes: fix.blocked
+    instructions: |
+      Apply the smallest fix that addresses the confirmed cause.
+      Emit fix.blocked only for a real blocker.
+
+  verifier:
+    name: Verifier
+    description: Confirms the bug is fixed and no obvious regression remains.
+    triggers: [fix.applied]
+    publishes: [fix.verified, fix.blocked]
+    default_publishes: fix.blocked
+    instructions: |
+      Re-run the original repro and a neighboring adversarial case.
+      Emit fix.verified only when the original bug is demonstrably gone.

--- a/docs/advanced/preset-contracts/autonomous-research-loop.yml
+++ b/docs/advanced/preset-contracts/autonomous-research-loop.yml
@@ -1,0 +1,34 @@
+name: autonomous-research-loop
+
+description: "Shared contract for research presets: bounded evidence gathering, synthesis, and explicit follow-up vs complete behavior."
+
+events:
+  research.start:
+    description: Research begins.
+  research.finding:
+    description: A bounded set of findings is ready for synthesis.
+  research.followup:
+    description: Another research wave is needed.
+
+event_loop:
+  starting_event: research.start
+  completion_promise: RESEARCH_COMPLETE
+
+hats:
+  researcher:
+    name: Researcher
+    description: Gathers bounded evidence for the current wave.
+    triggers: [research.start, research.followup]
+    publishes: [research.finding]
+    default_publishes: research.finding
+    instructions: |
+      Gather evidence for one wave only. Stop when there is enough evidence to synthesize.
+
+  synthesizer:
+    name: Synthesizer
+    description: Decides follow-up versus completion.
+    triggers: [research.finding]
+    publishes: [research.followup, RESEARCH_COMPLETE]
+    instructions: |
+      Emit RESEARCH_COMPLETE only when the question is fully answered and no real follow-up remains.
+      Emit research.followup only with one concrete unresolved gap.

--- a/docs/advanced/preset-contracts/autonomous-review-loop.yml
+++ b/docs/advanced/preset-contracts/autonomous-review-loop.yml
@@ -1,0 +1,45 @@
+name: autonomous-review-loop
+
+description: Shared contract for review-style presets. Supports iterative review waves and explicit finish semantics.
+
+events:
+  review.start:
+    description: Review begins.
+  review.section:
+    description: A scoped review section is ready for deeper analysis.
+  analysis.complete:
+    description: Deeper analysis for the current section is complete.
+  review.followup:
+    description: Another review wave is required.
+
+event_loop:
+  starting_event: review.start
+  completion_promise: REVIEW_COMPLETE
+
+hats:
+  reviewer:
+    name: Reviewer
+    description: Produces the next scoped review wave.
+    triggers: [review.start, review.followup]
+    publishes: [review.section]
+    default_publishes: review.section
+    instructions: |
+      Produce the next review section. Do not emit completion directly.
+
+  analyzer:
+    name: Analyzer
+    description: Deepens the highest-risk findings from the current review section.
+    triggers: [review.section]
+    publishes: [analysis.complete]
+    default_publishes: analysis.complete
+    instructions: |
+      Analyze the highest-risk findings and return concrete evidence.
+
+  closer:
+    name: Closer
+    description: Decides whether another wave is needed or the review is complete.
+    triggers: [analysis.complete]
+    publishes: [review.followup, REVIEW_COMPLETE]
+    instructions: |
+      Emit REVIEW_COMPLETE when the review is substantively done.
+      Emit review.followup only when there is a concrete unresolved section.

--- a/docs/advanced/preset-contracts/autonomous-task-loop.yml
+++ b/docs/advanced/preset-contracts/autonomous-task-loop.yml
@@ -1,0 +1,61 @@
+name: autonomous-task-loop
+
+description: Shared contract for autonomous implementation presets. Encodes self-resolution of ambiguity, explicit review, and sane completion/blocked semantics without assuming a human input step.
+
+events:
+  work.start:
+    description: Initial work request received.
+  task.ready:
+    description: One concrete task is ready for implementation.
+  review.ready:
+    description: Implementation increment is ready for review.
+  review.passed:
+    description: Review accepted the current increment.
+  review.rejected:
+    description: Review found actionable issues in the current increment.
+  work.blocked:
+    description: Builder cannot proceed without escalation or a narrower plan.
+
+event_loop:
+  starting_event: work.start
+  completion_promise: LOOP_COMPLETE
+
+hats:
+  planner:
+    name: Planner
+    description: Scopes work and resolves ambiguity explicitly enough for autonomous execution.
+    triggers: [work.start, review.rejected, work.blocked]
+    publishes: [task.ready, LOOP_COMPLETE]
+    instructions: |
+      Produce exactly one next concrete task or complete if no work remains.
+      If ambiguity exists, resolve it by making and recording a bounded assumption; do not pretend a human answered.
+      Never reopen already-complete work unless the rejection introduces real delta.
+
+  builder:
+    name: Builder
+    description: Implements one concrete task.
+    triggers: [task.ready]
+    publishes: [review.ready, work.blocked]
+    default_publishes: review.ready
+    instructions: |
+      Implement exactly one task. If blocked, emit work.blocked with the real blocker.
+      Do not emit completion yourself.
+
+  critic:
+    name: Critic
+    description: Adversarial review of the current increment.
+    triggers: [review.ready]
+    publishes: [review.passed, review.rejected]
+    default_publishes: review.rejected
+    instructions: |
+      Emit review.passed only when the increment genuinely satisfies the task.
+      Emit review.rejected only with actionable delta.
+
+  closer:
+    name: Closer
+    description: Decides whether reviewed work should continue or complete.
+    triggers: [review.passed]
+    publishes: [task.ready, LOOP_COMPLETE]
+    instructions: |
+      If more concrete work remains, publish task.ready for the next bounded task.
+      If no concrete work remains, emit LOOP_COMPLETE and stop.

--- a/presets/code-assist.yml
+++ b/presets/code-assist.yml
@@ -87,6 +87,9 @@ hats:
       - `task_id`
       - `task_key`
       - artifact path when the work is backed by a `.code-task.md` file
+      Emit `tasks.ready` with explicit JSON, for example:
+      - `ralph emit --json "tasks.ready" '{"task_id":"<task_id>","task_key":"<task_key>","artifact_path":"<artifact_path>"}'`
+      Never emit `tasks.ready` as a prose summary because the Builder needs the exact runtime-task identity from the payload.
 
       ### Read State
       On every activation:
@@ -133,15 +136,15 @@ hats:
       5. Choose Step 1 as the current step
       6. Ensure ONLY Step 1's runtime tasks using `ralph tools task ensure --description "..."`
       7. Write `progress.md` with the current step, the active wave's task keys, and empty completed-steps section
-      8. Pick exactly one ready runtime task from the Step 1 wave and publish `tasks.ready`
+      8. Pick exactly one ready runtime task from the Step 1 wave and publish `tasks.ready` with that task's `task_id`, `task_key`, and artifact path when applicable
       9. Once one ready runtime task exists and the shared docs are written, emit `tasks.ready` immediately. Do NOT keep refining later steps in the same turn.
 
       ### On Subsequent Activation (`queue.advance`)
       1. Re-read `<ready-tasks>`, `plan.md`, `progress.md`, and `.ralph/agent/tasks.jsonl`
       2. Identify the current step from `progress.md`
-      3. If ready or open tasks already exist for the current step, publish `tasks.ready` for the next one in that same wave
+      3. If ready or open tasks already exist for the current step, publish `tasks.ready` with the next task's `task_id`, `task_key`, and artifact path when applicable
       4. If the current step's wave is fully closed, move that step to `## Completed Steps`
-      5. If another numbered step remains, update `## Current Step`, ensure ONLY that next step's runtime tasks, refresh `## Active Wave`, and publish `tasks.ready`
+      5. If another numbered step remains, update `## Current Step`, ensure ONLY that next step's runtime tasks, refresh `## Active Wave`, and publish `tasks.ready` with the selected task identity
       6. If no numbered steps remain, do not invent more tasks; leave the queue empty so the Finalizer can terminate after the last reviewed task
       7. Do not spend the turn polishing docs once a ready task exists; emit immediately.
 
@@ -281,7 +284,8 @@ hats:
          - Save concise command/result notes in `progress.md`
          - Save substantive command output in `logs/` when useful
          - If this turn runs long, send `ralph tools interact progress`
-         - Then hand the increment to the Critic with `task_id`, `task_key`, and artifact path
+         - Then hand the increment to the Critic with `task_id`, `task_key`, and artifact path using `ralph emit --json "review.ready" '{"task_id":"<task_id>","task_key":"<task_key>","artifact_path":"<artifact_path>"}'`
+         - Leave the runtime task `open` while it is under review; Finalizer owns `task close` / `task reopen`
          - Once the task description is satisfied and the focused checks pass, emit promptly. Do not spend the rest of the turn narrating the work.
          - If a setup or test command fails once, inspect the files it wrote and move to the next concrete action. Do not spend the rest of the turn retrying environment probes.
 
@@ -298,6 +302,7 @@ hats:
       - You MUST implement the runtime task from the current payload, not the next thing in `progress.md`
       - You MUST NOT write implementation before tests
       - You MUST NOT add features not in the task/description
+      - You MUST NOT close or reopen the runtime task yourself; Finalizer owns completion state after review
       - You MUST follow codebase patterns when available
       - You MUST keep implementation code out of the shared docs directory
       - You MUST update `progress.md` as evidence/logging, not as the scheduler
@@ -391,7 +396,10 @@ hats:
       - or over-engineering/material style mismatch worth fixing now.
 
       Publish `review.passed` only when the increment looks correct enough for the Finalizer to evaluate overall completion.
-      In both pass/reject cases, include the same `task_id` and `task_key` in the payload.
+      Emit exactly one of `review.passed` or `review.rejected` yourself for every review turn.
+      In both pass/reject cases, include the same `task_id`, `task_key`, and artifact path from `review.ready` in the payload plus a concise evidence summary.
+      `default_publishes: "review.rejected"` is only a crash guard. It is NOT a valid success path because its empty payload loses runtime-task ownership on retry.
+      If you reject the increment, make the rejection actionable and preserve task identity so the Builder retries the same runtime task instead of drifting to a different one.
       For scaffold/setup slices, judge the task against its own acceptance criteria. Do not reject because future tasks have not been implemented yet.
 
       If you discover a durable repo-wide pattern or recurring fix, record it with `ralph tools memory add`.

--- a/presets/pdd-to-code-assist.yml
+++ b/presets/pdd-to-code-assist.yml
@@ -95,6 +95,7 @@ hats:
       Ask questions that address the specific concerns raised.
 
       Every `question.asked` and `requirements.complete` payload MUST include the active `task_id` and `task_key`.
+      For custom workflows, prefer an explicit `workflow_key` (or `phase_key`) in the payload. When absent, Ralph falls back to deriving the workflow lane from `task_key`.
 
       ### Constraints
       - You MUST NOT ask multiple questions at once because this overwhelms users and leads to incomplete responses
@@ -130,7 +131,7 @@ hats:
       3. Research if needed (explore codebase, check patterns)
       4. Provide a clear, specific answer
       5. Append the answer to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
-      6. Publish `answer.proposed` with the active `task_id` and `task_key`
+      6. Publish `answer.proposed` with the active `task_id`, `task_key`, and preferably an explicit `workflow_key` (or `phase_key`) for custom workflows
 
       ### When Triggered by requirements.complete
       Synthesize all Q&A into a detailed design document.


### PR DESCRIPTION
## Summary

This PR improves Ralph preset/runtime convergence hygiene for PDD-style loops and includes two supporting CLI bootstrap fixes discovered while working the issue.

Included changes:
- suppress duplicate/no-delta handoff churn
- reject/quarantine empty `question.asked` handoffs
- add monotonic phase locks so completed requirements/design phases do not reopen from stale duplicate events
- bootstrap planner artifacts for fresh worktree runs
- preserve/reset scratchpad correctly on fresh startup
- add regression coverage for the above behavior

## Why

We observed long-running PDD/code-assist loops produce useful artifacts but still degrade into no-op churn:
- empty or semantically null `question.asked`
- repeated `answer.proposed` / `requirements.complete`
- stale handoffs reopening already-completed phases
- fresh worktree runs missing planner packet / scratchpad bootstrap

These changes push the system toward actual convergence instead of token-burning oscillation.

## What changed

### Event loop / runtime
- added per-lane handoff signature tracking for duplicate suppression
- improved `question.asked` extraction/validation
- introduced monotonic phase-lock behavior for completed requirements/design phases
- added targeted regressions for stale duplicate handoffs and actionable rejection reopen behavior

### CLI / startup hygiene
- bootstrap `.ralph/agent/scratchpad.md` for fresh runs
- copy planner implementation packet into fresh worktrees when the prompt points into `.agents/scratchpad/implementation/...`
- preserve/reset scratchpad on fresh startup instead of deleting it outright
- add targeted bootstrap regressions

## Verification

Validated in loop slices and rerun gates including:
- targeted `ralph-core` handoff/phase-lock regressions
- targeted `ralph-cli` bootstrap regressions
- full `cargo test`
- `cargo test -p ralph-core smoke_runner`

