### PR TITLE
fix(ci): sync embedded code-task-generator skill file

### DIFF
--- a/crates/ralph-cli/sops/code-task-generator.md
+++ b/crates/ralph-cli/sops/code-task-generator.md
@@ -3,6 +3,8 @@ name: code-task-generator
 description: Generates structured .code-task.md files from descriptions or PDD implementation plans. Auto-detects input type, creates properly formatted tasks with Given-When-Then acceptance criteria.
 type: anthropic-skill
 version: "1.1"
+metadata:
+  internal: true
 ---
 
 # Code Task Generator


### PR DESCRIPTION
## Summary
- The embedded copy of `code-task-generator` skill at `crates/ralph-cli/sops/code-task-generator.md` was out of sync with its source at `.claude/skills/code-task-generator/SKILL.md`
- The source gained `metadata: internal: true` in commit bab59a3 but the sync script wasn't run afterward
- This fixes the `Check embedded files` CI job which is currently failing on all PRs

## Test plan
- [x] Ran `./scripts/sync-embedded-files.sh check` locally — passes
- CI `Check embedded files` job should pass on this PR

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>