### PR TITLE
ci(docs): create coverage output dir before llvm-cov

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,7 +64,9 @@ jobs:
 
       - name: Generate coverage summary
         if: github.event_name != 'pull_request'
-        run: cargo llvm-cov --all-features --workspace --json --summary-only --output-path coverage/summary.json
+        run: |
+          mkdir -p coverage
+          cargo llvm-cov --all-features --workspace --json --summary-only --output-path coverage/summary.json
 
       - name: Build documentation
         run: mkdocs build --strict --verbose


### PR DESCRIPTION
## Summary
- create the `coverage/` directory before writing the docs workflow coverage summary
- unblock post-merge `Deploy Documentation` runs on `main`

## Why
The push-to-main docs workflow was failing in `Generate coverage summary` because `cargo llvm-cov` was asked to write `coverage/summary.json` before the `coverage/` directory existed.

## Validation
- parsed `.github/workflows/docs.yml` with Python YAML loader

This addresses the post-merge docs deploy failure on `main`.