### PR TITLE
feat: improve rich TUI tool output and e2e harness

### DIFF
--- a/crates/ralph-adapters/src/stream_handler.rs
+++ b/crates/ralph-adapters/src/stream_handler.rs
@@ -539,7 +539,10 @@ impl StreamHandler for TuiStreamHandler {
         let line = Line::from(vec![
             Span::styled("  ↳ ", Style::default().fg(RatatuiColor::DarkGray)),
             Span::styled("✓ ", Style::default().fg(RatatuiColor::Green)),
-            Span::styled(truncate(&clean, 200), Style::default().fg(RatatuiColor::DarkGray)),
+            Span::styled(
+                truncate(&clean, 200),
+                Style::default().fg(RatatuiColor::DarkGray),
+            ),
         ]);
         self.add_non_text_line(line);
     }

--- a/crates/ralph-adapters/src/stream_handler.rs
+++ b/crates/ralph-adapters/src/stream_handler.rs
@@ -19,6 +19,11 @@ use std::{
 };
 use termimad::MadSkin;
 
+#[path = "tool_preview.rs"]
+mod tool_preview;
+
+use tool_preview::{format_tool_result, format_tool_summary};
+
 /// Detects if text contains ANSI escape sequences.
 ///
 /// Checks for the common ANSI escape sequence prefix `\x1b[` (ESC + `[`)
@@ -531,19 +536,23 @@ impl StreamHandler for TuiStreamHandler {
             return;
         }
         let clean = sanitize_tui_inline_text(&display);
-        let line = Line::from(Span::styled(
-            format!(" \u{2713} {}", truncate(&clean, 200)),
-            Style::default().fg(RatatuiColor::DarkGray),
-        ));
+        let line = Line::from(vec![
+            Span::styled("  ↳ ", Style::default().fg(RatatuiColor::DarkGray)),
+            Span::styled("✓ ", Style::default().fg(RatatuiColor::Green)),
+            Span::styled(truncate(&clean, 200), Style::default().fg(RatatuiColor::DarkGray)),
+        ]);
         self.add_non_text_line(line);
     }
 
     fn on_error(&mut self, error: &str) {
         let clean = sanitize_tui_inline_text(error);
-        let line = Line::from(Span::styled(
-            format!("\u{2717} Error: {}", clean),
-            Style::default().fg(RatatuiColor::Red),
-        ));
+        let line = Line::from(vec![
+            Span::styled("  ↳ ", Style::default().fg(RatatuiColor::DarkGray)),
+            Span::styled(
+                format!("\u{2717} Error: {}", clean),
+                Style::default().fg(RatatuiColor::Red),
+            ),
+        ]);
         self.add_non_text_line(line);
     }
 
@@ -567,130 +576,6 @@ impl StreamHandler for TuiStreamHandler {
         let line = Line::from(Span::styled(summary, Style::default().fg(color)));
         self.add_non_text_line(line);
     }
-}
-
-/// Extracts the most relevant field from tool input for display.
-///
-/// Returns a human-readable summary (file path, command, pattern, etc.) based on the tool type.
-/// Returns `None` for unknown tools or if the expected field is missing.
-fn format_tool_summary(name: &str, input: &serde_json::Value) -> Option<String> {
-    match name {
-        "Read" | "Edit" | "Write" | "read" | "write" => input
-            .get("file_path")
-            .or_else(|| input.get("path"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        "Bash" | "shell" => {
-            let cmd = input.get("command")?.as_str()?;
-            Some(truncate(cmd, 60))
-        }
-        "Grep" | "grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
-        "Glob" | "glob" | "ls" => input
-            .get("pattern")
-            .or_else(|| input.get("path"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        "Task" => input.get("description")?.as_str().map(|s| s.to_string()),
-        "WebFetch" | "web_fetch" => input.get("url")?.as_str().map(|s| s.to_string()),
-        "WebSearch" | "web_search" => input.get("query")?.as_str().map(|s| s.to_string()),
-        "LSP" => {
-            let op = input.get("operation")?.as_str()?;
-            let file = input.get("filePath")?.as_str()?;
-            Some(format!("{} @ {}", op, file))
-        }
-        "NotebookEdit" => input.get("notebook_path")?.as_str().map(|s| s.to_string()),
-        "TodoWrite" => Some("updating todo list".to_string()),
-        _ => {
-            // Generic fallback: try common keys
-            input
-                .get("path")
-                .or_else(|| input.get("file_path"))
-                .or_else(|| input.get("command"))
-                .or_else(|| input.get("pattern"))
-                .or_else(|| input.get("url"))
-                .or_else(|| input.get("query"))
-                .and_then(|v| v.as_str())
-                .map(|s| truncate(s, 60))
-        }
-    }
-}
-
-/// Extracts human-readable content from ACP tool result JSON envelopes.
-///
-/// ACP tool results arrive as `{"items":[{"Text":"..."} | {"Json":{...}}]}`.
-/// This function extracts the meaningful content:
-/// - Shell results (Json with stdout/stderr): shows stdout, or stderr on failure
-/// - Glob results (Json with filePaths): shows count and basenames
-/// - Text results: shows the text content directly
-/// - Falls back to raw string for non-JSON or unknown formats.
-fn format_tool_result(output: &str) -> String {
-    let Ok(val) = serde_json::from_str::<serde_json::Value>(output) else {
-        return output.to_string();
-    };
-    let Some(items) = val.get("items").and_then(|v| v.as_array()) else {
-        return output.to_string();
-    };
-    let Some(item) = items.first() else {
-        return String::new();
-    };
-
-    // {"Text": "..."}
-    if let Some(text) = item.get("Text").and_then(|v| v.as_str()) {
-        return text.to_string();
-    }
-
-    // {"Json": {...}}
-    if let Some(json) = item.get("Json") {
-        // Shell: {exit_status, stdout, stderr}
-        if let Some(stdout) = json.get("stdout").and_then(|v| v.as_str()) {
-            let stderr = json.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
-            let exit = json
-                .get("exit_status")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let failed = !exit.contains("status: 0");
-            return if failed && !stderr.is_empty() {
-                stderr.to_string()
-            } else if !stdout.is_empty() {
-                stdout.to_string()
-            } else {
-                stderr.to_string()
-            };
-        }
-        // Glob: {filePaths, totalFiles, truncated}
-        if let Some(paths) = json.get("filePaths").and_then(|v| v.as_array()) {
-            let total = json
-                .get("totalFiles")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(paths.len() as u64);
-            let names: Vec<&str> = paths
-                .iter()
-                .filter_map(|p| p.as_str())
-                .map(|p| p.rsplit('/').next().unwrap_or(p))
-                .collect();
-            return format!("{} files: {}", total, names.join(", "));
-        }
-        // Grep: {numFiles, numMatches, results: [{file, matches: [...]}]}
-        if let Some(results) = json.get("results").and_then(|v| v.as_array()) {
-            let num_matches = json.get("numMatches").and_then(|v| v.as_u64()).unwrap_or(0);
-            let first_match = results.first().and_then(|r| {
-                let file = r.get("file").and_then(|v| v.as_str()).unwrap_or("");
-                let basename = file.rsplit('/').next().unwrap_or(file);
-                let matches = r.get("matches").and_then(|v| v.as_array())?;
-                let first = matches.first().and_then(|m| m.as_str())?;
-                Some(format!("{}: {}", basename, first.trim()))
-            });
-            return match first_match {
-                Some(m) => format!("{} matches: {}", num_matches, m),
-                None => format!("{} matches", num_matches),
-            };
-        }
-
-        // Unknown Json: compact stringify
-        return json.to_string();
-    }
-
-    output.to_string()
 }
 
 /// Truncates a string to approximately `max_len` characters, adding "..." if truncated.
@@ -1070,10 +955,10 @@ mod tests {
                 line_text
             );
 
-            // Check style is red
-            let first_span = &lines[0].spans[0];
+            // Check style is red on the error payload span (after the dim arrow prefix)
+            let error_span = &lines[0].spans[1];
             assert_eq!(
-                first_span.style.fg,
+                error_span.style.fg,
                 Some(Color::Red),
                 "Error line should have red foreground"
             );
@@ -1814,6 +1699,20 @@ mod tests {
             let output = "just plain text output";
             let result = format_tool_result(output);
             assert_eq!(result, output, "Non-JSON should pass through unchanged");
+        }
+
+        #[test]
+        fn format_tool_result_compacts_short_multiline_text() {
+            let output = "README.md\nnotes.txt\nsummary.md\n";
+            let result = format_tool_result(output);
+            assert_eq!(result, "README.md • notes.txt • summary.md");
+        }
+
+        #[test]
+        fn format_tool_result_summarizes_long_multiline_text() {
+            let output = "first line\nsecond line\nthird line\nfourth line\nfifth line\n";
+            let result = format_tool_result(output);
+            assert_eq!(result, "first line • second line (+3 more lines)");
         }
 
         #[test]

--- a/crates/ralph-adapters/src/tool_preview.rs
+++ b/crates/ralph-adapters/src/tool_preview.rs
@@ -1,0 +1,161 @@
+use serde_json::Value;
+
+pub(super) fn format_tool_summary(name: &str, input: &Value) -> Option<String> {
+    match name {
+        "Read" | "Edit" | "Write" | "read" | "edit" | "write" => input
+            .get("file_path")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        "Bash" | "bash" | "shell" => {
+            let cmd = input.get("command")?.as_str()?;
+            Some(truncate_preview(cmd, 60))
+        }
+        "Grep" | "grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
+        "Glob" | "glob" | "ls" => input
+            .get("pattern")
+            .or_else(|| input.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        "Task" => input.get("description")?.as_str().map(|s| s.to_string()),
+        "WebFetch" | "web_fetch" => input.get("url")?.as_str().map(|s| s.to_string()),
+        "WebSearch" | "web_search" => input.get("query")?.as_str().map(|s| s.to_string()),
+        "LSP" => {
+            let op = input.get("operation")?.as_str()?;
+            let file = input.get("filePath")?.as_str()?;
+            Some(format!("{} @ {}", op, file))
+        }
+        "NotebookEdit" => input.get("notebook_path")?.as_str().map(|s| s.to_string()),
+        "TodoWrite" => Some("updating todo list".to_string()),
+        _ => input
+            .get("path")
+            .or_else(|| input.get("file_path"))
+            .or_else(|| input.get("command"))
+            .or_else(|| input.get("pattern"))
+            .or_else(|| input.get("url"))
+            .or_else(|| input.get("query"))
+            .and_then(|v| v.as_str())
+            .map(|s| truncate_preview(s, 60)),
+    }
+}
+
+pub(super) fn format_tool_result(output: &str) -> String {
+    let Ok(val) = serde_json::from_str::<Value>(output) else {
+        return summarize_plain_text(output);
+    };
+    let Some(items) = val.get("items").and_then(|v| v.as_array()) else {
+        return output.to_string();
+    };
+    let Some(item) = items.first() else {
+        return String::new();
+    };
+
+    if let Some(text) = item.get("Text").and_then(|v| v.as_str()) {
+        return summarize_plain_text(text);
+    }
+
+    if let Some(json) = item.get("Json") {
+        if let Some(stdout) = json.get("stdout").and_then(|v| v.as_str()) {
+            let stderr = json.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
+            let exit = json
+                .get("exit_status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let failed = !exit.contains("status: 0");
+            return if failed && !stderr.is_empty() {
+                summarize_plain_text(stderr)
+            } else if !stdout.is_empty() {
+                summarize_plain_text(stdout)
+            } else {
+                summarize_plain_text(stderr)
+            };
+        }
+
+        if let Some(paths) = json.get("filePaths").and_then(|v| v.as_array()) {
+            let total = json
+                .get("totalFiles")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(paths.len() as u64);
+            let names: Vec<&str> = paths
+                .iter()
+                .filter_map(|p| p.as_str())
+                .map(|p| p.rsplit('/').next().unwrap_or(p))
+                .collect();
+            let shown = names.iter().take(3).copied().collect::<Vec<_>>();
+            return if total > shown.len() as u64 {
+                format!(
+                    "{} files: {} (+{} more)",
+                    total,
+                    shown.join(", "),
+                    total - shown.len() as u64
+                )
+            } else {
+                format!("{} files: {}", total, shown.join(", "))
+            };
+        }
+
+        if let Some(results) = json.get("results").and_then(|v| v.as_array()) {
+            let num_matches = json.get("numMatches").and_then(|v| v.as_u64()).unwrap_or(0);
+            let first_match = results.first().and_then(|r| {
+                let file = r.get("file").and_then(|v| v.as_str()).unwrap_or("");
+                let basename = file.rsplit('/').next().unwrap_or(file);
+                let matches = r.get("matches").and_then(|v| v.as_array())?;
+                let first = matches.first().and_then(|m| m.as_str())?;
+                Some(format!("{}: {}", basename, first.trim()))
+            });
+            return match first_match {
+                Some(m) => format!("{} matches: {}", num_matches, m),
+                None => format!("{} matches", num_matches),
+            };
+        }
+
+        return json.to_string();
+    }
+
+    summarize_plain_text(output)
+}
+
+fn summarize_plain_text(output: &str) -> String {
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let lines: Vec<&str> = trimmed
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+
+    if lines.len() <= 1 {
+        return trimmed.to_string();
+    }
+
+    let short_lines = lines.len() <= 4 && lines.iter().all(|line| line.chars().count() <= 60);
+    if short_lines {
+        return lines.join(" • ");
+    }
+
+    let first = lines.first().copied().unwrap_or(trimmed);
+    let second = lines.get(1).copied();
+    let remaining = lines.len().saturating_sub(2);
+
+    match (second, remaining) {
+        (Some(next), 0) => format!("{} • {}", first, next),
+        (Some(next), more) => format!("{} • {} (+{} more lines)", first, next, more),
+        (None, _) => first.to_string(),
+    }
+}
+
+fn truncate_preview(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else {
+        let byte_idx = s
+            .char_indices()
+            .nth(max_len)
+            .map(|(idx, _)| idx)
+            .unwrap_or(s.len());
+        format!("{}...", &s[..byte_idx])
+    }
+}

--- a/crates/ralph-cli/presets/autoresearch.yml
+++ b/crates/ralph-cli/presets/autoresearch.yml
@@ -5,14 +5,16 @@
 #
 # Works for ANY measurable improvement: performance, code quality, test coverage,
 # bundle size, error rates, documentation completeness, security scores, etc.
+# Also works for subjective quality targets (UX, readability, design) via LLM-as-judge.
 #
-# The loop runs until interrupted. Each cycle: strategize -> implement -> measure -> evaluate.
+# The loop runs until interrupted. Each cycle: strategize -> implement -> measure -> judge -> evaluate.
 # State persists in autoresearch.md and autoresearch.jsonl.
 #
-# 4 Hats:
+# 5 Hats:
 # - Strategist: Decides what experiment to try next
 # - Implementer: Executes the planned change
-# - Benchmarker: Runs the measurement command and captures metrics
+# - Benchmarker: Runs the measurement command, captures metrics and artifacts
+# - Judge: Scores the experiment against the quality rubric using LLM-as-judge
 # - Evaluator: Decides keep/discard, commits or reverts, updates records
 #
 # Usage:
@@ -25,7 +27,7 @@
 event_loop:
   prompt_file: "PROMPT.md"
   completion_promise: "LOOP_COMPLETE"
-  required_events: ["experiment.measured", "experiment.evaluated"]
+  required_events: ["experiment.scored", "experiment.evaluated"]
   starting_event: "experiment.start"
   max_iterations: 500
   max_runtime_seconds: 28800   # 8 hours
@@ -47,6 +49,7 @@ core:
     - "One change at a time — each experiment tests exactly one hypothesis"
     - "Don't thrash — if repeatedly reverting the same idea, try something structurally different"
     - "Think longer when stuck — re-read source files, study the data, reason about root causes"
+    - "Judge scores are first-class — the judge hat always runs, scoring hard metrics and subjective quality alike"
 
 hats:
   strategist:
@@ -116,6 +119,26 @@ hats:
 
       ## Constraints
       <Hard rules: tests must pass, no new deps, etc.>
+
+      ## Judge Rubric
+      <Define how the LLM-as-judge scores each experiment. Always present — even for
+       pure-numeric workloads the judge validates metrics and checks for regressions.>
+
+      ### Criteria
+      <List each quality dimension the judge evaluates. Each criterion gets a 1-10 score.>
+      - **<criterion name>**: <what good looks like vs bad>
+
+      ### Artifacts
+      <What the Benchmarker should capture for the judge to evaluate.>
+      - Capture command: `<command that writes artifacts to .autoresearch/artifacts/>`
+      - Types: <screenshots, output samples, diffs, rendered HTML, logs, etc.>
+      - If no capture command: judge scores based on hard metrics + code diff only
+
+      ### Scoring
+      - Pass threshold: <minimum average score to keep, e.g., 7/10>
+      - Veto criteria: <any criterion below this score = automatic discard, e.g., 4/10>
+      - Weight: <how judge score combines with primary metric — "gate" (binary pass/fail),
+        "weighted" (blended score), or "tiebreak" (used only when metrics are equal)>
 
       ## What's Been Tried
       <Updated after each experiment. Note key wins, dead ends, and architectural insights.>
@@ -210,7 +233,7 @@ hats:
 
   benchmarker:
     name: "Benchmarker"
-    description: "Runs the measurement command from autoresearch.md, captures metrics, and runs correctness checks."
+    description: "Runs the measurement command from autoresearch.md, captures metrics, correctness checks, and judge artifacts."
     triggers: ["experiment.ready"]
     publishes: ["experiment.measured"]
     default_publishes: "experiment.measured"
@@ -237,8 +260,21 @@ hats:
          - Run `bash autoresearch.checks.sh 2>&1`
          - Record whether checks passed or failed
          - Checks execution time does NOT affect the primary metric
-      7. Emit with all metrics: `ralph emit "experiment.measured" "task_id=<id> task_key=<key> primary_metric=<value> exit_code=<code> duration=<seconds> checks=<passed|failed|skipped|not_run>"`
-      8. Stop after emitting.
+      7. Capture artifacts for the Judge:
+         - Read the "Judge Rubric > Artifacts" section of `autoresearch.md` for the capture command
+         - If a capture command is defined:
+           ```bash
+           mkdir -p .autoresearch/artifacts
+           <capture_command> 2>&1
+           ```
+         - If no capture command: generate a code diff as the artifact:
+           ```bash
+           mkdir -p .autoresearch/artifacts
+           git diff HEAD > .autoresearch/artifacts/diff.patch
+           ```
+         - Record the list of artifact files produced
+      8. Emit with all metrics: `ralph emit "experiment.measured" "task_id=<id> task_key=<key> primary_metric=<value> exit_code=<code> duration=<seconds> checks=<passed|failed|skipped|not_run> artifacts=<comma-separated artifact paths>"`
+      9. Stop after emitting.
 
       ### If Benchmark Crashes
 
@@ -256,40 +292,117 @@ hats:
       - You MUST run checks only when the benchmark passes — failed benchmarks skip checks
       - You MUST use `ralph emit` to publish events — plain-language summaries do NOT publish events
 
+  judge:
+    name: "Judge"
+    description: "Scores the experiment against the quality rubric using LLM-as-judge. Always runs."
+    triggers: ["experiment.measured"]
+    publishes: ["experiment.scored"]
+    default_publishes: "experiment.scored"
+    instructions: |
+      ## JUDGE MODE — Score The Experiment
+
+      Start from the auto-injected objective and current event context.
+      You are running inside Ralph. `ralph emit` is available.
+      The loop also sets `$RALPH_BIN`; prefer `"$RALPH_BIN" emit ...`.
+
+      You score every experiment. You do not decide keep/discard — the Evaluator does that.
+      Your job is to produce structured, consistent scores that the Evaluator can use.
+
+      ### Process
+
+      1. Read the `experiment.measured` payload for `task_id`, `task_key`, metrics, checks, and artifacts
+      2. Read `autoresearch.md` — find the "Judge Rubric" section for criteria, scoring rules, and pass threshold
+      3. If the benchmark crashed (exit_code != 0):
+         - Set all criterion scores to 0, judge_score to 0, judge_pass to false
+         - Skip to step 7
+      4. Read/view the artifacts:
+         - If artifact paths were provided, read each artifact file
+         - If artifacts include images (PNG, SVG), view them
+         - If no artifacts exist, read `git diff HEAD` for the code diff
+      5. Score each criterion from the rubric on a 1-10 scale:
+         - Write a one-line rationale for each score
+         - Be consistent: the same quality level should always get the same score
+         - Compare against what you've seen in previous experiments if `autoresearch.jsonl` exists
+         - Do NOT grade on a curve — use the rubric's definition of good/bad as the anchor
+      6. Compute the aggregate:
+         - `judge_score`: average of all criterion scores (rounded to 1 decimal)
+         - `judge_pass`: true if judge_score >= pass_threshold AND no criterion is below veto_threshold
+         - `judge_detail`: JSON object mapping criterion name to {score, rationale}
+      7. Forward all hard metrics from experiment.measured unchanged, adding judge scores:
+         ```
+         ralph emit "experiment.scored" "task_id=<id> task_key=<key> primary_metric=<value> exit_code=<code> duration=<seconds> checks=<checks> judge_score=<score> judge_pass=<true|false> judge_detail=<json>"
+         ```
+      8. Stop after emitting.
+
+      ### Scoring Without a Rubric
+
+      If autoresearch.md has no "Judge Rubric" section or the criteria list is empty:
+      - Score based on general code quality of the diff: correctness, simplicity, readability
+      - Use a single criterion "code_quality" with pass threshold 6/10
+      - This ensures every experiment gets a judge assessment even for pure-numeric workloads
+
+      ### Scoring Consistency
+
+      To maintain consistency across experiments:
+      - Read the last 3-5 entries in `autoresearch.jsonl` that have judge_detail
+      - Calibrate your scores relative to what you scored before
+      - If a previous experiment scored 7/10 for readability, a similar-quality change should also score ~7
+      - Avoid score drift (gradually inflating or deflating over the session)
+
+      ### Constraints
+      - You MUST NOT decide keep/discard — that belongs to the Evaluator
+      - You MUST NOT modify any source files
+      - You MUST NOT modify autoresearch.md or autoresearch.jsonl — that belongs to the Evaluator
+      - You MUST score every criterion listed in the rubric — do not skip any
+      - You MUST provide a rationale for every score — bare numbers are not acceptable
+      - You MUST forward all hard metrics from experiment.measured unchanged
+      - You MUST use `ralph emit` to publish events — plain-language summaries do NOT publish events
+      - You MUST NOT invoke `[Tool] Agent` or any parallel subagent tool in this preset
+
   evaluator:
     name: "Evaluator"
-    description: "Decides keep/discard based on metrics, commits or reverts, and updates experiment records."
-    triggers: ["experiment.measured"]
+    description: "Decides keep/discard based on metrics and judge scores, commits or reverts, and updates experiment records."
+    triggers: ["experiment.scored"]
     publishes: ["experiment.evaluated", "LOOP_COMPLETE"]
     default_publishes: "experiment.evaluated"
     instructions: |
-      ## EVALUATOR MODE — Judge The Experiment
+      ## EVALUATOR MODE — Decide The Experiment's Fate
 
       Start from the auto-injected objective and current event context.
       You are running inside Ralph. `ralph emit`, `ralph tools task`, and `ralph tools memory` are available.
       The loop also sets `$RALPH_BIN`; prefer `"$RALPH_BIN" emit ...` and `"$RALPH_BIN" tools ...`.
 
-      You are the judge. You decide whether to keep or discard each experiment based on hard data.
+      You are the final decision-maker. You combine hard metrics and judge scores to decide keep or discard.
       You also maintain the experiment log and session document.
 
       ### Process
 
-      1. Read the `experiment.measured` payload for `task_id`, `task_key`, metrics, and checks result
-      2. Read `autoresearch.md` for the metric direction (lower/higher is better)
+      1. Read the `experiment.scored` payload for `task_id`, `task_key`, metrics, checks, and judge scores
+      2. Read `autoresearch.md` for the metric direction (lower/higher is better) and judge weight mode
       3. Read `autoresearch.jsonl` to find the baseline and current best metric
          - If `autoresearch.jsonl` doesn't exist, this is the baseline — always KEEP
          - Baseline = first experiment; current best = best kept experiment so far
-      4. Evaluate the result:
+      4. Evaluate the result using both hard metrics and judge scores.
+         Read the "Judge Rubric > Scoring > Weight" from autoresearch.md to determine the judge weight mode:
+
+      **Weight modes:**
+      - `gate`: Judge is a binary gate. Primary metric must improve AND judge_pass must be true.
+      - `weighted`: Blended score. Combine primary metric improvement % and judge_score into a weighted decision.
+      - `tiebreak`: Judge score is used only when primary metrics are equal — higher judge_score wins.
+      - If no weight mode specified, default to `gate`.
 
       **KEEP** when:
       - This is the baseline (first experiment) — always keep to establish the reference
-      - Primary metric improved vs current best AND checks passed (or no checks file)
-      - Removing code for equal metric value (simpler = better)
+      - `gate` mode: primary metric improved vs current best AND checks passed AND judge_pass is true
+      - `weighted` mode: blended score (metric improvement + judge_score) exceeds threshold
+      - `tiebreak` mode: primary metric improved AND checks passed; OR metric equal AND judge_score > previous
+      - Removing code for equal metric value AND judge_pass is true (simpler = better)
 
       **DISCARD** when:
       - Primary metric is worse than current best
-      - Primary metric is equal to current best (unless code was removed — simpler = keep)
+      - Primary metric is equal to current best and judge doesn't break the tie (in tiebreak mode)
       - Primary metric improved but checks failed
+      - Primary metric improved but judge_pass is false (gate/weighted modes)
       - Primary metric improved but a secondary metric degraded catastrophically
 
       **CRASH** when:
@@ -304,11 +417,12 @@ hats:
       ```bash
       git checkout -- .
       git clean -fd
+      rm -rf .autoresearch/artifacts
       ```
 
       6. Append the result to `autoresearch.jsonl`:
          ```json
-         {"run":<N>,"commit":"<hash-or-empty>","metric":<value>,"metrics":{...},"status":"<keep|discard|crash>","description":"<what was tried>","timestamp":<epoch_ms>,"segment":0}
+         {"run":<N>,"commit":"<hash-or-empty>","metric":<value>,"metrics":{...},"judge_score":<score>,"judge_pass":<bool>,"judge_detail":{...},"status":"<keep|discard|crash>","description":"<what was tried>","timestamp":<epoch_ms>,"segment":0}
          ```
          - On KEEP: leave `commit` as `""` — fill after committing
          - On DISCARD/CRASH: `commit` is the current HEAD
@@ -316,7 +430,7 @@ hats:
       7. Update `autoresearch.md`:
          - On KEEP: update the "Current Best" value in the Metrics section
          - Append to "What's Been Tried":
-           `- **Run N (KEEP/DISCARD, metric=X)**: <what was tried>. Hypothesis: <confirmed/refuted>.`
+           `- **Run N (KEEP/DISCARD, metric=X, judge=Y/10)**: <what was tried>. Hypothesis: <confirmed/refuted>.`
 
       8. If the experiment revealed promising ideas, append them to `autoresearch.ideas.md`
 
@@ -341,7 +455,7 @@ hats:
 
       11. Close the runtime task: `ralph tools task close <task_id>`
 
-      12. Emit: `ralph emit "experiment.evaluated" "task_id=<id> task_key=<key> decision=<keep|discard|crash> metric=<value> delta=<percent vs baseline> run=<N> trend=<N>of5_kept reason=<brief reason>"`
+      12. Emit: `ralph emit "experiment.evaluated" "task_id=<id> task_key=<key> decision=<keep|discard|crash> metric=<value> judge_score=<score> judge_pass=<bool> delta=<percent vs baseline> run=<N> trend=<N>of5_kept reason=<brief reason>"`
       13. Stop after emitting.
 
       ### When To Stop
@@ -351,8 +465,8 @@ hats:
 
       ### Constraints
       - You MUST NOT modify source files — only git operations and experiment records
-      - You MUST NOT keep an experiment when checks failed
-      - You MUST NOT discard an experiment that improved the primary metric unless checks failed or complexity is unjustified
+      - You MUST NOT keep an experiment when checks failed or judge_pass is false (in gate/weighted modes)
+      - You MUST NOT discard an experiment that improved the primary metric and passed the judge unless complexity is unjustified
       - You MUST update "What's Been Tried" in autoresearch.md after every experiment — the Strategist depends on this
       - You MUST append to autoresearch.jsonl after every experiment for persistent tracking
       - You MUST revert cleanly on discard — no leftover changes in the working tree

--- a/crates/ralph-tui/src/rpc_source.rs
+++ b/crates/ralph-tui/src/rpc_source.rs
@@ -822,8 +822,14 @@ mod tests {
             .position(|line| line.contains("Recovered after failure."))
             .expect("after text should remain visible");
 
-        assert!(before_idx < error_idx, "error should stay after preceding text: {rendered:?}");
-        assert!(error_idx < after_idx, "error should stay before following text: {rendered:?}");
+        assert!(
+            before_idx < error_idx,
+            "error should stay after preceding text: {rendered:?}"
+        );
+        assert!(
+            error_idx < after_idx,
+            "error should stay before following text: {rendered:?}"
+        );
     }
 
     #[test]

--- a/crates/ralph-tui/src/rpc_source.rs
+++ b/crates/ralph-tui/src/rpc_source.rs
@@ -12,17 +12,19 @@ use std::time::Instant;
 
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
-use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tracing::{debug, warn};
 
 use ralph_proto::json_rpc::RpcEvent;
 
 use crate::state::{TaskCounts, TuiState, WaveInfo};
-use crate::state_mutations::{
-    append_error_line, apply_loop_completed, apply_task_active, apply_task_close,
-};
-use crate::text_renderer::{text_to_lines, truncate};
+use crate::state_mutations::{apply_loop_completed, apply_task_active, apply_task_close};
+use crate::text_renderer::{sanitize_tui_inline_text, text_to_lines, truncate};
+
+#[path = "../../ralph-adapters/src/tool_preview.rs"]
+mod tool_preview;
+
+use tool_preview::{format_tool_result, format_tool_summary};
 
 /// Runs the RPC event reader, processing events from the given async reader.
 ///
@@ -145,6 +147,27 @@ struct TextAccumulator {
 enum ContentBlock {
     Text(String),
     NonText(Line<'static>),
+}
+
+fn format_error_line(code: &str, message: &str) -> Line<'static> {
+    let clean = sanitize_tui_inline_text(message);
+    if code == "EXECUTION_ERROR" {
+        Line::from(vec![
+            Span::styled("  ↳ ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("\u{2717} Error: {}", clean),
+                Style::default().fg(Color::Red),
+            ),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(
+                format!("\u{26A0} [{code}] "),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::raw(clean),
+        ])
+    }
 }
 
 impl TextAccumulator {
@@ -283,6 +306,7 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>, acc: &mut Tex
             if !tool_name.contains(' ')
                 && let Some(summary) = format_tool_summary(tool_name, input)
             {
+                let summary = sanitize_tui_inline_text(&summary);
                 spans.push(Span::styled(
                     format!(" {}", summary),
                     Style::default().fg(Color::DarkGray),
@@ -309,17 +333,21 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>, acc: &mut Tex
                 return;
             }
 
-            let (prefix, color) = if *is_error {
-                ("\u{2717} ", Color::Red)
+            let clean = sanitize_tui_inline_text(&display);
+            let truncated = truncate(&clean, 200);
+            let line = if *is_error {
+                Line::from(vec![
+                    Span::styled("  ↳ ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("✗ ", Style::default().fg(Color::Red)),
+                    Span::styled(truncated, Style::default().fg(Color::Red)),
+                ])
             } else {
-                ("\u{2713} ", Color::DarkGray)
+                Line::from(vec![
+                    Span::styled("  ↳ ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("✓ ", Style::default().fg(Color::Green)),
+                    Span::styled(truncated, Style::default().fg(Color::DarkGray)),
+                ])
             };
-
-            let truncated = truncate(&display, 200);
-            let line = Line::from(Span::styled(
-                format!(" {}{}", prefix, truncated),
-                Style::default().fg(color),
-            ));
 
             if let Some(handle) = s.latest_iteration_lines_handle() {
                 acc.push_non_text(line, &handle);
@@ -330,7 +358,10 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>, acc: &mut Tex
         }
 
         RpcEvent::Error { code, message, .. } => {
-            append_error_line(&mut s, code, message);
+            let line = format_error_line(code, message);
+            if let Some(handle) = s.latest_iteration_lines_handle() {
+                acc.push_non_text(line, &handle);
+            }
 
             s.last_event = Some("error".to_string());
             s.last_event_at = Some(Instant::now());
@@ -544,122 +575,6 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>, acc: &mut Tex
     }
 }
 
-/// Extracts the most relevant field from tool input for display.
-fn format_tool_summary(name: &str, input: &Value) -> Option<String> {
-    // Try the primary key for the tool name first, then common fallbacks.
-    // ACP tools use lowercase names (read, write, shell, ls, glob, grep)
-    // while Claude uses PascalCase (Read, Write, Bash, Glob, Grep).
-    match name {
-        "Read" | "Edit" | "Write" | "read" | "write" => input
-            .get("path")
-            .or_else(|| input.get("file_path"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        "Bash" | "shell" => {
-            let cmd = input.get("command")?.as_str()?;
-            Some(truncate(cmd, 60))
-        }
-        "Grep" | "grep" => input.get("pattern")?.as_str().map(|s| s.to_string()),
-        "Glob" | "glob" | "ls" => input
-            .get("pattern")
-            .or_else(|| input.get("path"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        "Task" => input.get("description")?.as_str().map(|s| s.to_string()),
-        "WebFetch" | "web_fetch" => input.get("url")?.as_str().map(|s| s.to_string()),
-        "WebSearch" | "web_search" => input.get("query")?.as_str().map(|s| s.to_string()),
-        "LSP" => {
-            let op = input.get("operation")?.as_str()?;
-            let file = input.get("filePath")?.as_str()?;
-            Some(format!("{} @ {}", op, file))
-        }
-        "NotebookEdit" => input.get("notebook_path")?.as_str().map(|s| s.to_string()),
-        "TodoWrite" => Some("updating todo list".to_string()),
-        _ => {
-            // Generic fallback: try common keys
-            input
-                .get("path")
-                .or_else(|| input.get("file_path"))
-                .or_else(|| input.get("command"))
-                .or_else(|| input.get("pattern"))
-                .or_else(|| input.get("url"))
-                .or_else(|| input.get("query"))
-                .and_then(|v| v.as_str())
-                .map(|s| truncate(s, 60))
-        }
-    }
-}
-
-/// Extracts human-readable content from ACP tool result JSON envelopes.
-///
-/// ACP tool results arrive as `{"items":[{"Text":"..."} | {"Json":{...}}]}`.
-fn format_tool_result(output: &str) -> String {
-    let Ok(val) = serde_json::from_str::<Value>(output) else {
-        return output.to_string();
-    };
-    let Some(items) = val.get("items").and_then(|v| v.as_array()) else {
-        return output.to_string();
-    };
-    let Some(item) = items.first() else {
-        return String::new();
-    };
-
-    if let Some(text) = item.get("Text").and_then(|v| v.as_str()) {
-        return text.to_string();
-    }
-
-    if let Some(json) = item.get("Json") {
-        // Shell: {exit_status, stdout, stderr}
-        if let Some(stdout) = json.get("stdout").and_then(|v| v.as_str()) {
-            let stderr = json.get("stderr").and_then(|v| v.as_str()).unwrap_or("");
-            let exit = json
-                .get("exit_status")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let failed = !exit.contains("status: 0");
-            return if failed && !stderr.is_empty() {
-                stderr.to_string()
-            } else if !stdout.is_empty() {
-                stdout.to_string()
-            } else {
-                stderr.to_string()
-            };
-        }
-        // Glob/ls: {filePaths, totalFiles}
-        if let Some(paths) = json.get("filePaths").and_then(|v| v.as_array()) {
-            let total = json
-                .get("totalFiles")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(paths.len() as u64);
-            let names: Vec<&str> = paths
-                .iter()
-                .filter_map(|p| p.as_str())
-                .map(|p| p.rsplit('/').next().unwrap_or(p))
-                .collect();
-            return format!("{} files: {}", total, names.join(", "));
-        }
-        // Grep: {numFiles, numMatches, results}
-        if let Some(results) = json.get("results").and_then(|v| v.as_array()) {
-            let num_matches = json.get("numMatches").and_then(|v| v.as_u64()).unwrap_or(0);
-            let first_match = results.first().and_then(|r| {
-                let file = r.get("file").and_then(|v| v.as_str()).unwrap_or("");
-                let basename = file.rsplit('/').next().unwrap_or(file);
-                let matches = r.get("matches").and_then(|v| v.as_array())?;
-                let first = matches.first().and_then(|m| m.as_str())?;
-                Some(format!("{}: {}", basename, first.trim()))
-            });
-            return match first_match {
-                Some(m) => format!("{} matches: {}", num_matches, m),
-                None => format!("{} matches", num_matches),
-            };
-        }
-
-        return json.to_string();
-    }
-
-    output.to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -771,6 +686,151 @@ mod tests {
         let s = state.lock().unwrap();
         let lines = s.iterations[0].lines.lock().unwrap();
         assert_eq!(lines.len(), 1);
+    }
+
+    #[test]
+    fn test_tool_call_start_sanitizes_multiline_summary() {
+        let state = make_state();
+        let mut acc = make_acc();
+
+        apply_rpc_event(
+            &RpcEvent::IterationStart {
+                iteration: 1,
+                max_iterations: None,
+                hat: "builder".to_string(),
+                hat_display: "🔨Builder".to_string(),
+                backend: "claude".to_string(),
+                started_at: 0,
+            },
+            &state,
+            &mut acc,
+        );
+
+        apply_rpc_event(
+            &RpcEvent::ToolCallStart {
+                iteration: 1,
+                tool_name: "Bash".to_string(),
+                tool_call_id: "tool_1".to_string(),
+                input: json!({"command": "printf 'first line'\nprintf 'second line'"}),
+            },
+            &state,
+            &mut acc,
+        );
+
+        let s = state.lock().unwrap();
+        let lines = s.iterations[0].lines.lock().unwrap();
+        let rendered = lines[0].to_string();
+        assert!(!rendered.contains('\n'));
+        assert!(rendered.contains("printf 'first line' printf 'second line'"));
+    }
+
+    #[test]
+    fn test_tool_call_end_sanitizes_multiline_result_preview() {
+        let state = make_state();
+        let mut acc = make_acc();
+
+        apply_rpc_event(
+            &RpcEvent::IterationStart {
+                iteration: 1,
+                max_iterations: None,
+                hat: "builder".to_string(),
+                hat_display: "🔨Builder".to_string(),
+                backend: "pi".to_string(),
+                started_at: 0,
+            },
+            &state,
+            &mut acc,
+        );
+
+        apply_rpc_event(
+            &RpcEvent::ToolCallEnd {
+                iteration: 1,
+                tool_call_id: "tool_1".to_string(),
+                output: "# Demo README\nSecond line of context.".to_string(),
+                is_error: false,
+                duration_ms: 12,
+            },
+            &state,
+            &mut acc,
+        );
+
+        let s = state.lock().unwrap();
+        let lines = s.iterations[0].lines.lock().unwrap();
+        let rendered = lines[0].to_string();
+        assert_eq!(rendered, "  ↳ ✓ # Demo README • Second line of context.");
+    }
+
+    #[test]
+    fn test_execution_error_preserves_order_with_following_text() {
+        let state = make_state();
+        let mut acc = make_acc();
+
+        apply_rpc_event(
+            &RpcEvent::IterationStart {
+                iteration: 1,
+                max_iterations: None,
+                hat: "builder".to_string(),
+                hat_display: "🔨Builder".to_string(),
+                backend: "pi".to_string(),
+                started_at: 0,
+            },
+            &state,
+            &mut acc,
+        );
+
+        apply_rpc_event(
+            &RpcEvent::TextDelta {
+                iteration: 1,
+                delta: "Before failure. ".to_string(),
+            },
+            &state,
+            &mut acc,
+        );
+        apply_rpc_event(
+            &RpcEvent::Error {
+                iteration: 1,
+                code: "EXECUTION_ERROR".to_string(),
+                message: "permission denied: /root/summary.md".to_string(),
+                recoverable: true,
+            },
+            &state,
+            &mut acc,
+        );
+        apply_rpc_event(
+            &RpcEvent::TextDelta {
+                iteration: 1,
+                delta: "Recovered after failure.".to_string(),
+            },
+            &state,
+            &mut acc,
+        );
+
+        let s = state.lock().unwrap();
+        let lines = s.iterations[0].lines.lock().unwrap();
+        let rendered: Vec<String> = lines.iter().map(|line| line.to_string()).collect();
+
+        let before_idx = rendered
+            .iter()
+            .position(|line| line.contains("Before failure."))
+            .expect("before text should remain visible");
+        let error_idx = rendered
+            .iter()
+            .position(|line| line.contains("Error: permission denied"))
+            .expect("error line should remain visible");
+        let after_idx = rendered
+            .iter()
+            .position(|line| line.contains("Recovered after failure."))
+            .expect("after text should remain visible");
+
+        assert!(before_idx < error_idx, "error should stay after preceding text: {rendered:?}");
+        assert!(error_idx < after_idx, "error should stay before following text: {rendered:?}");
+    }
+
+    #[test]
+    fn test_execution_error_uses_legacy_style_red_error_line() {
+        let line = format_error_line("EXECUTION_ERROR", "permission denied");
+        assert_eq!(line.to_string(), "  ↳ ✗ Error: permission denied");
+        assert_eq!(line.spans[1].style.fg, Some(Color::Red));
     }
 
     #[test]

--- a/presets/autoresearch.yml
+++ b/presets/autoresearch.yml
@@ -5,14 +5,16 @@
 #
 # Works for ANY measurable improvement: performance, code quality, test coverage,
 # bundle size, error rates, documentation completeness, security scores, etc.
+# Also works for subjective quality targets (UX, readability, design) via LLM-as-judge.
 #
-# The loop runs until interrupted. Each cycle: strategize -> implement -> measure -> evaluate.
+# The loop runs until interrupted. Each cycle: strategize -> implement -> measure -> judge -> evaluate.
 # State persists in autoresearch.md and autoresearch.jsonl.
 #
-# 4 Hats:
+# 5 Hats:
 # - Strategist: Decides what experiment to try next
 # - Implementer: Executes the planned change
-# - Benchmarker: Runs the measurement command and captures metrics
+# - Benchmarker: Runs the measurement command, captures metrics and artifacts
+# - Judge: Scores the experiment against the quality rubric using LLM-as-judge
 # - Evaluator: Decides keep/discard, commits or reverts, updates records
 #
 # Usage:
@@ -25,7 +27,7 @@
 event_loop:
   prompt_file: "PROMPT.md"
   completion_promise: "LOOP_COMPLETE"
-  required_events: ["experiment.measured", "experiment.evaluated"]
+  required_events: ["experiment.scored", "experiment.evaluated"]
   starting_event: "experiment.start"
   max_iterations: 500
   max_runtime_seconds: 28800   # 8 hours
@@ -47,6 +49,7 @@ core:
     - "One change at a time — each experiment tests exactly one hypothesis"
     - "Don't thrash — if repeatedly reverting the same idea, try something structurally different"
     - "Think longer when stuck — re-read source files, study the data, reason about root causes"
+    - "Judge scores are first-class — the judge hat always runs, scoring hard metrics and subjective quality alike"
 
 hats:
   strategist:
@@ -116,6 +119,26 @@ hats:
 
       ## Constraints
       <Hard rules: tests must pass, no new deps, etc.>
+
+      ## Judge Rubric
+      <Define how the LLM-as-judge scores each experiment. Always present — even for
+       pure-numeric workloads the judge validates metrics and checks for regressions.>
+
+      ### Criteria
+      <List each quality dimension the judge evaluates. Each criterion gets a 1-10 score.>
+      - **<criterion name>**: <what good looks like vs bad>
+
+      ### Artifacts
+      <What the Benchmarker should capture for the judge to evaluate.>
+      - Capture command: `<command that writes artifacts to .autoresearch/artifacts/>`
+      - Types: <screenshots, output samples, diffs, rendered HTML, logs, etc.>
+      - If no capture command: judge scores based on hard metrics + code diff only
+
+      ### Scoring
+      - Pass threshold: <minimum average score to keep, e.g., 7/10>
+      - Veto criteria: <any criterion below this score = automatic discard, e.g., 4/10>
+      - Weight: <how judge score combines with primary metric — "gate" (binary pass/fail),
+        "weighted" (blended score), or "tiebreak" (used only when metrics are equal)>
 
       ## What's Been Tried
       <Updated after each experiment. Note key wins, dead ends, and architectural insights.>
@@ -210,7 +233,7 @@ hats:
 
   benchmarker:
     name: "Benchmarker"
-    description: "Runs the measurement command from autoresearch.md, captures metrics, and runs correctness checks."
+    description: "Runs the measurement command from autoresearch.md, captures metrics, correctness checks, and judge artifacts."
     triggers: ["experiment.ready"]
     publishes: ["experiment.measured"]
     default_publishes: "experiment.measured"
@@ -237,8 +260,21 @@ hats:
          - Run `bash autoresearch.checks.sh 2>&1`
          - Record whether checks passed or failed
          - Checks execution time does NOT affect the primary metric
-      7. Emit with all metrics: `ralph emit "experiment.measured" "task_id=<id> task_key=<key> primary_metric=<value> exit_code=<code> duration=<seconds> checks=<passed|failed|skipped|not_run>"`
-      8. Stop after emitting.
+      7. Capture artifacts for the Judge:
+         - Read the "Judge Rubric > Artifacts" section of `autoresearch.md` for the capture command
+         - If a capture command is defined:
+           ```bash
+           mkdir -p .autoresearch/artifacts
+           <capture_command> 2>&1
+           ```
+         - If no capture command: generate a code diff as the artifact:
+           ```bash
+           mkdir -p .autoresearch/artifacts
+           git diff HEAD > .autoresearch/artifacts/diff.patch
+           ```
+         - Record the list of artifact files produced
+      8. Emit with all metrics: `ralph emit "experiment.measured" "task_id=<id> task_key=<key> primary_metric=<value> exit_code=<code> duration=<seconds> checks=<passed|failed|skipped|not_run> artifacts=<comma-separated artifact paths>"`
+      9. Stop after emitting.
 
       ### If Benchmark Crashes
 
@@ -256,40 +292,117 @@ hats:
       - You MUST run checks only when the benchmark passes — failed benchmarks skip checks
       - You MUST use `ralph emit` to publish events — plain-language summaries do NOT publish events
 
+  judge:
+    name: "Judge"
+    description: "Scores the experiment against the quality rubric using LLM-as-judge. Always runs."
+    triggers: ["experiment.measured"]
+    publishes: ["experiment.scored"]
+    default_publishes: "experiment.scored"
+    instructions: |
+      ## JUDGE MODE — Score The Experiment
+
+      Start from the auto-injected objective and current event context.
+      You are running inside Ralph. `ralph emit` is available.
+      The loop also sets `$RALPH_BIN`; prefer `"$RALPH_BIN" emit ...`.
+
+      You score every experiment. You do not decide keep/discard — the Evaluator does that.
+      Your job is to produce structured, consistent scores that the Evaluator can use.
+
+      ### Process
+
+      1. Read the `experiment.measured` payload for `task_id`, `task_key`, metrics, checks, and artifacts
+      2. Read `autoresearch.md` — find the "Judge Rubric" section for criteria, scoring rules, and pass threshold
+      3. If the benchmark crashed (exit_code != 0):
+         - Set all criterion scores to 0, judge_score to 0, judge_pass to false
+         - Skip to step 7
+      4. Read/view the artifacts:
+         - If artifact paths were provided, read each artifact file
+         - If artifacts include images (PNG, SVG), view them
+         - If no artifacts exist, read `git diff HEAD` for the code diff
+      5. Score each criterion from the rubric on a 1-10 scale:
+         - Write a one-line rationale for each score
+         - Be consistent: the same quality level should always get the same score
+         - Compare against what you've seen in previous experiments if `autoresearch.jsonl` exists
+         - Do NOT grade on a curve — use the rubric's definition of good/bad as the anchor
+      6. Compute the aggregate:
+         - `judge_score`: average of all criterion scores (rounded to 1 decimal)
+         - `judge_pass`: true if judge_score >= pass_threshold AND no criterion is below veto_threshold
+         - `judge_detail`: JSON object mapping criterion name to {score, rationale}
+      7. Forward all hard metrics from experiment.measured unchanged, adding judge scores:
+         ```
+         ralph emit "experiment.scored" "task_id=<id> task_key=<key> primary_metric=<value> exit_code=<code> duration=<seconds> checks=<checks> judge_score=<score> judge_pass=<true|false> judge_detail=<json>"
+         ```
+      8. Stop after emitting.
+
+      ### Scoring Without a Rubric
+
+      If autoresearch.md has no "Judge Rubric" section or the criteria list is empty:
+      - Score based on general code quality of the diff: correctness, simplicity, readability
+      - Use a single criterion "code_quality" with pass threshold 6/10
+      - This ensures every experiment gets a judge assessment even for pure-numeric workloads
+
+      ### Scoring Consistency
+
+      To maintain consistency across experiments:
+      - Read the last 3-5 entries in `autoresearch.jsonl` that have judge_detail
+      - Calibrate your scores relative to what you scored before
+      - If a previous experiment scored 7/10 for readability, a similar-quality change should also score ~7
+      - Avoid score drift (gradually inflating or deflating over the session)
+
+      ### Constraints
+      - You MUST NOT decide keep/discard — that belongs to the Evaluator
+      - You MUST NOT modify any source files
+      - You MUST NOT modify autoresearch.md or autoresearch.jsonl — that belongs to the Evaluator
+      - You MUST score every criterion listed in the rubric — do not skip any
+      - You MUST provide a rationale for every score — bare numbers are not acceptable
+      - You MUST forward all hard metrics from experiment.measured unchanged
+      - You MUST use `ralph emit` to publish events — plain-language summaries do NOT publish events
+      - You MUST NOT invoke `[Tool] Agent` or any parallel subagent tool in this preset
+
   evaluator:
     name: "Evaluator"
-    description: "Decides keep/discard based on metrics, commits or reverts, and updates experiment records."
-    triggers: ["experiment.measured"]
+    description: "Decides keep/discard based on metrics and judge scores, commits or reverts, and updates experiment records."
+    triggers: ["experiment.scored"]
     publishes: ["experiment.evaluated", "LOOP_COMPLETE"]
     default_publishes: "experiment.evaluated"
     instructions: |
-      ## EVALUATOR MODE — Judge The Experiment
+      ## EVALUATOR MODE — Decide The Experiment's Fate
 
       Start from the auto-injected objective and current event context.
       You are running inside Ralph. `ralph emit`, `ralph tools task`, and `ralph tools memory` are available.
       The loop also sets `$RALPH_BIN`; prefer `"$RALPH_BIN" emit ...` and `"$RALPH_BIN" tools ...`.
 
-      You are the judge. You decide whether to keep or discard each experiment based on hard data.
+      You are the final decision-maker. You combine hard metrics and judge scores to decide keep or discard.
       You also maintain the experiment log and session document.
 
       ### Process
 
-      1. Read the `experiment.measured` payload for `task_id`, `task_key`, metrics, and checks result
-      2. Read `autoresearch.md` for the metric direction (lower/higher is better)
+      1. Read the `experiment.scored` payload for `task_id`, `task_key`, metrics, checks, and judge scores
+      2. Read `autoresearch.md` for the metric direction (lower/higher is better) and judge weight mode
       3. Read `autoresearch.jsonl` to find the baseline and current best metric
          - If `autoresearch.jsonl` doesn't exist, this is the baseline — always KEEP
          - Baseline = first experiment; current best = best kept experiment so far
-      4. Evaluate the result:
+      4. Evaluate the result using both hard metrics and judge scores.
+         Read the "Judge Rubric > Scoring > Weight" from autoresearch.md to determine the judge weight mode:
+
+      **Weight modes:**
+      - `gate`: Judge is a binary gate. Primary metric must improve AND judge_pass must be true.
+      - `weighted`: Blended score. Combine primary metric improvement % and judge_score into a weighted decision.
+      - `tiebreak`: Judge score is used only when primary metrics are equal — higher judge_score wins.
+      - If no weight mode specified, default to `gate`.
 
       **KEEP** when:
       - This is the baseline (first experiment) — always keep to establish the reference
-      - Primary metric improved vs current best AND checks passed (or no checks file)
-      - Removing code for equal metric value (simpler = better)
+      - `gate` mode: primary metric improved vs current best AND checks passed AND judge_pass is true
+      - `weighted` mode: blended score (metric improvement + judge_score) exceeds threshold
+      - `tiebreak` mode: primary metric improved AND checks passed; OR metric equal AND judge_score > previous
+      - Removing code for equal metric value AND judge_pass is true (simpler = better)
 
       **DISCARD** when:
       - Primary metric is worse than current best
-      - Primary metric is equal to current best (unless code was removed — simpler = keep)
+      - Primary metric is equal to current best and judge doesn't break the tie (in tiebreak mode)
       - Primary metric improved but checks failed
+      - Primary metric improved but judge_pass is false (gate/weighted modes)
       - Primary metric improved but a secondary metric degraded catastrophically
 
       **CRASH** when:
@@ -304,11 +417,12 @@ hats:
       ```bash
       git checkout -- .
       git clean -fd
+      rm -rf .autoresearch/artifacts
       ```
 
       6. Append the result to `autoresearch.jsonl`:
          ```json
-         {"run":<N>,"commit":"<hash-or-empty>","metric":<value>,"metrics":{...},"status":"<keep|discard|crash>","description":"<what was tried>","timestamp":<epoch_ms>,"segment":0}
+         {"run":<N>,"commit":"<hash-or-empty>","metric":<value>,"metrics":{...},"judge_score":<score>,"judge_pass":<bool>,"judge_detail":{...},"status":"<keep|discard|crash>","description":"<what was tried>","timestamp":<epoch_ms>,"segment":0}
          ```
          - On KEEP: leave `commit` as `""` — fill after committing
          - On DISCARD/CRASH: `commit` is the current HEAD
@@ -316,7 +430,7 @@ hats:
       7. Update `autoresearch.md`:
          - On KEEP: update the "Current Best" value in the Metrics section
          - Append to "What's Been Tried":
-           `- **Run N (KEEP/DISCARD, metric=X)**: <what was tried>. Hypothesis: <confirmed/refuted>.`
+           `- **Run N (KEEP/DISCARD, metric=X, judge=Y/10)**: <what was tried>. Hypothesis: <confirmed/refuted>.`
 
       8. If the experiment revealed promising ideas, append them to `autoresearch.ideas.md`
 
@@ -341,7 +455,7 @@ hats:
 
       11. Close the runtime task: `ralph tools task close <task_id>`
 
-      12. Emit: `ralph emit "experiment.evaluated" "task_id=<id> task_key=<key> decision=<keep|discard|crash> metric=<value> delta=<percent vs baseline> run=<N> trend=<N>of5_kept reason=<brief reason>"`
+      12. Emit: `ralph emit "experiment.evaluated" "task_id=<id> task_key=<key> decision=<keep|discard|crash> metric=<value> judge_score=<score> judge_pass=<bool> delta=<percent vs baseline> run=<N> trend=<N>of5_kept reason=<brief reason>"`
       13. Stop after emitting.
 
       ### When To Stop
@@ -351,8 +465,8 @@ hats:
 
       ### Constraints
       - You MUST NOT modify source files — only git operations and experiment records
-      - You MUST NOT keep an experiment when checks failed
-      - You MUST NOT discard an experiment that improved the primary metric unless checks failed or complexity is unjustified
+      - You MUST NOT keep an experiment when checks failed or judge_pass is false (in gate/weighted modes)
+      - You MUST NOT discard an experiment that improved the primary metric and passed the judge unless complexity is unjustified
       - You MUST update "What's Been Tried" in autoresearch.md after every experiment — the Strategist depends on this
       - You MUST append to autoresearch.jsonl after every experiment for persistent tracking
       - You MUST revert cleanly on discard — no leftover changes in the working tree

--- a/tools/e2e/conftest.py
+++ b/tools/e2e/conftest.py
@@ -9,13 +9,18 @@ from datetime import datetime
 from typing import AsyncGenerator
 
 import pytest
-import pytest_asyncio
+
+try:
+    import pytest_asyncio
+except ModuleNotFoundError:  # pragma: no cover - exercised by ambient python3 benchmark setup
+    pytest_asyncio = None
 
 from .helpers import TmuxSession, FreezeCapture, LLMJudge, IterationCapture
 
 
-# Configure pytest-asyncio
-pytest_plugins = ("pytest_asyncio",)
+# Configure pytest-asyncio when available.
+pytest_plugins = ("pytest_asyncio",) if pytest_asyncio is not None else ()
+async_fixture = pytest_asyncio.fixture if pytest_asyncio is not None else pytest.fixture
 
 
 def pytest_configure(config):
@@ -80,7 +85,7 @@ def tmux_session_name() -> str:
     return f"ralph-e2e-{uuid.uuid4().hex[:8]}"
 
 
-@pytest_asyncio.fixture
+@async_fixture
 async def tmux_session(tmux_session_name: str) -> AsyncGenerator[TmuxSession, None]:
     """Create and manage a tmux session for testing.
 
@@ -167,7 +172,7 @@ def iteration_evidence_dir(iteration_evidence_base_dir: Path) -> Path:
     return run_dir
 
 
-@pytest_asyncio.fixture
+@async_fixture
 async def iteration_capture(tmux_session: TmuxSession) -> IterationCapture:
     """Create an IterationCapture instance for the test.
 

--- a/tools/e2e/helpers/llm_judge.py
+++ b/tools/e2e/helpers/llm_judge.py
@@ -13,6 +13,7 @@ class CheckResult:
 
     passed: bool
     reason: str
+    score: Optional[int] = None  # 1-10 score for scored rubrics
 
 
 @dataclass
@@ -24,17 +25,25 @@ class JudgeResult:
     overall_reason: str = ""
     raw_response: str = ""
 
+    @property
+    def total_score(self) -> int:
+        """Sum of all criterion scores (0 if no scored criteria)."""
+        return sum(c.score for c in self.checks.values() if c.score is not None)
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
-        return {
+        result: dict[str, Any] = {
             "passed": self.passed,
             "checks": {
-                name: {"passed": check.passed, "reason": check.reason}
+                name: {"passed": check.passed, "reason": check.reason, **({"score": check.score} if check.score is not None else {})}
                 for name, check in self.checks.items()
             },
             "overall_reason": self.overall_reason,
             "raw_response": self.raw_response,
         }
+        if any(c.score is not None for c in self.checks.values()):
+            result["total_score"] = self.total_score
+        return result
 
 
 # Default validation criteria for idle timeout TUI state
@@ -284,9 +293,12 @@ Please read and analyze the image at: {image_path}
             checks = {}
             if "checks" in data:
                 for name, check_data in data["checks"].items():
+                    score = check_data.get("score")
+                    passed = check_data.get("pass", score is not None and score >= 7)
                     checks[name] = CheckResult(
-                        passed=check_data.get("pass", False),
+                        passed=passed,
                         reason=check_data.get("reason", ""),
+                        score=score,
                     )
 
             return JudgeResult(

--- a/tools/e2e/test_tui_rich_output.py
+++ b/tools/e2e/test_tui_rich_output.py
@@ -1,0 +1,379 @@
+"""Benchmark harness for rich TUI output with controlled adapter fixtures.
+
+This test intentionally uses a deterministic mock Pi backend instead of a live model.
+It launches Ralph in tmux with TUI enabled, captures ANSI output, validates the
+capture with the LLM judge helper, and prints a machine-readable metric summary.
+"""
+
+import asyncio
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+import textwrap
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from .helpers import IterationCapture, LLMJudge, TmuxSession
+
+
+RICH_OUTPUT_CRITERIA = """
+Analyze this ANSI-preserved Ralph TUI capture. Score each dimension 1-10.
+ANSI color escapes and box-drawing characters are normal and expected.
+
+Score each criterion on a 1-10 scale:
+
+1. **agent_text_readability** (1-10)
+   - 10: Assistant prose is beautifully formatted, well-spaced, easy to scan
+   - 5: Readable but cramped or poorly formatted
+   - 1: Garbled, lost between status lines, or unreadable
+
+2. **tool_call_specificity** (1-10)
+   - 10: Tool call shows full context (file path, command args, query text) with smart formatting
+   - 5: Shows tool name and partial context
+   - 1: Only tool name visible, no meaningful summary
+
+3. **tool_result_informativeness** (1-10)
+   - 10: Result preview shows exactly the right amount of content with smart truncation
+   - 5: Shows some content but truncation is too aggressive or too loose
+   - 1: Empty success marker or no useful preview at all
+
+4. **chronological_flow** (1-10)
+   - 10: Perfect ordering: text → tool call → result → text, with clear visual separation
+   - 5: Correct order but boundaries between sections are unclear
+   - 1: Jumbled or impossible to follow the sequence
+
+5. **visual_polish** (1-10)
+   - 10: Intentional design — colors, borders, alignment, whitespace all harmonious
+   - 5: Functional but bland or slightly misaligned
+   - 1: Ugly, broken borders, clashing colors, misaligned columns
+
+6. **information_density** (1-10)
+   - 10: Screen real estate used optimally — no wasted space, no overwhelming walls
+   - 5: Some wasted space or slightly too dense
+   - 1: Mostly empty or overwhelming wall of text
+
+7. **error_state_handling** (1-10)
+   - 10: Errors/warnings clearly distinguished with color and icons
+   - 5: Errors visible but not clearly differentiated from success
+   - 1: Errors silent or confusing (score 5 if no errors present to evaluate)
+
+8. **multi_tool_clarity** (1-10)
+   - 10: Multiple tool calls clearly distinguishable with individual results
+   - 5: Distinguishable but requires effort to match calls to results
+   - 1: Ambiguous which result belongs to which call (score 5 if only one tool call)
+
+9. **tui_structure** (1-10)
+   - 10: Header, footer, progress indicators all present and informative
+   - 5: Basic structure present but missing useful metadata
+   - 1: No visible structure, raw text dump
+
+10. **progressive_disclosure** (1-10)
+    - 10: Default view is clean, detail available on demand or via scrolling
+    - 5: Reasonable default but no way to get more detail
+    - 1: Either too sparse or dumps everything at once
+
+Respond with ONLY valid JSON (no markdown, no prose outside JSON):
+{
+  "pass": true/false,
+  "total_score": <sum of all scores, 0-100>,
+  "checks": {
+    "agent_text_readability": {"score": <1-10>, "reason": "..."},
+    "tool_call_specificity": {"score": <1-10>, "reason": "..."},
+    "tool_result_informativeness": {"score": <1-10>, "reason": "..."},
+    "chronological_flow": {"score": <1-10>, "reason": "..."},
+    "visual_polish": {"score": <1-10>, "reason": "..."},
+    "information_density": {"score": <1-10>, "reason": "..."},
+    "error_state_handling": {"score": <1-10>, "reason": "..."},
+    "multi_tool_clarity": {"score": <1-10>, "reason": "..."},
+    "tui_structure": {"score": <1-10>, "reason": "..."},
+    "progressive_disclosure": {"score": <1-10>, "reason": "..."}
+  },
+  "overall_reason": "..."
+}
+"""
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+@dataclass
+class CaptureArtifact:
+    mode: str
+    content: str
+    artifact_path: Path
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def normalize_line(line: str) -> str:
+    return " ".join(strip_ansi(line).split())
+
+
+def extract_matching_lines(content: str, markers: tuple[str, ...]) -> list[str]:
+    return [
+        normalize_line(line)
+        for line in strip_ansi(content).splitlines()
+        if any(marker in line for marker in markers)
+    ]
+
+
+def parity_pass(default_capture: str, legacy_capture: str) -> tuple[bool, dict[str, str]]:
+    markers = ("[Read]", "[Bash]", "[Write]", "✓")
+    default_sequence = extract_matching_lines(default_capture, markers)
+    legacy_sequence = extract_matching_lines(legacy_capture, markers)
+    default_errors = extract_matching_lines(default_capture, ("Error:", "EXECUTION_ERROR"))
+    legacy_errors = extract_matching_lines(legacy_capture, ("Error:", "EXECUTION_ERROR"))
+
+    details = {
+        "default_sequence": "\n".join(default_sequence),
+        "legacy_sequence": "\n".join(legacy_sequence),
+        "default_errors": "\n".join(default_errors),
+        "legacy_errors": "\n".join(legacy_errors),
+    }
+
+    return bool(default_sequence) and default_sequence == legacy_sequence, details
+
+
+def find_repo_venv_python() -> Optional[Path]:
+    candidate = Path(__file__).resolve().parents[2] / ".venv" / "bin" / "python"
+    return candidate if candidate.exists() else None
+
+
+def rerun_benchmark_in_repo_venv() -> bool:
+    if os.environ.get("RALPH_RICH_TUI_INNER") == "1":
+        return False
+
+    venv_python = find_repo_venv_python()
+    if venv_python is None:
+        return False
+
+    env = os.environ.copy()
+    env["RALPH_RICH_TUI_INNER"] = "1"
+    command = [
+        str(venv_python),
+        "-m",
+        "pytest",
+        "-q",
+        "-s",
+        f"{Path(__file__)}::test_tui_rich_output_benchmark",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.stdout:
+        print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+    if result.stderr:
+        print(result.stderr, end="" if result.stderr.endswith("\n") else "\n", file=sys.stderr)
+
+    assert result.returncode == 0, (
+        "rich-TUI benchmark fallback in .venv failed with exit code "
+        f"{result.returncode}"
+    )
+    assert "PRIMARY_METRIC=" in result.stdout, (
+        "rich-TUI benchmark fallback in .venv did not produce PRIMARY_METRIC output"
+    )
+    return True
+
+
+def build_mock_pi_fixture(tmp_root: Path) -> tuple[Path, Path, Path, Path]:
+    workspace = tmp_root / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "README.md").write_text(
+        "# Demo README\n\nSecond line of context.\n",
+        encoding="utf-8",
+    )
+    (workspace / "notes.txt").write_text(
+        "- deterministic fixture\n- rich tui benchmark\n",
+        encoding="utf-8",
+    )
+
+    script_path = tmp_root / "mock-pi.sh"
+    script_path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            sleep 0.2
+            printf '%s\n' \
+              '{"type":"session","version":3,"id":"test","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp"}' \
+              '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Inspecting README, checking the workspace, and preparing a short summary.\\n"}}' \
+              '{"type":"tool_execution_start","toolCallId":"toolu_read","toolName":"Read","args":{"path":"README.md"}}' \
+              '{"type":"tool_execution_end","toolCallId":"toolu_read","toolName":"Read","result":{"content":[{"type":"text","text":"# Demo README\\nSecond line of context."}]},"isError":false}' \
+              '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"README captured. Verifying the workspace file list before writing the summary.\\n"}}' \
+              '{"type":"tool_execution_start","toolCallId":"toolu_bash","toolName":"Bash","args":{"command":"ls -1 README.md notes.txt"}}' \
+              '{"type":"tool_execution_end","toolCallId":"toolu_bash","toolName":"Bash","result":{"content":[{"type":"text","text":"README.md\\nnotes.txt"}]},"isError":false}' \
+              '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Workspace looks right. Writing summary.md with the key points now.\\n"}}' \
+              '{"type":"tool_execution_start","toolCallId":"toolu_write_ok","toolName":"Write","args":{"path":"summary.md"}}' \
+              '{"type":"tool_execution_end","toolCallId":"toolu_write_ok","toolName":"Write","result":{"content":[{"type":"text","text":"Created summary.md with 2 bullet points."}]},"isError":false}' \
+              '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Summary saved. Intentionally attempting one failing backup write to exercise error handling.\\n"}}' \
+              '{"type":"tool_execution_start","toolCallId":"toolu_write_err","toolName":"Write","args":{"path":"/root/summary.md"}}' \
+              '{"type":"tool_execution_end","toolCallId":"toolu_write_err","toolName":"Write","result":{"content":[{"type":"text","text":"permission denied: /root/summary.md"}]},"isError":true}' \
+              '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Recovered from the failed backup write and finalized the response. LOOP_COMPLETE"}}' \
+              '{"type":"turn_end","message":{"role":"assistant","content":[],"provider":"anthropic","model":"mock-pi","usage":{"input":10,"output":20,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.01}},"stopReason":"stop"}}'
+            """
+        ),
+        encoding="utf-8",
+    )
+    script_path.chmod(0o755)
+
+    config_path = tmp_root / "ralph.mock.yml"
+    config_path.write_text(
+        textwrap.dedent(
+            f"""\
+            cli:
+              backend: pi
+              command: {script_path}
+
+            event_loop:
+              completion_promise: LOOP_COMPLETE
+              max_iterations: 1
+              max_runtime_seconds: 30
+              idle_timeout_secs: 5
+
+            memories:
+              enabled: false
+
+            tasks:
+              enabled: false
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    evidence_dir = (
+        Path(__file__).resolve().parents[2]
+        / "tui-validation"
+        / "rich-output"
+        / f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    )
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    return workspace, script_path, config_path, evidence_dir
+
+
+async def run_tui_capture(
+    *,
+    ralph_binary: Path,
+    workspace: Path,
+    config_path: Path,
+    evidence_dir: Path,
+    mode: str,
+    legacy_tui: bool,
+) -> CaptureArtifact:
+    session = TmuxSession(name=f"ralph-rich-{uuid.uuid4().hex[:8]}", width=120, height=40)
+    prompt = "Summarize the README using the controlled adapter fixture."
+
+    command_parts = [
+        shlex.quote(str(ralph_binary)),
+        "run",
+        "-c",
+        shlex.quote(str(config_path)),
+        "--skip-preflight",
+    ]
+    if legacy_tui:
+        command_parts.append("--legacy-tui")
+    command_parts.extend(["-p", shlex.quote(prompt)])
+    command = " ".join(command_parts)
+
+    async with session:
+        await session.send_keys(f"cd {shlex.quote(str(workspace))} && {command}")
+
+        started = await session.wait_for_alternate_screen(timeout=10.0)
+        assert started, f"{mode}: TUI never reached alternate screen"
+
+        capture = IterationCapture(session=session)
+        exited, content = await capture.wait_for_process_exit(timeout=20.0, check_interval=0.5)
+        assert exited, f"{mode}: Ralph did not exit in time"
+        assert content.strip(), f"{mode}: final TUI capture was empty"
+
+    artifact_path = evidence_dir / f"{mode}.ansi.txt"
+    artifact_path.write_text(content, encoding="utf-8")
+    return CaptureArtifact(mode=mode, content=content, artifact_path=artifact_path)
+
+
+@pytest.mark.e2e
+@pytest.mark.requires_tmux
+@pytest.mark.requires_claude
+def test_tui_rich_output_benchmark(ralph_binary: Path):
+    """Benchmark rich TUI output for a deterministic controlled-adapter scenario."""
+    if not TmuxSession.is_available():
+        pytest.skip("tmux not available")
+    if not LLMJudge.is_available() and rerun_benchmark_in_repo_venv():
+        return
+    if not LLMJudge.is_available():
+        pytest.skip("Claude Agent SDK not available")
+
+    async def run_benchmark() -> None:
+        with tempfile.TemporaryDirectory(prefix="ralph-rich-tui-") as tmp_dir:
+            workspace, _script_path, config_path, evidence_dir = build_mock_pi_fixture(Path(tmp_dir))
+
+            default_capture = await run_tui_capture(
+                ralph_binary=ralph_binary,
+                workspace=workspace,
+                config_path=config_path,
+                evidence_dir=evidence_dir,
+                mode="default",
+                legacy_tui=False,
+            )
+            legacy_capture = await run_tui_capture(
+                ralph_binary=ralph_binary,
+                workspace=workspace,
+                config_path=config_path,
+                evidence_dir=evidence_dir,
+                mode="legacy",
+                legacy_tui=True,
+            )
+
+            judge = LLMJudge()
+            judge_result = await judge.validate(default_capture.content, RICH_OUTPUT_CRITERIA)
+            parity_ok, parity_details = parity_pass(default_capture.content, legacy_capture.content)
+
+            # Extract per-criterion scores (1-10 each, 10 criteria, max 100)
+            criterion_scores = {}
+            for name, check in judge_result.checks.items():
+                criterion_scores[name] = check.score if check.score is not None else 0
+
+            primary_metric = judge_result.total_score  # 0-100 scored metric
+            judge_pass = primary_metric >= 70 and all(
+                s >= 3 for s in criterion_scores.values()
+            )
+
+            summary = {
+                "metric_name": "rich_tui_judge_score",
+                "primary_metric": primary_metric,
+                "judge_pass": judge_pass,
+                "criterion_scores": criterion_scores,
+                "parity": {
+                    "pass": parity_ok,
+                    "details": parity_details,
+                },
+                "judge": judge_result.to_dict(),
+                "captures": {
+                    "default": str(default_capture.artifact_path),
+                    "legacy": str(legacy_capture.artifact_path),
+                },
+            }
+
+            print(json.dumps(summary, indent=2))
+            print(f"PRIMARY_METRIC={primary_metric}")
+
+            assert default_capture.content.strip(), "default capture should not be empty"
+            assert legacy_capture.content.strip(), "legacy capture should not be empty"
+
+    asyncio.run(run_benchmark())


### PR DESCRIPTION
## Summary
- Extract tool-call preview logic from `stream_handler.rs` into a dedicated `tool_preview` module for cleaner separation of concerns
- Improve TUI rendering of structured tool calls and results in both in-process and RPC modes (`rpc_source.rs`)
- Add comprehensive e2e test suite (`test_tui_rich_output.py`) with LLM-as-judge scoring for rich output quality
- Update autoresearch preset with refined configuration

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo build` succeeds
- [ ] E2E rich TUI tests pass: `cd tools/e2e && python -m pytest test_tui_rich_output.py`
- [ ] Manual verification: run `ralph run` with autoresearch preset and confirm tool output renders correctly in TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)