### PR TITLE
[codex] fix tui mouse toggle

### DIFF
--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -118,9 +118,21 @@ pub fn dispatch_action(action: Action, state: &mut TuiState, viewport_height: us
         Action::EnterWaveView => {
             state.enter_wave_view();
         }
+        Action::ToggleMouseMode => {
+            state.mouse_capture_enabled = !state.mouse_capture_enabled;
+        }
         Action::None => {}
     }
     false
+}
+
+fn set_mouse_capture(enabled: bool) -> Result<()> {
+    if enabled {
+        execute!(io::stdout(), EnableMouseCapture)?;
+    } else {
+        execute!(io::stdout(), DisableMouseCapture)?;
+    }
+    Ok(())
 }
 
 /// Main TUI application for read-only observation.
@@ -172,7 +184,7 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
     pub async fn run(mut self) -> Result<()> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen)?;
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
         terminal.clear()?;
@@ -181,9 +193,17 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
         // When cleanup_tui() calls handle.abort(), the task is cancelled immediately
         // at its current await point, skipping all code after the loop. This defer!
         // guard runs on Drop, which is guaranteed even during task cancellation.
+        let cleanup_state = Arc::clone(&self.state);
         defer! {
             let _ = disable_raw_mode();
-            let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture, Show);
+            let mouse_capture_enabled = cleanup_state
+                .lock()
+                .map(|state| state.mouse_capture_enabled)
+                .unwrap_or(false);
+            if mouse_capture_enabled {
+                let _ = execute!(io::stdout(), DisableMouseCapture);
+            }
+            let _ = execute!(io::stdout(), LeaveAlternateScreen, Show);
         }
 
         let update_state = Arc::clone(&self.state);
@@ -326,8 +346,14 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
                                     // Map key to action and dispatch
                                     let action = map_key(key);
                                     let mut state = self.state.lock().unwrap();
+                                    let mouse_capture_enabled_before = state.mouse_capture_enabled;
                                     if dispatch_action(action, &mut state, viewport_height) {
                                         break;
+                                    }
+                                    let mouse_capture_enabled_after = state.mouse_capture_enabled;
+                                    drop(state);
+                                    if mouse_capture_enabled_before != mouse_capture_enabled_after {
+                                        set_mouse_capture(mouse_capture_enabled_after)?;
                                     }
                                 }
                                 // Ignore other events (FocusGained, FocusLost, Paste, Resize, key releases)
@@ -626,6 +652,18 @@ mod tests {
         assert!(!should_quit, "Non-quit actions should return false");
     }
 
+    #[test]
+    fn dispatch_action_toggle_mouse_mode_flips_state() {
+        let mut state = TuiState::new();
+        assert!(!state.mouse_capture_enabled);
+
+        dispatch_action(Action::ToggleMouseMode, &mut state, 10);
+        assert!(state.mouse_capture_enabled);
+
+        dispatch_action(Action::ToggleMouseMode, &mut state, 10);
+        assert!(!state.mouse_capture_enabled);
+    }
+
     // =========================================================================
     // AC6: No PTY Code — Structural Test
     // =========================================================================
@@ -684,6 +722,14 @@ mod tests {
             production_code.contains("KeyCode::Char('c')")
                 && production_code.contains("KeyModifiers::CONTROL"),
             "Production code must detect Ctrl+C via crossterm events"
+        );
+    }
+
+    #[test]
+    fn mouse_capture_starts_disabled_by_default() {
+        assert!(
+            !TuiState::new().mouse_capture_enabled,
+            "Production TUI should start with mouse capture disabled so native text selection works by default"
         );
     }
 }

--- a/crates/ralph-tui/src/input.rs
+++ b/crates/ralph-tui/src/input.rs
@@ -42,6 +42,8 @@ pub enum Action {
     GuidanceNow,
     /// Enter wave worker drill-down view
     EnterWaveView,
+    /// Toggle mouse capture for wheel scrolling vs native text selection
+    ToggleMouseMode,
     /// Key not mapped to any action
     None,
 }
@@ -59,6 +61,7 @@ pub enum Action {
 /// - `/`: Start search
 /// - `n`: Next search match
 /// - `N`: Previous search match
+/// - `m`: Toggle mouse mode
 /// - `?`: Show help
 /// - `Esc`: Dismiss help/cancel search
 pub fn map_key(key: KeyEvent) -> Action {
@@ -87,6 +90,9 @@ pub fn map_key(key: KeyEvent) -> Action {
 
         // Wave view
         KeyCode::Char('w') => Action::EnterWaveView,
+
+        // Mouse mode
+        KeyCode::Char('m') => Action::ToggleMouseMode,
 
         // Help
         KeyCode::Char('?') => Action::ShowHelp,
@@ -214,7 +220,14 @@ mod tests {
         assert_eq!(map_key(key), Action::GuidanceNow);
     }
 
-    // AC17: Unknown Key Returns None
+    // AC17: m Toggles Mouse Mode
+    #[test]
+    fn m_returns_toggle_mouse_mode() {
+        let key = KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE);
+        assert_eq!(map_key(key), Action::ToggleMouseMode);
+    }
+
+    // AC18: Unknown Key Returns None
     #[test]
     fn unknown_key_returns_none() {
         let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);

--- a/crates/ralph-tui/src/state.rs
+++ b/crates/ralph-tui/src/state.rs
@@ -192,6 +192,9 @@ pub struct TuiState {
     pub last_event_at: Option<Instant>,
     /// Whether to show help overlay.
     pub show_help: bool,
+    /// Whether mouse capture is enabled for wheel scrolling.
+    /// When false, the terminal keeps native drag-to-select behavior.
+    pub mouse_capture_enabled: bool,
     /// Whether in scroll mode.
     pub in_scroll_mode: bool,
     /// Current search query (if in search input mode).
@@ -310,6 +313,7 @@ impl TuiState {
             last_event: None,
             last_event_at: None,
             show_help: false,
+            mouse_capture_enabled: false,
             in_scroll_mode: false,
             search_query: String::new(),
             search_forward: true,

--- a/crates/ralph-tui/src/widgets/footer.rs
+++ b/crates/ralph-tui/src/widgets/footer.rs
@@ -129,6 +129,13 @@ impl Widget for Footer<'_> {
             "Total Time Elapsed: 00:00".to_string()
         };
         left_spans.push(Span::raw(elapsed_display));
+        if self.state.mouse_capture_enabled {
+            left_spans.push(Span::raw(" │ "));
+            left_spans.push(Span::styled(
+                "Mouse: scroll (m)",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
 
         let indicator_text = if self.state.loop_completed {
             "■ DONE"
@@ -350,6 +357,25 @@ mod tests {
             text.contains('◉') && text.contains("ACTIVE"),
             "should show ACTIVE indicator at startup, got: {}",
             text
+        );
+    }
+
+    #[test]
+    fn footer_shows_mouse_mode() {
+        let mut state = TuiState::new();
+        let select_text = render_to_string(&state);
+        assert!(
+            !select_text.contains("Mouse:"),
+            "should keep default footer uncluttered when mouse capture is off, got: {}",
+            select_text
+        );
+
+        state.mouse_capture_enabled = true;
+        let scroll_text = render_to_string(&state);
+        assert!(
+            scroll_text.contains("Mouse: scroll (m)"),
+            "should show scroll mode when mouse capture enabled, got: {}",
+            scroll_text
         );
     }
 }

--- a/crates/ralph-tui/src/widgets/help.rs
+++ b/crates/ralph-tui/src/widgets/help.rs
@@ -49,6 +49,10 @@ pub fn render(f: &mut Frame, area: Rect) {
             Span::styled("  G", Style::default().fg(Color::Cyan)),
             Span::raw("      Scroll to bottom"),
         ]),
+        Line::from(vec![
+            Span::styled("  m", Style::default().fg(Color::Cyan)),
+            Span::raw("      Toggle mouse mode (select/scroll)"),
+        ]),
         Line::from(""),
         Line::from(Span::styled("Search:", Style::default().fg(Color::Yellow))),
         Line::from(vec![


### PR DESCRIPTION
## Summary
This change fixes a TUI usability regression where users could not select text with a normal mouse drag unless they held `Shift`. The terminal UI was enabling mouse capture as soon as it entered the alternate screen, so the terminal routed drag events to the application instead of handling native selection itself.

The fix changes the default behavior so mouse capture starts disabled, which restores normal text selection immediately. To preserve the existing wheel-scroll use case, the TUI now exposes an explicit `m` toggle that turns mouse capture on and off at runtime. When mouse capture is enabled, the footer shows that mouse scroll mode is active, and the help overlay documents the toggle.

## Root Cause
The TUI bootstrap path in `crates/ralph-tui/src/app.rs` always sent `EnableMouseCapture` during startup. In most terminals, that means mouse drag and wheel events are delivered to the TUI instead of being handled by the terminal itself. That behavior is useful for app-level mouse scrolling, but it breaks the more important default expectation that users can drag to select text directly.

## Fix
The change removes default mouse capture from TUI startup and cleanup, adds a `mouse_capture_enabled` flag to `TuiState`, introduces a new `ToggleMouseMode` action mapped to `m`, and applies the crossterm mouse-capture escape sequence only when that mode is toggled. The help overlay now advertises the toggle, and the footer shows a `Mouse: scroll (m)` indicator only while capture is active so the default footer layout stays uncluttered.

## Validation
I ran the full repo test suite on this branch, plus the focused TUI and smoke checks:

- `cargo test`
- `cargo test -p ralph-tui`
- `cargo test -p ralph-core smoke_runner`
