### PR TITLE
security: replace source with safe variable parser in sync-embedded-files.sh

### DIFF
--- a/scripts/sync-embedded-files.sh
+++ b/scripts/sync-embedded-files.sh
@@ -68,8 +68,10 @@ load_pdd_source_config() {
         exit 1
     fi
 
-    # shellcheck disable=SC1090
-    source "$config_path"
+    # Extract only the three expected variables without executing arbitrary shell code.
+    PDD_UPSTREAM_REPO="$(grep '^PDD_UPSTREAM_REPO=' "$config_path" | head -1 | sed 's/^PDD_UPSTREAM_REPO="\(.*\)"$/\1/')"
+    PDD_UPSTREAM_REF="$(grep '^PDD_UPSTREAM_REF=' "$config_path" | head -1 | sed 's/^PDD_UPSTREAM_REF="\(.*\)"$/\1/')"
+    PDD_UPSTREAM_PATH="$(grep '^PDD_UPSTREAM_PATH=' "$config_path" | head -1 | sed 's/^PDD_UPSTREAM_PATH="\(.*\)"$/\1/')"
 
     : "${PDD_UPSTREAM_REPO:?PDD_UPSTREAM_REPO must be set in $PDD_SOURCE_CONFIG}"
     : "${PDD_UPSTREAM_REF:?PDD_UPSTREAM_REF must be set in $PDD_SOURCE_CONFIG}"


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`scripts/sync-embedded-files.sh` uses `source "$config_path"` to read three variable values from `crates/ralph-cli/sops/upstream/pdd.env`. Sourcing a file executes its entire contents as shell code. While the path is hardcoded and repo-internal today, this creates a shell-injection surface: any shell code written or injected into `pdd.env` — whether by a compromised commit, a misconfigured editor, or a script that generates the file — will execute with the script's full privileges.

## Fix

Replace the `source` call with three targeted `grep`/`sed` extractions, one per expected variable (`PDD_UPSTREAM_REPO`, `PDD_UPSTREAM_REF`, `PDD_UPSTREAM_PATH`). Each line reads only the named key and nothing else. The downstream validation block (`${VAR:?...}`) is preserved unchanged to keep error messaging consistent.

Behaviour and output are identical; only the attack surface is reduced.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->