### PR TITLE
fix: propagate RALPH_EVENTS_FILE env and preserve late termination reason

### DIFF
--- a/crates/ralph-adapters/src/cli_executor.rs
+++ b/crates/ralph-adapters/src/cli_executor.rs
@@ -350,6 +350,14 @@ fn inject_ralph_runtime_env(command: &mut Command, workspace_root: &std::path::P
     }
     command.env("RALPH_BIN", &current_exe);
     command.env("RALPH_WORKSPACE_ROOT", workspace_root);
+
+    // Propagate RALPH_EVENTS_FILE so `ralph emit` from any CWD writes to the correct events file
+    let marker = workspace_root.join(".ralph/current-events");
+    if let Ok(relative) = std::fs::read_to_string(&marker) {
+        let abs = workspace_root.join(relative.trim());
+        command.env("RALPH_EVENTS_FILE", &abs);
+    }
+
     if std::path::Path::new("/var/tmp").is_dir() {
         command.env("TMPDIR", "/var/tmp");
         command.env("TMP", "/var/tmp");

--- a/crates/ralph-adapters/src/pty_executor.rs
+++ b/crates/ralph-adapters/src/pty_executor.rs
@@ -1785,6 +1785,14 @@ fn inject_ralph_runtime_env(cmd_builder: &mut CommandBuilder, workspace_root: &s
     }
     cmd_builder.env("RALPH_BIN", current_exe);
     cmd_builder.env("RALPH_WORKSPACE_ROOT", workspace_root);
+
+    // Propagate RALPH_EVENTS_FILE so `ralph emit` from any CWD writes to the correct events file
+    let marker = workspace_root.join(".ralph/current-events");
+    if let Ok(relative) = std::fs::read_to_string(&marker) {
+        let abs = workspace_root.join(relative.trim());
+        cmd_builder.env("RALPH_EVENTS_FILE", abs);
+    }
+
     if std::path::Path::new("/var/tmp").is_dir() {
         cmd_builder.env("TMPDIR", "/var/tmp");
         cmd_builder.env("TMP", "/var/tmp");

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -2388,13 +2388,18 @@ pub async fn run_loop_impl(
             .map(|events| events.had_events)
             .unwrap_or(false);
 
+        let mut late_termination_reason: Option<TerminationReason> = None;
         if !agent_wrote_events && output_mentions_ralph_emit(&output) {
             match recover_expected_emit_after_output(&mut event_loop)
                 .inspect_err(|e| warn!(error = %e, "Failed to recover expected emit events"))
                 .ok()
             {
-                Some(LateEventRecovery::PendingWork | LateEventRecovery::Terminate(_)) => {
+                Some(LateEventRecovery::PendingWork) => {
                     agent_wrote_events = true;
+                }
+                Some(LateEventRecovery::Terminate(reason)) => {
+                    agent_wrote_events = true;
+                    late_termination_reason = Some(reason);
                 }
                 Some(LateEventRecovery::NoLateEvents) | None => {
                     warn!(
@@ -2467,7 +2472,9 @@ pub async fn run_loop_impl(
             return Ok(reason);
         }
 
-        if let Some(reason) = event_loop.check_completion_event() {
+        if let Some(reason) =
+            late_termination_reason.or_else(|| event_loop.check_completion_event())
+        {
             info!(
                 "Completion event {} detected.",
                 config.event_loop.completion_promise

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -2492,13 +2492,15 @@ fn emit_command_with_root(
 
     // Resolve events file: RALPH_EVENTS_FILE env > marker file > CLI arg
     // This ensures `ralph emit` writes to the same events file as the active run
-    let events_file = if let Ok(path) = std::env::var("RALPH_EVENTS_FILE") {
-        PathBuf::from(path)
-    } else {
-        fs::read_to_string(&current_events_marker)
-            .map(|s| resolve_marker_target(&workspace_root, &s))
-            .unwrap_or_else(|_| args.file.clone())
-    };
+    let events_file = std::env::var("RALPH_EVENTS_FILE")
+        .ok()
+        .filter(|p| !p.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            fs::read_to_string(&current_events_marker)
+                .map(|s| resolve_marker_target(&workspace_root, &s))
+                .unwrap_or_else(|_| args.file.clone())
+        });
 
     // Ensure parent directory exists
     if let Some(parent) = events_file.parent()

--- a/crates/ralph-cli/src/wave.rs
+++ b/crates/ralph-cli/src/wave.rs
@@ -129,7 +129,9 @@ pub fn write_wave_events(topic: &str, payloads: &[String], events_file: &Path) -
 /// Priority: RALPH_EVENTS_FILE env > .ralph/current-events marker > default .ralph/events.jsonl
 pub fn resolve_events_file() -> PathBuf {
     if let Ok(path) = std::env::var("RALPH_EVENTS_FILE") {
-        return PathBuf::from(path);
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
     }
     fs::read_to_string(".ralph/current-events")
         .map(|s| PathBuf::from(s.trim()))

--- a/crates/ralph-core/src/task_store.rs
+++ b/crates/ralph-core/src/task_store.rs
@@ -291,7 +291,7 @@ impl TaskStore {
     pub fn open(&self) -> Vec<&Task> {
         self.tasks
             .iter()
-            .filter(|t| t.status != TaskStatus::Closed)
+            .filter(|t| !t.status.is_terminal())
             .collect()
     }
 


### PR DESCRIPTION
## Summary

Two fixes for event handling reliability in loop execution.

### 1. Propagate `RALPH_EVENTS_FILE` in `inject_ralph_runtime_env`

**Files:** `cli_executor.rs`, `pty_executor.rs`

`ralph emit` resolves `--file .ralph/events-*.jsonl` relative to CWD. When an agent `cd`s to a project root (e.g. to run builds), emit writes to the wrong events file. The loop runner never sees the events and the loop stalls.

Fix: read the `.ralph/current-events` marker file, resolve it to an absolute path, and export `RALPH_EVENTS_FILE` to the backend subprocess. This env var takes highest priority in emit's file resolution.

### 2. Preserve `LateEventRecovery::Terminate` reason

**File:** `loop_runner.rs`

`recover_expected_emit_after_output` can return `LateEventRecovery::Terminate(reason)`, but the match arm grouped it with `PendingWork` and discarded the reason:

```rust
// Before — termination reason silently dropped
Some(LateEventRecovery::PendingWork | LateEventRecovery::Terminate(_)) => {
    agent_wrote_events = true;
}
```

Now `Terminate(reason)` is captured and checked via `.or_else()` alongside `check_completion_event()`, ensuring late termination signals are honored.

## Testing

- `cargo test` — all tests pass
- `cargo clippy --all-targets --all-features` — no new warnings
- `cargo fmt --check` — clean
- Tested in production with kiro-cli backend running multi-hat loops where agents frequently change CWD