### PR TITLE
Feature/kiro acp completion fallback

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -14,8 +14,8 @@ use ralph_adapters::{
 };
 use ralph_core::diagnostics::{HookDisposition, HookRunTelemetryEntry};
 use ralph_core::{
-    CompletionAction, EventLogger, EventLoop, EventParser, EventRecord, HookEngine,
-    HookExecutor, HookExecutorContract, HookMutationConfig, HookOnError, HookPayloadBuilderInput,
+    CompletionAction, EventLogger, EventLoop, EventParser, EventRecord, HookEngine, HookExecutor,
+    HookExecutorContract, HookMutationConfig, HookOnError, HookPayloadBuilderInput,
     HookPayloadContextInput, HookPhaseEvent, HookRunRequest, HookRunResult, HookSuspendMode,
     LoopCompletionHandler, LoopContext, LoopHistory, LoopRegistry, MergeQueue, RalphConfig, Record,
     SessionRecorder, SummaryWriter, SuspendStateRecord, SuspendStateStore, TerminationReason,

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -4044,7 +4044,7 @@ fn convert_termination_type(
         | ralph_adapters::TerminationType::ForceKill => Some(TerminationReason::Interrupted),
     }
 }
-#[cfg(test_]
+#[cfg(test)]
 fn detect_solo_output_completion(
     registry: &ralph_core::HatRegistry,
     output: &str,

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -14,7 +14,7 @@ use ralph_adapters::{
 };
 use ralph_core::diagnostics::{HookDisposition, HookRunTelemetryEntry};
 use ralph_core::{
-    CompletionAction, EventLogger, EventLoop, EventParser, EventRecord, HatRegistry, HookEngine,
+    CompletionAction, EventLogger, EventLoop, EventParser, EventRecord, HookEngine,
     HookExecutor, HookExecutorContract, HookMutationConfig, HookOnError, HookPayloadBuilderInput,
     HookPayloadContextInput, HookPhaseEvent, HookRunRequest, HookRunResult, HookSuspendMode,
     LoopCompletionHandler, LoopContext, LoopHistory, LoopRegistry, MergeQueue, RalphConfig, Record,
@@ -2510,14 +2510,16 @@ pub async fn run_loop_impl(
             return Ok(reason);
         }
 
-        if detect_solo_output_completion(
-            event_loop.registry(),
-            &output,
-            &config.event_loop.completion_promise,
-        ) {
+        // Fallback: detect completion promise in output text.
+        // Primary path is JSONL events (check_completion_event above).
+        // This catches backends (e.g. kiro-cli) that output LOOP_COMPLETE
+        // as text without using `ralph emit`.
+        if !agent_wrote_events
+            && EventParser::contains_promise(&output, &config.event_loop.completion_promise)
+        {
             let reason = TerminationReason::CompletionPromise;
             info!(
-                "All done! {} detected in solo output.",
+                "All done! {} detected in output text (no JSONL events written).",
                 config.event_loop.completion_promise
             );
 
@@ -4042,9 +4044,9 @@ fn convert_termination_type(
         | ralph_adapters::TerminationType::ForceKill => Some(TerminationReason::Interrupted),
     }
 }
-
+#[cfg(test_]
 fn detect_solo_output_completion(
-    registry: &HatRegistry,
+    registry: &ralph_core::HatRegistry,
     output: &str,
     completion_promise: &str,
 ) -> bool {


### PR DESCRIPTION
## Summary

Fix completion detection for `kiro-acp` in hat-mode loops.

`kiro-acp` can return `LOOP_COMPLETE` in assistant text without producing JSONL events (`ralph emit`). The existing fallback path (`detect_solo_output_completion`) only applied in hatless mode (`registry.is_empty()`), so hat-mode loops could miss completion and continue until `max_iterations`.

This PR adds a guarded text fallback in `loop_runner`:

- Trigger completion when:

  - no JSONL events were written for the iteration (`!agent_wrote_events`), and
  - output text contains the configured completion promise (`EventParser::contains_promise(...)`).

- Event-driven completion remains the primary path.

- Backends that already write JSONL events are unaffected.

## Root cause

ACP execution (`crates/ralph-adapters/src/acp_executor.rs`) is JSON-RPC over stdio and streams assistant/tool text through the ACP client path. In this mode, the assistant can complete via plain text output, but may not emit orchestration events into the JSONL event file.

Loop completion logic previously assumed hat-mode completion should come from event processing, with text fallback effectively restricted to hatless execution. That assumption does not hold for ACP backend behavior.

## Changes

### `crates/ralph-cli/src/loop_runner.rs`

- Replaced hatless-only completion fallback usage with a generalized guarded fallback:
  - `if !agent_wrote_events && EventParser::contains_promise(&output, &config.event_loop.completion_promise)`
- Updated informational logging to clarify fallback source:
  - completion detected from output text when no JSONL events were written.

## Behavior impact

- __Before:__ hat-mode + `kiro-acp` could ignore `LOOP_COMPLETE` text and run until safeguards.
- __After:__ hat-mode + `kiro-acp` terminates correctly when completion promise appears in output text and no events were written.
- __No regression expected__ for event-emitting backends due to `!agent_wrote_events` guard.

## Validation

- `cargo build` (Docker): pass
- `cargo fmt --all -- --check` (Docker): pass
- `cargo clippy --all-targets --all-features -- -D warnings` (Docker): pass
- `cargo test -p ralph-core --test smoke_runner` (Docker): pass

Manual behavior check:

- Local hat-mode run with `kiro-acp` now terminates on completion promise output instead of spinning to iteration limit.

## Notes

- Branch: `feature/kiro-acp-completion-fallback`
- Commit: `fc9ed34`
