### PR TITLE
fix(release): add ralph-api to crates.io publish order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,16 +298,22 @@ jobs:
       - name: Publish crates to crates.io
         run: |
           # Publish crates in dependency order with delays for registry indexing
-          # Order: ralph-proto -> ralph-telegram -> ralph-core -> ralph-adapters, ralph-tui -> ralph-cli
+          # Order: ralph-proto -> ralph-telegram -> ralph-core -> ralph-api -> ralph-adapters, ralph-tui -> ralph-cli
 
           publish_crate() {
             local crate=$1
             echo "Publishing $crate..."
-            if cargo publish -p "$crate" --no-verify 2>&1; then
+            if cargo publish -p "$crate" --no-verify 2>&1 | tee /tmp/publish-$crate.log; then
               echo "$crate published successfully"
             else
-              # Continue if it failed because the version already exists (idempotent re-runs)
-              echo "Warning: $crate publish returned an error (may already exist), continuing..."
+              local log=$(cat /tmp/publish-$crate.log)
+              if echo "$log" | grep -q "already uploaded"; then
+                echo "$crate already published at this version, skipping."
+              else
+                echo "::error::Failed to publish $crate"
+                cat /tmp/publish-$crate.log
+                exit 1
+              fi
             fi
             sleep 30
           }
@@ -315,6 +321,7 @@ jobs:
           publish_crate ralph-proto
           publish_crate ralph-telegram
           publish_crate ralph-core
+          publish_crate ralph-api
           publish_crate ralph-adapters
           publish_crate ralph-tui
           publish_crate ralph-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,7 +2730,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ralph-adapters"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-api"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-bench"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-cli"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-core"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-e2e"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-proto"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-telegram"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-tui"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [workspace.package]
 edition = "2024"
-version = "2.8.0"
+version = "2.8.1"
 license = "MIT"
 repository = "https://github.com/mikeyobrien/ralph-orchestrator"
 homepage = "https://github.com/mikeyobrien/ralph-orchestrator"
@@ -139,15 +139,15 @@ scopeguard = "1"
 strip-ansi-escapes = "0.2"
 
 # Internal crates (version required for crates.io publishing)
-ralph-proto = { version = "2.8.0", path = "crates/ralph-proto" }
-ralph-core = { version = "2.8.0", path = "crates/ralph-core", features = ["recording"] }
-ralph-adapters = { version = "2.8.0", path = "crates/ralph-adapters" }
-ralph-tui = { version = "2.8.0", path = "crates/ralph-tui" }
-ralph-cli = { version = "2.8.0", path = "crates/ralph-cli" }
-ralph-bench = { version = "2.8.0", path = "crates/ralph-bench" }
-ralph-e2e = { version = "2.8.0", path = "crates/ralph-e2e" }
-ralph-telegram = { version = "2.8.0", path = "crates/ralph-telegram" }
-ralph-api = { version = "2.8.0", path = "crates/ralph-api" }
+ralph-proto = { version = "2.8.1", path = "crates/ralph-proto" }
+ralph-core = { version = "2.8.1", path = "crates/ralph-core", features = ["recording"] }
+ralph-adapters = { version = "2.8.1", path = "crates/ralph-adapters" }
+ralph-tui = { version = "2.8.1", path = "crates/ralph-tui" }
+ralph-cli = { version = "2.8.1", path = "crates/ralph-cli" }
+ralph-bench = { version = "2.8.1", path = "crates/ralph-bench" }
+ralph-e2e = { version = "2.8.1", path = "crates/ralph-e2e" }
+ralph-telegram = { version = "2.8.1", path = "crates/ralph-telegram" }
+ralph-api = { version = "2.8.1", path = "crates/ralph-api" }
 
 # Telegram bot framework
 teloxide = { version = "0.13", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-orchestrator",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "description": "AI agent orchestrator with web dashboard",
   "workspaces": [


### PR DESCRIPTION
## Summary
- `ralph-cli` depends on `ralph-api` but it was missing from the `publish-crates` job in the release workflow, causing `cargo publish` for ralph-cli to fail since v2.8.0
- The error was silently swallowed by the catch-all `Warning... continuing` handler
- Adds `ralph-api` to publish order (after `ralph-core`, before `ralph-adapters`)
- Replaces blanket error suppression with proper "already uploaded" detection — actual failures now surface as CI errors
- Bumps to v2.8.1 to trigger a new release

## Test plan
- [x] Pre-commit hooks pass (fmt, clippy, tests)
- [ ] CI passes on PR
- [ ] After merge + tag, verify `publish-crates` job publishes ralph-cli 2.8.1 to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)