### PR TITLE
fix: add Pi and Roo to doctor auth env var detection

### DIFF
--- a/crates/ralph-cli/src/doctor.rs
+++ b/crates/ralph-cli/src/doctor.rs
@@ -374,6 +374,16 @@ fn auth_env_vars(backend: &str) -> Option<Vec<&'static str>> {
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
         ]),
+        "pi" => Some(vec![
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+        ]),
+        "roo" => Some(vec![
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+        ]),
         _ => None,
     }
 }
@@ -433,6 +443,8 @@ fn canonical_backend_name(backend: &str, command: Option<&str>) -> String {
         "amp" => "amp".to_string(),
         "copilot" => "copilot".to_string(),
         "opencode" => "opencode".to_string(),
+        "pi" => "pi".to_string(),
+        "roo" => "roo".to_string(),
         _ => normalized,
     }
 }


### PR DESCRIPTION
Pi and Roo are supported backends but were missing from `auth_env_vars()` and `canonical_backend_name()` in doctor.rs.

This caused `ralph doctor` to fall through to the generic "authenticate via the CLI" hint instead of checking for known provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`).

Changes:
- Add `"pi"` and `"roo"` to `auth_env_vars()` with their supported provider keys
- Add `"pi"` and `"roo"` to `canonical_backend_name()` for explicit mapping