### PR TITLE
docs: add Pi backend to backends guide

### DIFF
--- a/docs/guide/backends.md
+++ b/docs/guide/backends.md
@@ -13,6 +13,7 @@ Ralph supports multiple AI CLI backends. This guide covers setup and selection.
 | Amp | `amp` | Sourcegraph |
 | Copilot CLI | `copilot` | GitHub |
 | OpenCode | `opencode` | Community |
+| Pi | `pi` | Multi-provider |
 
 ## Auto-Detection
 
@@ -31,6 +32,7 @@ Detection order (first available wins):
 5. Amp
 6. Copilot
 7. OpenCode
+8. Pi
 
 ## Explicit Selection
 
@@ -55,7 +57,7 @@ Each backend below includes:
 - **Hat YAML** configuration
 - **`ralph doctor`** validation notes
 
-Backend names (used in YAML and CLI flags): `claude`, `kiro`, `gemini`, `codex`, `amp`, `copilot`, `opencode`.
+Backend names (used in YAML and CLI flags): `claude`, `kiro`, `gemini`, `codex`, `amp`, `copilot`, `opencode`, `pi`.
 
 ### Claude Code (`claude`)
 
@@ -268,6 +270,43 @@ hats:
 - `opencode --version` must succeed
 - Warns if none of `OPENCODE_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` are set
 
+### Pi (`pi`)
+
+Multi-provider AI coding assistant.
+
+```bash
+# Install
+npm install -g @mariozechner/pi-coding-agent
+
+# Verify
+pi --version
+```
+
+**Auth & env vars:**
+- Set one of: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or any supported provider key
+- Pi routes to the provider specified via `--provider` (default: google)
+- Pass API key explicitly with `--api-key` or rely on provider-specific env vars
+
+**Hat YAML:**
+```yaml
+hats:
+  coder:
+    backend: "pi"
+```
+
+**Pi provider selection (optional):**
+```yaml
+hats:
+  coder:
+    backend:
+      type: "pi"
+      args: ["--provider", "anthropic", "--model", "claude-sonnet-4"]
+```
+
+**Doctor checks:**
+- `pi --version` must succeed
+- Warns if no provider API key is set
+
 ## Per-Hat Backend Override
 
 Different hats can use different backends:
@@ -305,13 +344,13 @@ cli:
 
 ## Backend Comparison
 
-| Feature | Claude | Kiro | Gemini | Codex |
-|---------|--------|------|--------|-------|
-| Streaming | Yes | Yes | Yes | Yes |
-| Tool use | Full | Full | Partial | Partial |
-| Context size | Large | Large | Large | Medium |
-| Speed | Fast | Fast | Fast | Medium |
-| Cost | $$ | $ | $ | $$ |
+| Feature | Claude | Kiro | Gemini | Codex | Pi |
+|---------|--------|------|--------|-------|----|
+| Streaming | Yes | Yes | Yes | Yes | Yes |
+| Tool use | Full | Full | Partial | Partial | Full |
+| Context size | Large | Large | Large | Medium | Large |
+| Speed | Fast | Fast | Fast | Medium | Fast |
+| Cost | $$ | $ | $ | $$ | $ |
 
 ## Troubleshooting
 
@@ -324,7 +363,7 @@ ERROR: No AI agents detected
 **Solution:**
 1. Install a supported backend
 2. Ensure it's in your PATH
-3. Test directly: `claude -p "test"`
+3. Test directly: `claude -p "test"` or `pi -p "test"`
 
 ### Authentication Failed
 
@@ -342,6 +381,9 @@ copilot auth login
 
 # Gemini - set API key
 export GEMINI_API_KEY=your-key
+
+# Pi - set provider API key
+export ANTHROPIC_API_KEY=your-key
 ```
 
 If the CLI is already authenticated but `ralph doctor` still warns, ensure the


### PR DESCRIPTION
Pi is already fully supported in code:

- `CliBackend::pi()` / `CliBackend::pi_interactive()` in cli\_backend.rs
- `pi_stream.rs` NDJSON parser (text\_delta, tool\_execution, turn\_end with cost)
- `DEFAULT_PRIORITY` in auto\_detect.rs
- `VALID_BACKENDS` in backend\_support.rs
- `ralph.pi.yml` example config

But it was missing from the documentation. This PR adds Pi alongside the other backends:

- Supported Backends table
- Auto-detection order
- Backend Setup section (install, auth, hat YAML, provider selection, doctor checks)
- Backend Comparison table
- Troubleshooting examples