### PR TITLE
fix(api): deduplicate MCP tool schemas to reduce payload size

### DIFF
--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -629,17 +629,88 @@ fn schema_method_map(
     Ok(map)
 }
 
-fn schema_ref_object(root_schema: &Value, schema_ref: &str) -> Result<Map<String, Value>> {
+/// Collect all $ref paths from a JSON value recursively.
+fn collect_refs(val: &Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    match val {
+        Value::Object(map) => {
+            if let Some(r) = map.get("$ref").and_then(Value::as_str) {
+                refs.push(r.to_string());
+            }
+            for v in map.values() {
+                refs.extend(collect_refs(v));
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                refs.extend(collect_refs(v));
+            }
+        }
+        _ => {}
+    }
+    refs
+}
+
+/// Resolve a $ref like "#/$defs/Foo" to just the def name "Foo".
+fn resolve_def_name(ref_path: &str) -> Option<&str> {
+    ref_path.strip_prefix("#/$defs/")
+}
+
+/// Collect all transitive $def names needed for a given schema.
+fn collect_needed_defs(
+    root_schema: &Value,
+    schema_ref: &str,
+) -> Result<std::collections::HashSet<String>> {
     let defs = root_schema
+        .get("$defs")
+        .context("schema must expose $defs")?;
+
+    let mut needed = std::collections::HashSet::new();
+    let mut to_process = Vec::new();
+
+    // Start with the directly referenced def
+    if let Some(def_name) = resolve_def_name(schema_ref) {
+        to_process.push(def_name.to_string());
+    }
+
+    while let Some(current) = to_process.pop() {
+        if !needed.insert(current.clone()) {
+            continue; // Already processed
+        }
+        if let Some(def_val) = defs.get(&current) {
+            for ref_path in collect_refs(def_val) {
+                if let Some(dep_name) = resolve_def_name(&ref_path) {
+                    to_process.push(dep_name.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(needed)
+}
+
+fn schema_ref_object(root_schema: &Value, schema_ref: &str) -> Result<Map<String, Value>> {
+    let all_defs = root_schema
         .get("$defs")
         .cloned()
         .context("schema must expose $defs")?;
+
+    // Only include $defs that are actually referenced by this tool's schema
+    let needed_names = collect_needed_defs(root_schema, schema_ref)?;
+    let filtered_defs: Map<String, Value> = all_defs
+        .as_object()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(name, _)| needed_names.contains(name))
+        .collect();
+
     let schema = json!({
         "$schema": root_schema
             .get("$schema")
             .cloned()
             .unwrap_or_else(|| json!("https://json-schema.org/draft/2020-12/schema")),
-        "$defs": defs,
+        "$defs": filtered_defs,
         "$ref": schema_ref,
     });
     schema

--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -843,6 +843,36 @@ mod tests {
         assert!(stream_next.tool.output_schema.is_some());
     }
 
+    #[test]
+    fn catalog_trims_per_tool_schema_defs() {
+        let root_schema: Value = serde_json::from_str(include_str!("../data/rpc-v1-schema.json"))
+            .expect("embedded rpc-v1 schema must parse");
+        let full_def_count = root_schema["$defs"]
+            .as_object()
+            .expect("root schema exposes $defs")
+            .len();
+        let catalog = tool_catalog();
+        let task_create = catalog.lookup("task_create").expect("task_create tool");
+        let task_create_def_count = task_create.tool.input_schema["$defs"]
+            .as_object()
+            .expect("task_create input schema exposes filtered $defs")
+            .len();
+
+        assert!(
+            task_create_def_count < full_def_count,
+            "task_create should not republish every root $defs entry ({task_create_def_count}/{full_def_count})"
+        );
+
+        let listed = catalog.list_tools(None).expect("tools should list");
+        let payload_size = serde_json::to_vec(&listed.tools)
+            .expect("tools/list payload should serialize")
+            .len();
+        assert!(
+            payload_size < 1_000_000,
+            "tools/list schema payload should stay under 1MB, got {payload_size} bytes"
+        );
+    }
+
     #[tokio::test]
     async fn stream_next_times_out_without_events() {
         let (server, _workspace) = test_server();

--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -630,17 +630,88 @@ fn schema_method_map(
     Ok(map)
 }
 
-fn schema_ref_object(root_schema: &Value, schema_ref: &str) -> Result<Map<String, Value>> {
+/// Collect all $ref paths from a JSON value recursively.
+fn collect_refs(val: &Value) -> Vec<String> {
+    let mut refs = Vec::new();
+    match val {
+        Value::Object(map) => {
+            if let Some(r) = map.get("$ref").and_then(Value::as_str) {
+                refs.push(r.to_string());
+            }
+            for v in map.values() {
+                refs.extend(collect_refs(v));
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                refs.extend(collect_refs(v));
+            }
+        }
+        _ => {}
+    }
+    refs
+}
+
+/// Resolve a $ref like "#/$defs/Foo" to just the def name "Foo".
+fn resolve_def_name(ref_path: &str) -> Option<&str> {
+    ref_path.strip_prefix("#/$defs/")
+}
+
+/// Collect all transitive $def names needed for a given schema.
+fn collect_needed_defs(
+    root_schema: &Value,
+    schema_ref: &str,
+) -> Result<std::collections::HashSet<String>> {
     let defs = root_schema
+        .get("$defs")
+        .context("schema must expose $defs")?;
+
+    let mut needed = std::collections::HashSet::new();
+    let mut to_process = Vec::new();
+
+    // Start with the directly referenced def
+    if let Some(def_name) = resolve_def_name(schema_ref) {
+        to_process.push(def_name.to_string());
+    }
+
+    while let Some(current) = to_process.pop() {
+        if !needed.insert(current.clone()) {
+            continue; // Already processed
+        }
+        if let Some(def_val) = defs.get(&current) {
+            for ref_path in collect_refs(def_val) {
+                if let Some(dep_name) = resolve_def_name(&ref_path) {
+                    to_process.push(dep_name.to_string());
+                }
+            }
+        }
+    }
+
+    Ok(needed)
+}
+
+fn schema_ref_object(root_schema: &Value, schema_ref: &str) -> Result<Map<String, Value>> {
+    let all_defs = root_schema
         .get("$defs")
         .cloned()
         .context("schema must expose $defs")?;
+
+    // Only include $defs that are actually referenced by this tool's schema
+    let needed_names = collect_needed_defs(root_schema, schema_ref)?;
+    let filtered_defs: Map<String, Value> = all_defs
+        .as_object()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|(name, _)| needed_names.contains(name))
+        .collect();
+
     let schema = json!({
         "$schema": root_schema
             .get("$schema")
             .cloned()
             .unwrap_or_else(|| json!("https://json-schema.org/draft/2020-12/schema")),
-        "$defs": defs,
+        "$defs": filtered_defs,
         "$ref": schema_ref,
     });
     schema


### PR DESCRIPTION
## Summary

When serving tools via the MCP stdio protocol, each tool's input and output schemas previously included all 65 `$defs` entries from the RPC schema (~26KB), even though most tools only reference a handful of them. This caused the total `tools/list` response to reach ~2.4MB, making Claude Code defer all tools as too large (#287).

This change adds three helper functions that trace `$ref` paths in each tool's schema and include only the specifically referenced `$defs` entries:
- `collect_refs()` — recursively finds all `$ref` paths in a JSON value
- `resolve_def_name()` — extracts def name from a `$ref` path like `#/$defs/Foo`
- `collect_needed_defs()` — BFS traversal to find all transitive dependencies

This reduces per-tool schema size by ~71% (from 26KB to ~8KB), bringing the total `tools/list` payload from ~2.4MB down to ~0.7MB — well within Claude Code's handling limits.

## Validation

- ✅ `cargo check -p ralph-api` passes
- ✅ All 19 ralph-api unit tests pass (including MCP catalog tests)
- ✅ All 23 integration tests pass (RPC, streaming, task loop, uncovered)
- ✅ No behavioral changes — only schema payload optimization

## Environment

- ralph v2.9.2
- Claude Code v2.1.x+

Closes #287
