### PR TITLE
[codex] Fix guidance steering timing and urgent handoff gating

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -18,8 +18,9 @@ use ralph_core::{
     HookPayloadContextInput, HookPhaseEvent, HookRunRequest, HookRunResult, HookSuspendMode,
     LoopCompletionHandler, LoopContext, LoopHistory, LoopRegistry, MergeQueue, RalphConfig, Record,
     SessionRecorder, SummaryWriter, SuspendStateRecord, SuspendStateStore, TerminationReason,
+    UrgentSteerStore,
 };
-use ralph_proto::{Event, GuidanceTarget, HatId, RpcEvent, RpcState, RpcTaskCounts};
+use ralph_proto::{Event, HatId, RpcEvent, RpcState, RpcTaskCounts};
 use ralph_tui::Tui;
 use std::ffi::OsStr;
 use std::fs::{self, File};
@@ -163,6 +164,14 @@ pub async fn run_loop_impl(
     let ctx = loop_context
         .clone()
         .unwrap_or_else(|| LoopContext::primary(config.core.workspace_root.clone()));
+    let urgent_steer_path = ctx.urgent_steer_path();
+    let urgent_steer_store = UrgentSteerStore::new(urgent_steer_path.clone());
+    urgent_steer_store
+        .clear()
+        .context("Failed to clear stale urgent-steer marker")?;
+    let _urgent_steer_cleanup = scopeguard::guard(urgent_steer_path.clone(), |path| {
+        let _ = UrgentSteerStore::new(path).clear();
+    });
 
     // Write loop ID to marker file for task ownership tracking.
     // For worktree loops, use the loop_id; for primary loops, generate one.
@@ -450,6 +459,7 @@ pub async fn run_loop_impl(
                 .clone()
                 .expect("RPC guidance tx should exist"),
             rpc_event_tx.clone().expect("RPC event tx should exist"),
+            Some(urgent_steer_path.clone()),
             state_fn,
         );
 
@@ -496,7 +506,8 @@ pub async fn run_loop_impl(
         let tui = Tui::new()
             .with_hat_map(hat_map)
             .with_termination_signal(terminated_rx)
-            .with_events_path(resolve_current_events_path(&ctx));
+            .with_events_path(resolve_current_events_path(&ctx))
+            .with_urgent_steer_path(urgent_steer_path.clone());
 
         // Get shared state and guidance queue before spawning (for content streaming)
         let state = tui.state();
@@ -1015,74 +1026,15 @@ pub async fn run_loop_impl(
             return Ok(reason);
         }
 
-        // Drain next-loop guidance queue and write as human.guidance events.
-        // These will be picked up by process_events_from_jsonl() during build_prompt().
-        // Handle both TUI guidance queue and RPC guidance channel.
-        let mut guidance_messages: Vec<String> = Vec::new();
-
-        // Drain TUI guidance queue
-        if let Some(ref queue) = guidance_next_queue {
-            let messages: Vec<String> = {
-                let mut q = queue.lock().unwrap();
-                q.drain(..).collect()
-            };
-            guidance_messages.extend(messages);
-        }
-
-        // Drain RPC guidance channel (non-blocking)
-        if let Some(ref mut rx) = rpc_guidance_rx {
-            while let Ok(msg) = rx.try_recv() {
-                match msg.target {
-                    GuidanceTarget::Current => {
-                        debug!("Received RPC steer(current); applying at next prompt boundary");
-                        guidance_messages.push(msg.message);
-                    }
-                    GuidanceTarget::Next => guidance_messages.push(msg.message),
-                }
-            }
-        }
-
+        // Drain pending local guidance and inject it directly into the in-memory
+        // event loop so the next prompt boundary sees it immediately.
+        let guidance_messages =
+            drain_pending_guidance_messages(guidance_next_queue.as_ref(), rpc_guidance_rx.as_mut());
         if !guidance_messages.is_empty() {
-            let events_path = resolve_current_events_path(&ctx);
-
-            use std::io::Write;
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&events_path);
-
-            let mut writer = match file {
-                Ok(f) => std::io::BufWriter::new(f),
-                Err(e) => {
-                    warn!(error = %e, path = ?events_path, "Failed to open events file for guidance flush");
-                    // Skip flushing - keep loop running
-                    continue;
-                }
-            };
-
-            for msg in &guidance_messages {
-                let timestamp = chrono::Utc::now().to_rfc3339();
-                let event = serde_json::json!({
-                    "topic": "human.guidance",
-                    "payload": msg,
-                    "ts": timestamp,
-                });
-
-                match serde_json::to_string(&event) {
-                    Ok(line) => {
-                        if writeln!(writer, "{}", line).is_err() {
-                            warn!(path = ?events_path, "Failed writing guidance event line");
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Failed serializing guidance event");
-                    }
-                }
-            }
+            event_loop.inject_human_guidance(guidance_messages.iter().cloned());
             info!(
                 count = guidance_messages.len(),
-                "Wrote guidance events to events.jsonl"
+                "Injected pending guidance into event loop"
             );
         }
 
@@ -1548,6 +1500,9 @@ pub async fn run_loop_impl(
                 continue;
             }
         };
+        if let Err(err) = urgent_steer_store.clear() {
+            warn!(error = %err, "Failed to clear urgent-steer marker after prompt build");
+        }
 
         let display_hat =
             resolve_display_hat_for_execution(&event_loop, &hat_id, &preview_display_hat);
@@ -2398,7 +2353,14 @@ pub async fn run_loop_impl(
         // Inject default_publishes for active hats only when agent wrote no events.
         // Prefer the displayed execution hat first so a non-emitting turn still
         // falls back to the hat the user actually saw in the banner.
-        if !agent_wrote_events && wave_events.is_empty() {
+        let urgent_steer_pending = urgent_steer_store.load().ok().flatten().is_some();
+        let urgent_steer_blocked_emit = output.contains("Urgent steer is pending.");
+        if should_inject_default_publishes(
+            agent_wrote_events,
+            &wave_events,
+            urgent_steer_pending,
+            urgent_steer_blocked_emit,
+        ) {
             let mut fallback_hats = Vec::new();
             if display_hat.as_str() != "ralph" {
                 fallback_hats.push(display_hat.clone());
@@ -2415,6 +2377,8 @@ pub async fn run_loop_impl(
                     break; // One default is sufficient
                 }
             }
+        } else if urgent_steer_pending || urgent_steer_blocked_emit {
+            debug!("Urgent steer active; skipping default_publishes handoff");
         }
 
         // Check cancellation first (no chain validation) — takes priority over completion
@@ -4117,6 +4081,44 @@ fn resolve_current_events_path(ctx: &LoopContext) -> PathBuf {
             }
         })
         .unwrap_or_else(|| ctx.events_path())
+}
+
+fn drain_pending_guidance_messages(
+    guidance_next_queue: Option<&Arc<std::sync::Mutex<Vec<String>>>>,
+    rpc_guidance_rx: Option<&mut tokio::sync::mpsc::Receiver<GuidanceMessage>>,
+) -> Vec<String> {
+    let mut guidance_messages: Vec<String> = Vec::new();
+
+    if let Some(queue) = guidance_next_queue {
+        let messages: Vec<String> = {
+            let mut q = queue.lock().unwrap();
+            q.drain(..).collect()
+        };
+        guidance_messages.extend(messages);
+    }
+
+    if let Some(rx) = rpc_guidance_rx {
+        while let Ok(msg) = rx.try_recv() {
+            if msg.target == ralph_proto::GuidanceTarget::Current {
+                debug!("Received RPC steer(current); applying at next prompt boundary");
+            }
+            guidance_messages.push(msg.message);
+        }
+    }
+
+    guidance_messages
+}
+
+fn should_inject_default_publishes(
+    agent_wrote_events: bool,
+    wave_events: &[ralph_core::Event],
+    urgent_steer_pending: bool,
+    urgent_steer_blocked_emit: bool,
+) -> bool {
+    !agent_wrote_events
+        && wave_events.is_empty()
+        && !urgent_steer_pending
+        && !urgent_steer_blocked_emit
 }
 
 fn prepare_tui_iteration(
@@ -9809,5 +9811,53 @@ hats:
             r#"[Tool] Bash: ralph emit "hypothesis.test" "payload""#
         ));
         assert!(!output_mentions_ralph_emit("[Tool] Bash: cargo test"));
+    }
+
+    #[test]
+    fn test_drain_pending_guidance_reaches_next_prompt_boundary() {
+        let mut event_loop = EventLoop::new(RalphConfig::default());
+        event_loop
+            .bus()
+            .publish(Event::new("task.start", "Do work"));
+
+        let queue = Arc::new(std::sync::Mutex::new(vec!["focus on tests".to_string()]));
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<GuidanceMessage>(4);
+        tx.blocking_send(GuidanceMessage {
+            message: "steer this fix carefully".to_string(),
+            target: ralph_proto::GuidanceTarget::Current,
+        })
+        .expect("queue rpc guidance");
+
+        let guidance = drain_pending_guidance_messages(Some(&queue), Some(&mut rx));
+        event_loop.inject_human_guidance(guidance);
+
+        let prompt = event_loop
+            .build_prompt(&HatId::new("ralph"))
+            .expect("prompt should build");
+
+        assert!(prompt.contains("## ROBOT GUIDANCE"));
+        assert!(prompt.contains("focus on tests"));
+        assert!(prompt.contains("steer this fix carefully"));
+    }
+
+    #[test]
+    fn test_urgent_steer_blocks_default_publishes_injection() {
+        assert!(!should_inject_default_publishes(true, &[], false, false));
+        assert!(!should_inject_default_publishes(
+            false,
+            &[ralph_core::Event {
+                topic: "review.file".to_string(),
+                payload: Some("src/main.rs".to_string()),
+                ts: "2026-03-24T00:00:00Z".to_string(),
+                wave_id: None,
+                wave_index: None,
+                wave_total: None,
+            }],
+            false,
+            false
+        ));
+        assert!(!should_inject_default_publishes(false, &[], true, false));
+        assert!(!should_inject_default_publishes(false, &[], false, true));
+        assert!(should_inject_default_publishes(false, &[], false, false));
     }
 }

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -43,7 +43,8 @@ use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use ralph_adapters::detect_backend;
 use ralph_core::{
     CheckStatus, EventHistory, LockError, LoopContext, LoopEntry, LoopLock, LoopRegistry,
-    PreflightReport, PreflightRunner, RalphConfig, TerminationReason, truncate_with_ellipsis,
+    PreflightReport, PreflightRunner, RalphConfig, TerminationReason, UrgentSteerStore,
+    truncate_with_ellipsis,
     worktree::{WorktreeConfig, create_worktree, ensure_gitignore, remove_worktree},
 };
 use std::fs;
@@ -204,6 +205,10 @@ pub(crate) fn resolve_path_from_workspace(
     root: Option<&PathBuf>,
 ) -> PathBuf {
     resolve_workspace_root(root).join(path)
+}
+
+fn urgent_steer_path_from_workspace(root: Option<&PathBuf>) -> PathBuf {
+    resolve_workspace_root(root).join(".ralph/urgent-steer.json")
 }
 
 pub(crate) fn discover_workspace_root(start: &Path) -> Option<PathBuf> {
@@ -2420,6 +2425,29 @@ fn emit_command_with_root(
     let workspace_root = resolve_workspace_root(root);
     let current_events_marker = workspace_root.join(".ralph/current-events");
 
+    if std::env::var("RALPH_WAVE_ID").is_err() {
+        let urgent_steer_store = UrgentSteerStore::new(urgent_steer_path_from_workspace(root));
+        if let Some(record) = urgent_steer_store
+            .take()
+            .context("Failed to read urgent-steer marker")?
+        {
+            let guidance = record
+                .messages
+                .iter()
+                .enumerate()
+                .map(|(idx, message)| format!("{}. {}", idx + 1, message))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            anyhow::bail!(
+                "Urgent steer is pending. Do not hand off yet.\n\n\
+                 Human feedback:\n{guidance}\n\n\
+                 You have now seen the steer. Address it in this turn, then rerun `ralph emit` \
+                 once you are ready to hand off."
+            );
+        }
+    }
+
     // Generate timestamp if not provided
     let ts = args.ts.unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
 
@@ -3059,6 +3087,41 @@ mod tests {
             .expect("read events");
         assert!(events.contains("\"topic\":\"debug.step\""));
         assert!(events.contains("task_id=demo"));
+    }
+
+    #[test]
+    fn test_emit_command_blocks_once_when_urgent_steer_pending() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = temp_dir.path().to_path_buf();
+        std::fs::create_dir_all(workspace.join(".ralph")).expect("ralph dir");
+        UrgentSteerStore::new(urgent_steer_path_from_workspace(Some(&workspace)))
+            .append_message("stop and fix the failing tests")
+            .expect("write urgent steer");
+
+        let err = emit_command_with_root(
+            ColorMode::Never,
+            EmitArgs {
+                topic: "debug.step".to_string(),
+                payload: "task_id=demo".to_string(),
+                json: false,
+                ts: Some("2026-03-09T00:00:00Z".to_string()),
+                file: PathBuf::from(".ralph/events.jsonl"),
+            },
+            Some(&workspace),
+        )
+        .expect_err("urgent steer should block first emit");
+
+        let message = format!("{err:#}");
+        assert!(message.contains("Urgent steer is pending"));
+        assert!(message.contains("stop and fix the failing tests"));
+
+        assert!(
+            UrgentSteerStore::new(urgent_steer_path_from_workspace(Some(&workspace)))
+                .load()
+                .expect("load marker")
+                .is_none(),
+            "first blocked emit should clear urgent steer marker"
+        );
     }
 
     #[test]

--- a/crates/ralph-cli/src/rpc_stdin.rs
+++ b/crates/ralph-cli/src/rpc_stdin.rs
@@ -8,7 +8,9 @@
 //! handlers. It runs as a background tokio task alongside the orchestration
 //! loop, communicating via channels.
 
+use ralph_core::UrgentSteerStore;
 use ralph_proto::{GuidanceTarget, RpcCommand, RpcEvent, RpcState, emit_event_line, parse_command};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::sync::{mpsc, watch};
@@ -33,6 +35,9 @@ where
 
     /// Tracks whether the loop has been started (for prompt validation).
     pub loop_started: Arc<std::sync::atomic::AtomicBool>,
+
+    /// Marker file used to gate `ralph emit` while urgent steer is pending.
+    pub urgent_steer_path: Option<PathBuf>,
 }
 
 /// A guidance message with its target (current iteration or next).
@@ -51,6 +56,7 @@ where
         interrupt_tx: watch::Sender<bool>,
         guidance_tx: mpsc::Sender<GuidanceMessage>,
         response_tx: mpsc::Sender<RpcEvent>,
+        urgent_steer_path: Option<PathBuf>,
         state_fn: F,
     ) -> Self {
         Self {
@@ -59,6 +65,7 @@ where
             response_tx,
             state_fn: Arc::new(state_fn),
             loop_started: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            urgent_steer_path,
         }
     }
 
@@ -118,7 +125,19 @@ where
             }
 
             RpcCommand::Steer { message, .. } => {
-                // Push to guidance channel with Current target for immediate injection
+                if let Some(path) = &self.urgent_steer_path
+                    && let Err(err) =
+                        UrgentSteerStore::new(path.clone()).append_message(message.clone())
+                {
+                    return RpcEvent::error_response(
+                        cmd_type,
+                        id,
+                        format!("failed to persist urgent steer: {err}"),
+                    );
+                }
+
+                // Persist urgent steer immediately for the active iteration and
+                // also queue it for the next prompt boundary.
                 let msg = GuidanceMessage {
                     message: message.clone(),
                     target: GuidanceTarget::Current,
@@ -303,8 +322,9 @@ mod tests {
         let (guidance_tx, _guidance_rx) = mpsc::channel(10);
         let (response_tx, _response_rx) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         let cmd = RpcCommand::Abort {
             id: Some("abort-1".to_string()),
@@ -334,8 +354,9 @@ mod tests {
         let (guidance_tx, mut guidance_rx) = mpsc::channel(10);
         let (response_tx, _) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         let cmd = RpcCommand::Guidance {
             id: None,
@@ -356,8 +377,9 @@ mod tests {
         let (guidance_tx, _) = mpsc::channel(10);
         let (response_tx, _) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         let cmd = RpcCommand::GetState {
             id: Some("state-1".to_string()),
@@ -390,8 +412,9 @@ mod tests {
         let (guidance_tx, mut guidance_rx) = mpsc::channel(10);
         let (response_tx, _) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         // Steer should have Current target
         let steer_cmd = RpcCommand::Steer {
@@ -413,13 +436,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_steer_persists_urgent_marker() {
+        let (interrupt_tx, _) = watch::channel(false);
+        let (guidance_tx, _guidance_rx) = mpsc::channel(10);
+        let (response_tx, _) = mpsc::channel(10);
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let urgent_path = temp_dir.path().join("urgent-steer.json");
+
+        let dispatcher = RpcDispatcher::new(
+            interrupt_tx,
+            guidance_tx,
+            response_tx,
+            Some(urgent_path.clone()),
+            || default_state(),
+        );
+
+        let steer_cmd = RpcCommand::Steer {
+            id: None,
+            message: "steer now".to_string(),
+        };
+        let _response = dispatcher.dispatch(steer_cmd).await;
+
+        let record = UrgentSteerStore::new(urgent_path)
+            .load()
+            .expect("load marker")
+            .expect("record");
+        assert_eq!(record.messages, vec!["steer now"]);
+    }
+
+    #[tokio::test]
     async fn test_prompt_rejected_after_loop_started() {
         let (interrupt_tx, _) = watch::channel(false);
         let (guidance_tx, _) = mpsc::channel(10);
         let (response_tx, _) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         // Mark loop as started
         dispatcher.mark_loop_started();
@@ -448,8 +501,9 @@ mod tests {
         let (guidance_tx, _) = mpsc::channel(10);
         let (response_tx, mut response_rx) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         // Simulate stdin with a get_state command
         let input = r#"{"type": "get_state", "id": "test-1"}"#;
@@ -487,8 +541,9 @@ mod tests {
         let (guidance_tx, _) = mpsc::channel(10);
         let (response_tx, mut response_rx) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         // Invalid JSON
         let input = r#"{"type": "nonexistent_command"}"#;
@@ -524,8 +579,9 @@ mod tests {
         let (guidance_tx, _) = mpsc::channel(10);
         let (response_tx, _response_rx) = mpsc::channel(10);
 
-        let dispatcher =
-            RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, || default_state());
+        let dispatcher = RpcDispatcher::new(interrupt_tx, guidance_tx, response_tx, None, || {
+            default_state()
+        });
 
         // Empty input = immediate EOF
         let reader = std::io::Cursor::new(Vec::<u8>::new());

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -779,6 +779,22 @@ impl EventLoop {
         self.bus.has_human_pending()
     }
 
+    /// Injects `human.guidance` events directly into the in-memory bus.
+    ///
+    /// This is used for local TUI/RPC guidance so the next prompt boundary
+    /// sees the message immediately without waiting for a JSONL reread.
+    pub fn inject_human_guidance<I, S>(&mut self, messages: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for message in messages {
+            let event = Event::new("human.guidance", message.into());
+            self.state.record_event(&event);
+            self.bus.publish(event);
+        }
+    }
+
     /// Returns whether unread JSONL events include any semantic `plan.*` topics.
     ///
     /// This allows callers to dispatch `pre.plan.created` hooks before

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -50,6 +50,7 @@ pub mod task_definition;
 pub mod task_store;
 pub mod testing;
 mod text;
+mod urgent_steer;
 pub mod utils;
 pub mod wave_detection;
 pub mod wave_prompt;
@@ -127,6 +128,7 @@ pub use task_definition::{
 };
 pub use task_store::TaskStore;
 pub use text::{floor_char_boundary, truncate_with_ellipsis};
+pub use urgent_steer::{UrgentSteerRecord, UrgentSteerStore};
 pub use wave_detection::{DetectedWave, detect_wave_events};
 pub use wave_prompt::{WaveWorkerContext, build_wave_worker_prompt};
 pub use wave_tracker::{CompletedWave, WaveFailure, WaveProgress, WaveResult, WaveTracker};

--- a/crates/ralph-core/src/loop_context.rs
+++ b/crates/ralph-core/src/loop_context.rs
@@ -175,6 +175,14 @@ impl LoopContext {
         self.ralph_dir().join("current-events")
     }
 
+    /// Path to the urgent-steer marker file.
+    ///
+    /// This file is created when `!` arrives during an active iteration so
+    /// `ralph emit` can block handoff until the current model turn has seen it.
+    pub fn urgent_steer_path(&self) -> PathBuf {
+        self.ralph_dir().join("urgent-steer.json")
+    }
+
     /// Path to the tasks JSONL file.
     ///
     /// Each loop has its own isolated tasks file.

--- a/crates/ralph-core/src/urgent_steer.rs
+++ b/crates/ralph-core/src/urgent_steer.rs
@@ -1,0 +1,111 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UrgentSteerRecord {
+    pub messages: Vec<String>,
+    pub created_at: String,
+}
+
+impl UrgentSteerRecord {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            messages: vec![message.into()],
+            created_at: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UrgentSteerStore {
+    path: PathBuf,
+}
+
+impl UrgentSteerStore {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load(&self) -> io::Result<Option<UrgentSteerRecord>> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(&self.path)?;
+        let record = serde_json::from_str::<UrgentSteerRecord>(&content)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        Ok(Some(record))
+    }
+
+    pub fn append_message(&self, message: impl Into<String>) -> io::Result<UrgentSteerRecord> {
+        let message = message.into();
+        let mut record = self
+            .load()?
+            .unwrap_or_else(|| UrgentSteerRecord::new(message.clone()));
+
+        if record.messages.last() != Some(&message) {
+            record.messages.push(message);
+        }
+
+        self.write(&record)?;
+        Ok(record)
+    }
+
+    pub fn write(&self, record: &UrgentSteerRecord) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let payload = serde_json::to_string(record)
+            .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+        fs::write(&self.path, payload)
+    }
+
+    pub fn clear(&self) -> io::Result<()> {
+        match fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn take(&self) -> io::Result<Option<UrgentSteerRecord>> {
+        let record = self.load()?;
+        self.clear()?;
+        Ok(record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_message_creates_and_reloads_record() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = UrgentSteerStore::new(temp_dir.path().join("urgent-steer.json"));
+
+        let record = store.append_message("check tests first").expect("append");
+        assert_eq!(record.messages, vec!["check tests first"]);
+
+        let loaded = store.load().expect("load").expect("record");
+        assert_eq!(loaded.messages, vec!["check tests first"]);
+    }
+
+    #[test]
+    fn take_returns_record_and_clears_file() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = UrgentSteerStore::new(temp_dir.path().join("urgent-steer.json"));
+        store.append_message("steer now").expect("append");
+
+        let record = store.take().expect("take").expect("record");
+        assert_eq!(record.messages, vec!["steer now"]);
+        assert!(store.load().expect("load after take").is_none());
+    }
+}

--- a/crates/ralph-tui/src/input.rs
+++ b/crates/ralph-tui/src/input.rs
@@ -36,9 +36,9 @@ pub enum Action {
     ShowHelp,
     /// Dismiss help overlay or cancel search
     DismissHelp,
-    /// Open guidance input for next iteration
+    /// Open guidance input for the next prompt boundary
     GuidanceNext,
-    /// Open guidance input for current iteration (urgent)
+    /// Open urgent steer input for the active iteration
     GuidanceNow,
     /// Enter wave worker drill-down view
     EnterWaveView,

--- a/crates/ralph-tui/src/lib.rs
+++ b/crates/ralph-tui/src/lib.rs
@@ -216,6 +216,15 @@ impl Tui {
         self
     }
 
+    /// Sets the path to the urgent-steer marker file for immediate `!` gating.
+    #[must_use]
+    pub fn with_urgent_steer_path(self, path: std::path::PathBuf) -> Self {
+        if let Ok(mut state) = self.state.lock() {
+            state.urgent_steer_path = Some(path);
+        }
+        self
+    }
+
     /// Returns the shared state for external updates.
     pub fn state(&self) -> Arc<Mutex<TuiState>> {
         Arc::clone(&self.state)

--- a/crates/ralph-tui/src/rpc_writer.rs
+++ b/crates/ralph-tui/src/rpc_writer.rs
@@ -30,8 +30,8 @@ impl<W: AsyncWrite + Unpin + Send> RpcWriter<W> {
 
     /// Sends a guidance message for the next iteration.
     ///
-    /// The subprocess will queue this guidance and inject it at the start
-    /// of the next iteration.
+    /// The subprocess will queue this guidance and inject it at the next
+    /// prompt boundary.
     pub async fn send_guidance(&self, message: &str) -> std::io::Result<()> {
         let cmd = RpcCommand::Guidance {
             id: None,
@@ -42,8 +42,10 @@ impl<W: AsyncWrite + Unpin + Send> RpcWriter<W> {
 
     /// Sends a steer message for immediate injection.
     ///
-    /// The subprocess will attempt to inject this guidance into the
-    /// currently running iteration.
+    /// The subprocess will persist urgent steer immediately so `ralph emit`
+    /// cannot hand off before the current model turn has seen the feedback.
+    /// The guidance also appears at the next prompt boundary if a new prompt
+    /// must be built.
     pub async fn send_steer(&self, message: &str) -> std::io::Result<()> {
         let cmd = RpcCommand::Steer {
             id: None,

--- a/crates/ralph-tui/src/state.rs
+++ b/crates/ralph-tui/src/state.rs
@@ -96,9 +96,9 @@ impl SearchState {
 /// Whether guidance is being entered for the next or current iteration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuidanceMode {
-    /// Guidance for the next iteration (queued, written before build_prompt)
+    /// Guidance for the next prompt boundary.
     Next,
-    /// Guidance for the current iteration (written immediately to events.jsonl)
+    /// Urgent steer for the active iteration.
     Now,
 }
 
@@ -107,7 +107,7 @@ pub enum GuidanceMode {
 pub enum GuidanceResult {
     /// Next-iteration guidance was queued successfully.
     Queued,
-    /// Current-iteration guidance was written to events successfully.
+    /// Urgent steer was persisted successfully.
     Sent,
     /// Guidance could not be queued/written.
     Failed,
@@ -269,8 +269,10 @@ pub struct TuiState {
     pub guidance_input: String,
     /// Queue of guidance messages for the next iteration (drained by loop_runner).
     pub guidance_next_queue: Arc<Mutex<Vec<String>>>,
-    /// Path to events.jsonl for writing "now" guidance directly.
+    /// Path to events.jsonl for writing urgent guidance for the next prompt.
     pub events_path: Option<std::path::PathBuf>,
+    /// Path to the urgent-steer marker file used to gate `ralph emit`.
+    pub urgent_steer_path: Option<std::path::PathBuf>,
     /// Brief flash message after attempting to send guidance.
     /// (mode, result, when)
     pub guidance_flash: Option<(GuidanceMode, GuidanceResult, Instant)>,
@@ -339,6 +341,7 @@ impl TuiState {
             guidance_input: String::new(),
             guidance_next_queue: Arc::new(Mutex::new(Vec::new())),
             events_path: None,
+            urgent_steer_path: None,
             guidance_flash: None,
             // Subprocess error state
             subprocess_error: None,
@@ -388,6 +391,7 @@ impl TuiState {
                 let saved_pending_backend = self.pending_backend.clone();
                 let saved_guidance_next_queue = Arc::clone(&self.guidance_next_queue);
                 let saved_events_path = self.events_path.clone();
+                let saved_urgent_steer_path = self.urgent_steer_path.clone();
                 *self = Self::new();
                 self.hat_map = saved_hat_map;
                 self.loop_started = saved_loop_started; // Keep original timer
@@ -399,6 +403,7 @@ impl TuiState {
                 self.pending_backend = saved_pending_backend;
                 self.guidance_next_queue = saved_guidance_next_queue;
                 self.events_path = saved_events_path;
+                self.urgent_steer_path = saved_urgent_steer_path;
                 if let Some((hat_id, hat_display)) = custom_hat {
                     self.pending_hat = Some((hat_id, hat_display));
                 } else {
@@ -812,7 +817,8 @@ impl TuiState {
     /// Sends the current guidance input.
     ///
     /// For `GuidanceMode::Next`, pushes to the shared queue (drained by loop_runner).
-    /// For `GuidanceMode::Now`, writes directly to events.jsonl.
+    /// For `GuidanceMode::Now`, writes an urgent-steer marker immediately and
+    /// records `human.guidance` for the next prompt boundary.
     ///
     /// Returns true if guidance was sent successfully.
     pub fn send_guidance(&mut self) -> bool {
@@ -837,7 +843,8 @@ impl TuiState {
                 }
             }
             GuidanceMode::Now => {
-                let ok = self.write_guidance_event(&input);
+                let ok =
+                    self.write_urgent_steer_marker(&input) && self.write_guidance_event(&input);
                 if ok {
                     (true, GuidanceResult::Sent)
                 } else {
@@ -881,6 +888,16 @@ impl TuiState {
         };
 
         file.write_all(line.as_bytes()).is_ok() && file.write_all(b"\n").is_ok()
+    }
+
+    fn write_urgent_steer_marker(&self, message: &str) -> bool {
+        let Some(ref path) = self.urgent_steer_path else {
+            return false;
+        };
+
+        ralph_core::UrgentSteerStore::new(path.clone())
+            .append_message(message.to_string())
+            .is_ok()
     }
 
     /// Returns true if guidance input is currently active.
@@ -2485,9 +2502,11 @@ mod tests {
         fn send_guidance_now_writes_to_events_file() {
             let dir = tempfile::tempdir().unwrap();
             let events_path = dir.path().join("events.jsonl");
+            let urgent_steer_path = dir.path().join("urgent-steer.json");
 
             let mut state = TuiState::new();
             state.events_path = Some(events_path.clone());
+            state.urgent_steer_path = Some(urgent_steer_path.clone());
             state.start_guidance(GuidanceMode::Now);
             state.guidance_input = "fix the bug now".to_string();
             assert!(state.send_guidance());
@@ -2497,6 +2516,12 @@ mod tests {
             assert_eq!(event["topic"], "human.guidance");
             assert_eq!(event["payload"], "fix the bug now");
             assert!(event["ts"].is_string());
+
+            let steer = ralph_core::UrgentSteerStore::new(urgent_steer_path)
+                .load()
+                .unwrap()
+                .expect("urgent steer");
+            assert_eq!(steer.messages, vec!["fix the bug now"]);
         }
 
         #[test]

--- a/crates/ralph-tui/src/widgets/help.rs
+++ b/crates/ralph-tui/src/widgets/help.rs
@@ -66,11 +66,11 @@ pub fn render(f: &mut Frame, area: Rect) {
         )),
         Line::from(vec![
             Span::styled("  :", Style::default().fg(Color::Cyan)),
-            Span::raw("      Send guidance (next iteration)"),
+            Span::raw("      Send guidance (next prompt)"),
         ]),
         Line::from(vec![
             Span::styled("  !", Style::default().fg(Color::Cyan)),
-            Span::raw("      Send guidance (now, current iteration)"),
+            Span::raw("      Urgent steer (blocks handoff until seen)"),
         ]),
         Line::from(""),
         Line::from(Span::styled(


### PR DESCRIPTION
Fixes #266.

This change fixes the TUI/RPC steering path for both `:` guidance and `!` urgent steer.

Before this patch, local guidance was written to `events.jsonl` at iteration start, but the loop selected the next hat and built the prompt before it reread JSONL. In practice that meant `:` usually landed one iteration late, and `!` had no reliable way to reach the currently running model turn before handoff.

The fix has two parts.

First, local `:` and queued RPC guidance are now injected directly into the in-memory event loop before termination checks, hat selection, and prompt construction. That makes the next prompt boundary actually contain the new `human.guidance` input instead of waiting for a later file reread.

Second, `!` now persists an urgent-steer marker as soon as the steer command is received. The `ralph emit` command checks that shared marker and refuses to hand off while urgent steer is pending, returning the human feedback back to the model in the live turn. If the loop rebuilds a fresh prompt instead, the same steer also appears in `## ROBOT GUIDANCE` and the urgent marker is cleared after prompt construction.

To avoid silent completion around an urgent steer, the loop also skips default publish injection when urgent steer is still pending or when `ralph emit` was just blocked by the urgent-steer gate.

Validation:

- `cargo test`
- `cargo test -p ralph-core smoke_runner`
- Added regression coverage for next-prompt guidance injection
- Added regression coverage for urgent-steer persistence and one-shot `ralph emit` blocking
