### PR TITLE
fix(event_loop): use config scratchpad path instead of hardcoded loop context default

### DIFF
--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -393,8 +393,15 @@ impl EventLoop {
             .unwrap_or_else(|| PathBuf::from(".ralph/agent/tasks.jsonl"))
     }
 
-    /// Returns the scratchpad path based on loop context or config.
+    /// Returns the scratchpad path based on config and loop context.
+    ///
+    /// If the config specifies a custom (non-default) scratchpad path, that
+    /// always wins. Otherwise, the loop context path is used for worktree
+    /// isolation, falling back to the config default.
     fn scratchpad_path(&self) -> PathBuf {
+        if self.config.core.scratchpad != ".ralph/agent/scratchpad.md" {
+            return PathBuf::from(&self.config.core.scratchpad);
+        }
         self.loop_context
             .as_ref()
             .map(|ctx| ctx.scratchpad_path())

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -3480,6 +3480,25 @@ fn test_paths_use_loop_context_when_present() {
 }
 
 #[test]
+fn test_custom_scratchpad_overrides_loop_context() {
+    use crate::loop_context::LoopContext;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_context = LoopContext::primary(temp_dir.path().to_path_buf());
+    let mut config = RalphConfig::default();
+    config.core.scratchpad = ".ralph/debug/global.md".to_string();
+
+    let event_loop = EventLoop::with_context(config, loop_context);
+
+    // Custom scratchpad path should take precedence over loop context
+    assert_eq!(
+        event_loop.scratchpad_path(),
+        PathBuf::from(".ralph/debug/global.md"),
+        "Custom scratchpad in config should override loop context default"
+    );
+}
+
+#[test]
 fn test_paths_fallback_to_config_when_no_context() {
     let temp_dir = tempfile::tempdir().unwrap();
     let scratchpad_path = temp_dir.path().join("scratchpad.md");

--- a/crates/ralph-core/src/hatless_ralph.rs
+++ b/crates/ralph-core/src/hatless_ralph.rs
@@ -455,8 +455,10 @@ Keep temporary artifacts where later steps can still inspect them, such as a rep
                 .filter_map(|e| e.ok())
                 .filter_map(|e| {
                     let path = e.path();
+                    let fname = path.file_name().and_then(|s| s.to_str());
                     if path.extension().and_then(|s| s.to_str()) == Some("md")
-                        && path.file_name().and_then(|s| s.to_str()) != Some("memories.md")
+                        && fname != Some("memories.md")
+                        && fname != Some("scratchpad.md")
                     {
                         path.file_name()
                             .and_then(|s| s.to_str())


### PR DESCRIPTION
## What

Fixes scratchpad content injection when `core.scratchpad` is set to a custom path. Also filters `scratchpad.md` from the "AVAILABLE CONTEXT FILES" prompt section.

## Why

When `core.scratchpad` was configured to a non-default path (e.g., `.ralph/debug/global.md`), `prepend_scratchpad()` read content from `.ralph/agent/scratchpad.md` (via `LoopContext::scratchpad_path()` which is hardcoded) while labeling the `<scratchpad>` tag with the correct config path — silently injecting the wrong file's content into the prompt.

Additionally, `scratchpad.md` was listed in the "AVAILABLE CONTEXT FILES" section even though it's already separately injected via the `<scratchpad>` tag, which is redundant and confusing when a custom path is in use.

## How

1. **`EventLoop::scratchpad_path()`** — When the config has a custom (non-default) scratchpad path, use it directly instead of deferring to `LoopContext`. The loop context path is still used for worktree isolation when the default path is configured.

2. **`HatlessRalph::core_prompt()`** — Filter `scratchpad.md` (alongside `memories.md`) from the context files listing, since the scratchpad is always injected separately.

3. **New test** — `test_custom_scratchpad_overrides_loop_context` verifies the config path takes precedence when both a loop context and custom scratchpad are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)