### PR TITLE
security: use npm ci for deterministic installs in test-fresh-install.sh

### DIFF
--- a/scripts/test-fresh-install.sh
+++ b/scripts/test-fresh-install.sh
@@ -65,9 +65,9 @@ fi
 cd "$WORK_DIR"
 
 # --- npm install ---
-info "Running npm install..."
-npm install
-pass "npm install succeeded"
+info "Running npm ci..."
+npm ci
+pass "npm ci succeeded"
 
 # Verify lockfile artifact
 if [ ! -f "node_modules/.package-lock.json" ]; then


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`scripts/test-fresh-install.sh` runs `npm install` to validate that the web dashboard sets up correctly from a clean state. `npm install` resolves package versions from the npm registry at runtime and may install versions that differ from what is in `package-lock.json` if the lockfile is slightly out of date — silently drifting from the pinned dependency tree. In a supply-chain attack scenario, a compromised transitive dependency could be picked up without any lockfile mismatch warning.

## Fix

Replace `npm install` with `npm ci`. `npm ci` installs exclusively what is recorded in `package-lock.json` and exits with an error if the lockfile is missing or inconsistent with `package.json`. This is the standard recommendation for CI and fresh-install validation scripts. The existing `package-lock.json` in the repository makes this a drop-in replacement.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->