### PR TITLE
ci: shift left — merge clippy into test job, local coverage, pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,19 @@ jobs:
       - name: Check embedded files are in sync
         run: ./scripts/sync-embedded-files.sh check
 
+  # Format check: no compile needed, runs in seconds
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -30,18 +43,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
-      - name: Build ralph binary
-        run: cargo build --bin ralph
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
         run: cargo test -- --skip acp_executor::tests::test_create_terminal_and_output
       - name: Run hooks BDD gate
         run: ./scripts/hooks-bdd-gate.sh
-      - name: Build ralph-e2e
-        run: cargo build --release -p ralph-e2e
       - name: Run mock E2E tests
-        run: ./target/release/ralph-e2e --mock --skip-analysis || true
+        run: |
+          cargo build -p ralph-e2e
+          ./target/debug/ralph-e2e --mock --skip-analysis || true
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -53,8 +68,8 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-  # Clippy and Format checks moved to lint.yml (runs automatically on fork PRs
-  # via pull_request_target, no maintainer approval needed)
+  # Clippy and Format checks also run in lint.yml on fork PRs
+  # (pull_request_target, no secrets needed for fmt-only)
 
   web-tests:
     name: Web Tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
-name: Lint
+name: Lint (Fork PRs)
 
 # Runs automatically on all PRs including forks (no approval needed).
-# Safe because: no secrets, no write permissions, fmt doesn't compile code.
-# Clippy does compile — permissions are locked down to limit blast radius.
+# Only format checking here — no compile, no secrets, minimal blast radius.
+# Clippy has been moved into ci.yml to share the compilation cache with tests.
 
 on:
   pull_request_target:
@@ -29,23 +29,3 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Pre-push hook: run the full CI gate locally before pushing.
+# This catches test failures before they burn CI minutes.
+#
+# Mirrors the CI test job: embedded-check + clippy + test + BDD gate.
+# Skips: web-tests (npm), package-check, E2E (heavy, best left to CI).
+#
+# Skip with: git push --no-verify
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+# Hooks inherit Git env vars (GIT_DIR/GIT_INDEX_FILE/etc.).
+# Unset them so nested `git` calls in tests run against their own repos.
+while IFS= read -r git_env_var; do
+  unset "$git_env_var"
+done < <(git rev-parse --local-env-vars)
+
+# Prefer CI-equivalent toolchain selection when possible.
+TOOLCHAIN_MODE="path"
+
+if command -v rustup >/dev/null 2>&1; then
+  TOOLCHAIN_MODE="rustup"
+fi
+
+run_cargo() {
+  if [[ "$TOOLCHAIN_MODE" == "rustup" ]]; then
+    rustup run stable cargo "$@"
+  else
+    cargo "$@"
+  fi
+}
+
+run_check() {
+  local label="$1"
+  shift
+
+  echo ""
+  echo "🔍 ${label}..."
+  if ! "$@"; then
+    echo ""
+    echo "❌ ${label} failed! Push aborted."
+    echo "   Fix the issue or skip with: git push --no-verify"
+    exit 1
+  fi
+  echo "✅ ${label} passed"
+}
+
+run_check "Embedded files sync check" ./scripts/sync-embedded-files.sh check
+run_check "Clippy (all targets/features, warnings as errors)" run_cargo clippy --all-targets --all-features -- -D warnings
+run_check "Tests (cargo test)" run_cargo test
+run_check "Hooks BDD gate" ./scripts/hooks-bdd-gate.sh
+
+echo ""
+echo "🎉 All pre-push checks passed!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project and everyone participating in it is governed by the [Code of Conduc
 git clone https://github.com/mikeyobrien/ralph-orchestrator.git
 cd ralph-orchestrator
 
-# Install git hooks for pre-commit checks
+# Install git hooks for pre-commit and pre-push checks
 ./scripts/setup-hooks.sh
 
 # Build the project
@@ -103,11 +103,26 @@ cargo test
 # Run smoke tests (replay-based, no API calls)
 cargo test -p ralph-core smoke_runner
 
-# Run with coverage
-cargo tarpaulin --out Html --output-dir coverage --skip-clean
+# Run with coverage (local only — uses cargo-llvm-cov)
+just coverage          # Full HTML report → coverage/html/index.html
+just coverage-summary  # Quick terminal summary
+just coverage-open     # Generate and open in browser
 ```
 
 **Important**: Always run smoke tests after making code changes. Smoke tests use recorded fixtures and are fast, free, and deterministic.
+
+### Coverage
+
+Coverage runs locally only — it is intentionally not part of CI to keep PR feedback fast and cheap. We use `cargo-llvm-cov` (included in the devenv shell) which instruments the same compilation that `cargo test` already does, so there's no separate build penalty.
+
+```bash
+# Install manually if not using devenv
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov
+
+# Generate coverage
+just coverage
+```
 
 ### Project Structure
 

--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,20 @@ clean:
 ci: fmt-check lint embedded-check test
     @echo "✅ CI checks passed"
 
+# Run tests with coverage report (local only, never in CI)
+coverage:
+    cargo llvm-cov --all-features --workspace --html --output-dir coverage
+    @echo ""
+    @echo "📊 Coverage report: coverage/html/index.html"
+
+# Quick coverage summary without HTML report
+coverage-summary:
+    cargo llvm-cov --all-features --workspace --summary-only
+
+# Run coverage and open report in browser
+coverage-open: coverage
+    open coverage/html/index.html 2>/dev/null || xdg-open coverage/html/index.html 2>/dev/null || echo "Open coverage/html/index.html manually"
+
 # Calibrated hooks mutation rollout threshold (see docs/06-analysis/hooks-mutation-baseline-2026-03-01.md)
 HOOKS_MUTATION_THRESHOLD := "55"
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -10,6 +10,7 @@
     just
     cargo-watch
     cargo-nextest
+    cargo-llvm-cov
     nodejs_22
     pkg-config
     openssl
@@ -20,7 +21,7 @@
   languages.rust = {
     enable = true;
     channel = "stable";
-    components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" ];
+    components = [ "rustc" "cargo" "clippy" "rustfmt" "rust-analyzer" "llvm-tools-preview" ];
   };
 
   # https://devenv.sh/processes/
@@ -39,6 +40,7 @@
     echo "  just lint      - Run clippy"
     echo "  just test      - Run tests"
     echo "  just build     - Build release binary"
+    echo "  just coverage  - Run tests with coverage report"
     echo "  verify         - Run full test suite + smoke tests"
   '';
 

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -24,11 +24,28 @@ else
     exit 1
 fi
 
+# Install pre-push hook
+if [ -f "$HOOKS_DIR/pre-push" ]; then
+    cp "$HOOKS_DIR/pre-push" "$GIT_HOOKS_DIR/pre-push"
+    chmod +x "$GIT_HOOKS_DIR/pre-push"
+    echo "✅ Installed pre-push hook"
+else
+    echo "⚠️  No pre-push hook found in .hooks/ (optional)"
+fi
+
 echo ""
 echo "🎉 Git hooks installed successfully!"
 echo ""
-echo "The pre-commit hook will now run before each commit to check:"
+echo "The pre-commit hook will run before each commit to check:"
 echo "  • ./scripts/sync-embedded-files.sh check"
 echo "  • cargo fmt --all -- --check (formatting)"
 echo "  • cargo clippy --all-targets --all-features -- -D warnings"
 echo "  • cargo test"
+echo ""
+echo "The pre-push hook will run before each push to verify:"
+echo "  • Embedded files sync check"
+echo "  • Clippy (all targets/features)"
+echo "  • Full test suite"
+echo "  • Hooks BDD gate"
+echo ""
+echo "Skip either hook with --no-verify when needed."


### PR DESCRIPTION
## Summary

Shift CI left to reduce GH Actions minutes per PR and move coverage to local-only.

## Changes

### CI (`ci.yml`)

| Before | After | Impact |
|--------|-------|--------|
| Clippy ran in separate `lint.yml` job, compiling the entire workspace from scratch | Clippy runs as a step in the `test` job, sharing the cargo cache | **~8-12 min saved per PR** (one full Rust compilation eliminated) |
| Explicit `cargo build --bin ralph` before `cargo test` | Removed — `cargo test` already compiles everything `hooks-bdd-gate.sh` needs | **~2-3 min saved** |
| E2E built with `cargo build --release -p ralph-e2e` | Debug build: `cargo build -p ralph-e2e` | **~3-5 min saved** (no LTO for mock E2E) |
| Format check only in `lint.yml` | Also in `ci.yml` as a standalone zero-compile job | Redundant safety net for non-fork PRs |

### Lint (`lint.yml`)

- Stripped to **fmt-only** for fork PRs via `pull_request_target`
- Clippy removed (now in `ci.yml` where it shares the compilation cache)
- Zero secrets, zero compilation, minimal blast radius for untrusted code

### Local Coverage (`Justfile` + `devenv.nix`)

- Added `just coverage` / `just coverage-summary` / `just coverage-open` using `cargo-llvm-cov`
- `cargo-llvm-cov` + `llvm-tools-preview` added to devenv shell
- Coverage runs locally only — intentionally not in CI to keep PR feedback fast and cheap
- Replaces the `cargo tarpaulin` reference in CONTRIBUTING.md

### Pre-Push Hook (`.hooks/pre-push`)

- New pre-push hook that mirrors the CI test job: embedded-check → clippy → tests → BDD gate
- Catches failures before they burn CI minutes
- Skippable with `git push --no-verify`
- `setup-hooks.sh` updated to install both pre-commit and pre-push hooks

### Release (`release.yml`)

- Left untouched — the `dist plan` on PRs is lightweight (~30s) by design from cargo-dist, and the `build-local-artifacts` job already has an `if` gate that skips the expensive matrix builds on PRs

## Estimated Impact

| Change | Minutes saved per PR |
|--------|---------------------|
| Merge clippy into test job cache | ~8-12 min |
| Remove redundant `cargo build --bin ralph` | ~2-3 min |
| Debug instead of release for E2E | ~3-5 min |
| Pre-push hook (prevents failed CI runs) | Variable — avoids entire wasted runs |
| **Total** | **~13-20 min per PR** + avoided failures |

## Files Changed

- `.github/workflows/ci.yml` — consolidated test + clippy + fmt
- `.github/workflows/lint.yml` — fmt-only for fork PRs
- `Justfile` — coverage targets
- `devenv.nix` — cargo-llvm-cov + llvm-tools-preview
- `.hooks/pre-push` — new pre-push gate
- `scripts/setup-hooks.sh` — install both hooks
- `CONTRIBUTING.md` — llvm-cov docs, coverage section

## Testing

- [ ] CI passes on this PR (self-validates the new workflow)
- [ ] `just coverage` works locally with devenv
- [ ] `./scripts/setup-hooks.sh` installs both hooks