### PR TITLE
feat(builder): visual workflow editor with live agent observation

### DIFF
--- a/.ralph/specs/workflow-builder-live-observation.spec.md
+++ b/.ralph/specs/workflow-builder-live-observation.spec.md
@@ -1,0 +1,330 @@
+---
+status: draft
+gap_analysis: null
+related:
+  - workflow-builder-ui-edit-controls.spec.md
+  - hat-collections.spec.md
+---
+
+# Workflow Builder Live Observation
+
+## Overview
+
+The Builder page (`/builder`) currently supports editing hat collection
+workflows but has no awareness of running loops. This spec adds a live
+observation mode: when a loop executes against a collection, the same
+graph that the user designed lights up in real time, showing which hat
+is active, which events are firing, and what iteration the loop is on.
+
+Edit mode and observation mode share the same page and graph layout.
+No separate route or tab is introduced.
+
+## Non-Goals
+
+- Streaming agent log output in the PropertiesPanel (separate feature)
+- Historical replay of completed loops
+- Cost or token tracking in the Builder
+- Backpressure gate visualization
+- Automatic config sync between collection and ralph.yml
+- Supporting multiple simultaneous observed loops per Builder instance
+
+## Design
+
+### Backend: Event File Watcher (B1)
+
+The orchestration loop writes every hat-to-hat event to a JSONL file.
+Each fresh loop run creates a new timestamped file (e.g.
+`.ralph/events-20260423-120000.jsonl`). A marker file
+`.ralph/current-events` contains the relative path to the active file.
+
+A new background task in `ralph-api` polls this file every 500ms:
+
+1. Read `.ralph/current-events` to resolve the active events file path
+2. If the path changed since last poll, reset the byte offset to 0
+3. Read from the stored byte offset to EOF
+4. Parse each new line as `EventRecord`. Both Ralph-emitted events (with
+   `hat`, `iteration`, `triggered`) and agent-emitted events (only `ts`,
+   `topic`, `payload`) are valid. Missing fields default to empty or 0
+   via `#[serde(default)]`
+5. Publish each record to the stream domain as a `loop.orchestration`
+   event
+6. If the file or marker does not exist, skip and retry next poll
+
+No changes to `ralph-cli`. No subprocess piping. The file watcher runs
+independently of the RPC handler (no mutex interaction).
+
+### Frontend: Observation Overlay (B2)
+
+`CollectionBuilder` gains an observation layer driven by a zustand store.
+When observation is active, the graph renders visual overlays on nodes
+and edges based on incoming `loop.orchestration` stream events.
+
+State model (zustand, survives navigation):
+
+```
+active: boolean
+loopId: string | null
+iteration: number
+activeHatId: string | null
+nodeStates: Record<string, 'idle' | 'pending' | 'active' | 'completed'>
+lastFiredEdgeId: string | null
+lastFiredAt: number
+```
+
+Event-to-state mapping:
+
+Ralph writes two kinds of events to `.ralph/events-*.jsonl` (see
+`crates/ralph-core/src/event_logger.rs` `EventRecord`):
+
+1. **Loop-level events** (written by Ralph itself): carry `hat`,
+   `iteration`, `triggered`, and full context.
+2. **Agent-level events** (written by the active agent via tool calls):
+   carry only `ts`, `topic`, and `payload`. `hat` defaults to empty
+   string via `#[serde(default)]`.
+
+In a typical run, agent-level events dominate (empirically ~21 of 22
+events in a single pong-game run). The observation overlay must handle
+both shapes, inferring the transition from graph topology when the event
+lacks explicit hat context.
+
+| Event shape | State update |
+|---|---|
+| Loop-level with `hat` and `triggered` (e.g. `task.start`) | `triggered` hat → active; prior active → completed |
+| Agent-level with `topic` matching an edge label | Edge's `source` hat → completed, `target` hat → active, edge → fired |
+| Any event with `topic` matching an edge label | Set `lastFiredEdgeId` to that edge, reset timer |
+| `iteration` increments | Update iteration counter |
+| `topic` = loop completion promise (`LOOP_COMPLETE`, `loop.terminate`) | All nodes → completed, exit observation after 2s |
+
+Events with `hat: "loop"` are meta-events from the framework itself, not
+from a user-defined hat. They drive transitions (via `triggered`) but
+never appear as the "active hat" badge in the toolbar.
+
+Node visual states:
+
+| State | Border | Animation |
+|---|---|---|
+| Idle | None | None |
+| Pending | `!border-2 !border-sky-400` | Static |
+| Active | `!border-2` | `animate-border-pulse` (red, border-color only) |
+| Completed | `!border-2 !border-teal-400` | Static + ✓ badge |
+
+Edge fired state: `stroke-dasharray` + `stroke-dashoffset` CSS animation
+over 1.5s. If a new fire arrives before the animation completes, the
+timer resets (previous animation cancelled). Only one edge animates at
+a time (known limitation for MVP).
+
+Edit mode vs observation mode:
+- Observation: palette collapsed, properties panel hidden, drag/drop
+  disabled, delete keys disabled, toolbar shows iteration counter +
+  active hat name + Stop + inline legend
+- Edit: current behavior + Run button
+
+Observation toolbar layout:
+- Left: `● Observing` badge, `Iteration N` counter, active-hat badge
+  (filtered: `loop` is never shown as the active hat because it is a
+  framework-level synthetic marker, not a user hat)
+- Right: inline legend (`● pending`, `● active`, `● done ✓`) so the
+  user can map ring colors without hunting for docs. The legend uses
+  solid background swatches matching the node rings
+
+The toolbar uses `flex-wrap` so the legend gracefully drops to a second
+line on narrow viewports.
+
+### Frontend: Run Button (B3)
+
+A Run button in the Builder toolbar starts a loop:
+
+1. If dirty, Run is disabled; the user must save first (to avoid
+   desync between the graph shown and the graph being run)
+2. On click, open a prompt dialog asking what the workflow should do
+3. On prompt submit, call `collection.run` with the collection id and
+   the prompt
+4. The RPC exports the collection as a hats-only YAML and spawns
+   `ralph run -H <yaml> -a -p <prompt>` in the workspace. `-a`
+   (autonomous) is required because the API spawns ralph as a
+   background subprocess with no controlling tty
+5. Enter observation mode for the loop. The RPC response includes
+   `startingHat` (the hat that will activate first, derived from the
+   graph topology). The frontend calls `setHatActive(startingHat)`
+   immediately, eliminating the timing race between the RPC return
+   and the first WebSocket event.
+6. Toolbar switches to: `Observing` badge, iteration counter, active
+   hat badge, Stop button, inline legend
+7. Stop calls `loop.stop` (which reads `.ralph/loop.lock` for the PID
+   and signals the process), exits observation, returns to edit mode
+8. Loop completion exits observation automatically after a 2s delay
+9. If the spawned ralph exits non-zero within the first 500ms, the
+   RPC returns an error containing ralph's verbatim stderr. The
+   Builder shows a dismissable error banner with that text
+
+MVP limitation: the Run button uses the user's existing `ralph.yml` for
+backend/max_iterations/backpressure config. The collection only provides
+hats and events. If the configured backend is not installed or
+misconfigured, ralph exits non-zero and the Builder surfaces the stderr
+verbatim in a dismissable banner; the user is expected to fix their
+config and retry.
+
+## Acceptance Criteria
+
+### Event Watcher Publishes to Stream
+
+- **Given** a loop is running and writing to `.ralph/events-*.jsonl`
+- **When** a new event line is appended to the file
+- **Then** within 500ms, a `loop.orchestration` event appears on the
+  stream WebSocket with the correct `hat`, `iteration`, `topic`, and
+  `triggered` fields
+
+### Watcher Handles Missing File
+
+- **Given** no loop is running and `.ralph/current-events` does not exist
+- **When** the watcher polls
+- **Then** it skips without error and retries on the next poll
+
+### Watcher Switches on New Loop
+
+- **Given** the watcher is tailing `events-A.jsonl`
+- **When** a new loop starts and `.ralph/current-events` changes to
+  `events-B.jsonl`
+- **Then** the watcher resets its offset and begins tailing the new file
+
+### Node Lights Up When Hat Activates
+
+- **Given** the Builder is in observation mode showing a collection with
+  a planner and builder hat connected by an edge labelled `subtask.ready`
+- **When** a `loop.orchestration` event arrives with either
+  - (a) `hat: "builder"` (Ralph-emitted), or
+  - (b) `topic: "subtask.ready"` without a `hat` field (agent-emitted)
+- **Then** the builder node shows an indigo ring (active), the planner
+  node transitions to completed (teal ring + ✓), and the edge pulses
+
+### Edge Pulses When Event Fires
+
+- **Given** the Builder is in observation mode with an edge labeled
+  `build.done`
+- **When** a `loop.orchestration` event arrives with `topic: "build.done"`
+- **Then** the edge renders a dash-offset pulse animation for 1.5s
+
+### Iteration Counter Updates
+
+- **Given** the Builder is in observation mode
+- **When** events arrive with incrementing `iteration` values
+- **Then** the toolbar displays the current iteration number
+
+### Run Button Starts Loop
+
+- **Given** a saved collection is open in the Builder with no unsaved
+  changes
+- **When** the user clicks Run, enters a prompt in the dialog, and
+  submits
+- **Then** `collection.run` is called with the collection id and prompt;
+  on success the Builder enters observation mode
+
+### Run Button Disabled While Dirty
+
+- **Given** the collection has unsaved changes
+- **When** the user looks at the Run button
+- **Then** the button is disabled with a tooltip explaining to save first
+
+### Run Error Feedback
+
+- **Given** the configured backend binary (from `ralph.yml`) is not
+  installed on PATH
+- **When** the user clicks Run and submits a prompt
+- **Then** ralph's verbatim stderr is shown in a dismissable banner
+  prefixed with the exit code (e.g. `ralph run exited with exit code 1:
+  kiro-acp: No such file or directory`)
+
+### Stop Button Exits Observation
+
+- **Given** the Builder is in observation mode
+- **When** the user clicks Stop
+- **Then** `loop.stop` is called and the Builder returns to edit mode
+
+### Loop Completion Exits Observation
+
+- **Given** the Builder is in observation mode
+- **When** the loop emits the completion promise event
+- **Then** all nodes show completed state and observation mode exits
+  after a brief delay
+
+### Observation Survives Navigation
+
+- **Given** the Builder is in observation mode
+- **When** the user navigates to /tasks and back to /builder
+- **Then** observation mode is still active with the current state
+  (zustand persistence + WebSocket reconnect with replay)
+
+### Editing Disabled During Observation
+
+- **Given** the Builder is in observation mode
+- **When** the user tries to drag a node, delete an edge, or drop a
+  hat from the palette
+- **Then** the action is blocked (palette hidden, properties panel
+  hidden, delete keys disabled, drag/drop disabled)
+
+## Implementation Notes
+
+### Files Changed (B1: Rust)
+
+| File | Change |
+|---|---|
+| `crates/ralph-api/src/protocol.rs` | Add `loop.orchestration` to `STREAM_TOPICS`; add `collection.run` types |
+| `crates/ralph-api/src/event_watcher.rs` (new) | File-polling watcher that tails events JSONL |
+| `crates/ralph-api/src/transport.rs` | Spawn watcher task on server startup with shutdown wiring |
+| `crates/ralph-api/src/collection_domain.rs` | Add `run()` method that spawns `ralph run -H ... -a -p ...`, surfaces stderr on failure, detaches a reaper thread so successful runs don't leave zombies |
+| `crates/ralph-api/src/runtime/dispatch.rs` | Dispatch `collection.run` to the domain |
+| `crates/ralph-api/src/mcp.rs` | Tool description for `collection.run` |
+| `crates/ralph-api/data/rpc-v1-schema.json` | Schema entries for `collectionRunParams` / `collectionRunResult` |
+| `crates/ralph-api/src/lib.rs` | Re-export `event_watcher` module |
+| `crates/ralph-api/Cargo.toml` | Depend on `ralph-core` for `EventRecord`, on `tempfile` for tests |
+
+### Files Changed (B2: Frontend)
+
+| File | Change |
+|---|---|
+| `frontend/ralph-web/src/stores/observationStore.ts` (new) | Zustand store for observation state; exposes itself on `window.__observationStore` in dev builds for Playwright |
+| `frontend/ralph-web/src/hooks/useLoopObservation.ts` (new) | Hook that subscribes to `loop.orchestration` stream and updates the store |
+| `frontend/ralph-web/src/components/builder/CollectionBuilder.tsx` | Conditional rendering based on observation state; inline `ObservationLegend` in observation toolbar; filter `loop` out of active-hat badge |
+| `frontend/ralph-web/src/components/builder/HatNode.tsx` | Accept `observationState`, render ring + `data-hat-key` + `data-observation-state` attributes |
+| `frontend/ralph-web/src/components/builder/OffsetEdge.tsx` | Accept `fired` data prop, render pulse animation; expose `data-edge-id` + `data-fired` |
+| `frontend/ralph-web/src/components/layout/AppShell.tsx` | Add `h-full` to the outlet wrapper so the Builder's flex tree can claim full viewport height |
+| `frontend/ralph-web/src/index.css` | Add `@keyframes edgePulse` |
+| `frontend/ralph-web/src/vite-env.d.ts` (new) | `/// <reference types="vite/client" />` for `import.meta.env` typing |
+
+### Files Changed (B3: Frontend)
+
+| File | Change |
+|---|---|
+| `frontend/ralph-web/src/pages/BuilderPage.tsx` | Run/Stop buttons, prompt dialog integration, error banner, blueprint click handler |
+| `frontend/ralph-web/src/components/builder/RunPromptDialog.tsx` (new) | Modal asking what the workflow should do before starting the loop |
+| `frontend/ralph-web/src/components/builder/blueprints.ts` (new) | Pre-built workflow templates (starter simple versions, not full shipped presets) |
+| `frontend/ralph-web/src/trpc.ts` | Add `collection.run` and `loops.stop` mutation wrappers |
+| `frontend/ralph-web/src/rpc/client.ts` | Add `collection.run` to `MUTATING_METHODS` for idempotency-key handling |
+
+### Dependencies
+
+No new runtime dependencies in either Rust or TypeScript.
+
+The `ralph-core` crate is added as a dependency of `ralph-api` for the
+`EventRecord` type. This is a workspace-internal dependency, not external.
+
+### Test Coverage
+
+| Module | Tests |
+|---|---|
+| `event_watcher.rs` | Unit tests: parse valid/invalid lines, handle missing file, detect marker change, offset tracking |
+| `collection_domain.rs` | Unit tests: `run()` surfaces stderr on non-zero exit; `run()` surfaces a clear error when the ralph binary itself is missing |
+| `observationStore.ts` | Covered via Playwright because the observation UI drives the store through `window.__observationStore`; node-state transitions asserted via `data-observation-state` attributes |
+| Playwright e2e (`builder.spec.ts`) | 30 tests covering Collection List, New Collection, Save/Edit Flow, Import YAML, Run + Observation (including full 4-hat chain state machine with mocked RPC, edge-fire toggle, legend visibility, properties-panel toggle), Node deletion via Backspace and Delete, Blueprint cards, and Run Error Feedback |
+| UI flows | Manual verification against acceptance criteria |
+
+### Known Limitations
+
+- 500ms polling latency: events appear with up to half a second delay
+- Single-edge animation: rapid successive events cancel the previous
+  edge's animation
+- Navigation replay gap: returning mid-loop may show some nodes as
+  idle if the replay buffer doesn't cover full history
+- Config mismatch: Run button uses existing ralph.yml, not the
+  collection's YAML directly
+- No streaming log output in PropertiesPanel during observation

--- a/.ralph/specs/workflow-builder-ui-edit-controls.spec.md
+++ b/.ralph/specs/workflow-builder-ui-edit-controls.spec.md
@@ -1,0 +1,381 @@
+---
+status: draft
+gap_analysis: null
+related:
+  - hat-collections.spec.md
+---
+
+# Workflow Builder UI Edit Controls
+
+## Overview
+
+The web dashboard's Builder page (`/builder`) is a visual workflow editor for
+hat collections. Users drag hats from a palette, connect them via event edges,
+and save the resulting graph. Before this spec, the page supported creation
+and export but had no controls for deleting individual edges, recovering from
+accidentally-orphaned edges, importing YAML back into a collection, or guarding
+against lost unsaved work.
+
+This spec defines the edit controls the Builder must expose so a user can
+maintain a collection end-to-end from the UI, plus the YAML round-trip that
+completes the export → edit → re-import loop.
+
+## Goals
+
+1. **Deletable edges and nodes** — keyboard and mouse affordances for removing
+   individual elements without re-saving the whole graph manually
+2. **No orphaned edges** — when a user removes an event from a hat's
+   `publishes` or `triggers`, the connected edges must be cleaned up
+3. **YAML round-trip** — users can re-import a previously exported YAML file
+   (or any compatible preset) via the UI
+4. **Readable imports** — re-imported graphs land on a layered layout rather
+   than a single vertical column
+5. **Edit safety** — unsaved changes are detected and the user is asked to
+   confirm before losing them
+
+## Non-Goals
+
+- Chat interface or conversational UI — Ralph is a loop runner, not a chat product
+- Theme system or color customization — one dark theme is sufficient for alpha
+- Live loop output streaming in the Builder — separate feature, different page
+- Sidebar navigation blocking via `useBlocker` — requires router migration to
+  `createBrowserRouter`, out of scope for edit controls
+- Fixing the exported YAML hat key format (`planner-a1b2c3d4`) — pre-existing
+  backend behavior
+
+## Design
+
+### Edge Controls
+
+The Builder uses React Flow v12. Edge deletion is surfaced through
+React Flow's built-in events; no custom delete affordance lives inside the
+edge component itself.
+
+- **Keyboard deletion** — `deleteKeyCode={["Backspace", "Delete"]}` on `<ReactFlow>`.
+  Both keys are bound because Mac keyboards require `Fn + Backspace` to produce
+  `Delete`, making a Delete-only binding unreachable for most Mac users. This is
+  safe because the Builder's text inputs (toolbar, PropertiesPanel) are rendered
+  outside the `<ReactFlow>` component tree — key events in those inputs do not
+  bubble into React Flow's key handler.
+- **Selection feedback** — the `OffsetEdge` component reads React Flow's
+  `selected` prop and increases stroke width and glow opacity while selected
+  so users see what keyboard deletion will affect.
+
+### Node Deletion and Edge Cleanup
+
+React Flow's `onNodesChange` removes nodes from state when the user presses
+Delete, but it does **not** remove the connected edges. An `onNodesDelete`
+handler on `<ReactFlow>` explicitly filters edges whose `source` or `target`
+matches any deleted node's id.
+
+The pre-existing `handleDeleteNode` path (the "Delete Hat" button in the
+PropertiesPanel) already filters edges; the new `onNodesDelete` handler
+covers the keyboard path so both entry points produce the same result.
+
+### Edge Sync When Publishes or Triggers Change
+
+The PropertiesPanel allows the user to edit a hat's `publishes` and
+`triggersOn` arrays. Each trigger in `triggersOn` renders a target handle
+with `id={triggerEvent}`; each event in `publishes` renders a source handle
+with `id={publishEvent}`. Edges are stored with `sourceHandle` /
+`targetHandle` equal to the event name.
+
+When the user removes an event from either array, any edge whose
+`sourceHandle` or `targetHandle` references the removed event becomes
+invalid (it points at a handle that no longer renders). The Builder filters
+those edges on the same change. A `console.info` reports the removal count
+so developers can observe the cleanup.
+
+### YAML Import
+
+A new `ImportYamlDialog` component provides a modal with:
+- Text area for pasting YAML
+- File input that accepts `.yml` / `.yaml` and reads via `FileReader`
+- Required `name` input (seeded from the uploaded filename when empty)
+- Optional `description` input
+
+The dialog delegates YAML parsing to the backend via the existing
+`collection.import` RPC (no frontend YAML parser dependency is introduced).
+Parse errors are surfaced inline using the same error banner style as
+`SettingsPage`.
+
+### Auto-Layout on Fresh Import
+
+The Rust YAML importer produces a graph with every node at `x = 250` and
+`y` increasing by 200 per node — a single vertical column. Opening that
+graph in the Builder is ugly. A pure `autoLayout` function in a new
+`layout.ts` module runs a Kahn-style BFS over the graph and assigns each
+node to a left-to-right "level" based on its distance from the in-degree-0
+roots, laying the graph out as a layered column-per-level grid.
+
+Auto-layout fires exactly once: on mount of `CollectionBuilder` when the
+component receives `justImported={true}` and the `needsLayout` heuristic
+matches the importer's stacked output. Subsequent renders never re-layout.
+The resulting graph is marked dirty so the user can persist the layout by
+clicking Save.
+
+Cycles and disconnected subgraphs are handled:
+- Back-edges (cycles) are ignored via first-seen-wins level assignment so
+  BFS always terminates
+- In-degree-0 nodes are all placed at level 0, even with no outgoing edges
+- Pure-cycle graphs (no roots at all) seed level 0 with the first node
+
+### Role-Based Visual Identity
+
+Each hat node displays an emoji and border color derived from its role
+(planner, builder, reviewer, validator, confessor, custom). The mapping
+lives in a shared `roles.ts` module consumed by both `HatNode` (border +
+emoji) and `CollectionBuilder`'s `MiniMap` (node color), so the two views
+cannot drift apart.
+
+The role is extracted from the node's `data.key` field by stripping the
+8-hex-character UUID suffix that `onDrop` appends when a hat is dragged
+from the palette. Unknown roles fall back to a `custom` entry with a
+neutral 🎩 emoji and the default border color. The fallback is mandatory:
+`HatNode` reads `getRoleMeta(...).emoji` unconditionally, so losing the
+fallback would crash the render.
+
+### Dirty-State and Save Feedback
+
+The dirty flag lives in `BuilderPage` (not in `CollectionBuilder`) so edits
+to the Name and Description inputs in the page header flip dirty along
+with graph edits. `CollectionBuilder` receives the flag as a prop and
+calls an `onMarkDirty` callback on every internal change.
+
+A `Badge` in the Builder toolbar shows "Unsaved changes" whenever the
+flag is true. A `saveStatus: "idle" | "success" | "error"` prop drives
+post-save feedback using the same `CheckCircle2` / `AlertCircle` icons
+and three-second auto-clear as `SettingsPage`.
+
+Unsaved-work protection:
+- A `beforeunload` effect (gated on `isDirty`) prompts before tab close
+  or reload
+- `handleBack` in `BuilderPage` calls `confirm("Discard unsaved changes?")`
+  before returning to the list view
+- Sidebar navigation cannot be blocked (the app uses `<BrowserRouter>`
+  rather than a data router, so `useBlocker` is not available); this is
+  an accepted limitation
+
+### Just-Imported One-Shot
+
+A `justImportedId` ref in `BuilderPage` records the id of the last
+imported collection. `CollectionBuilder` receives
+`justImported = (selectedId === justImportedId.current)` as a prop. This
+guard:
+- Triggers auto-layout only for the freshly imported graph
+- Naturally false when the user opens a different collection (since
+  `selectedId` changes)
+- Is also explicitly cleared in `handleBack` and in the update mutation's
+  `onSuccess` so it does not fire a second time after a save or navigation
+
+## Acceptance Criteria
+
+### Edge Deletion — Keyboard
+
+- **Given** an edge between two hats is selected on the canvas
+- **When** the user presses `Backspace` or `Delete`
+- **Then** the edge is removed and the dirty indicator appears
+
+### Backspace Does Not Delete Canvas Elements When Input Is Focused
+
+- **Given** the canvas contains a selected edge and the user's cursor is
+  in the Collection Name input
+- **When** the user presses `Backspace`
+- **Then** a character is deleted from the input and the edge remains
+  (because the input is outside the `<ReactFlow>` tree)
+
+### Node Deletion Cleans Up Edges
+
+- **Given** a hat node with incoming and outgoing edges is selected
+- **When** the user presses `Delete`
+- **Then** the node is removed and every edge referencing that node is
+  also removed
+
+### Edge Sync — Publish Removed
+
+- **Given** a hat's `publishes` array contains `subtask.ready` and an
+  outgoing edge labelled `subtask.ready` exists
+- **When** the user removes `subtask.ready` from the hat's publishes
+- **Then** the edge is filtered out of the graph
+
+### Edge Sync — Trigger Removed
+
+- **Given** a hat's `triggersOn` array contains `build.done` and an
+  incoming edge labelled `build.done` exists
+- **When** the user removes `build.done` from the hat's triggers
+- **Then** the edge is filtered out of the graph
+
+### Selection Feedback
+
+- **Given** an edge exists on the canvas
+- **When** the user clicks it to select it
+- **Then** the edge renders with increased stroke width and glow
+  opacity relative to the unselected state
+
+### YAML Import — Paste
+
+- **Given** the user opens the Import YAML dialog
+- **When** the user pastes a valid preset YAML, enters a name, and
+  clicks Import
+- **Then** a new collection is created and the Builder opens it in
+  edit view
+
+### YAML Import — File Upload
+
+- **Given** the user opens the Import YAML dialog
+- **When** the user selects a local `.yml` file
+- **Then** the file contents populate the textarea and the Name field
+  is seeded from the filename (if still empty)
+
+### YAML Import — Invalid YAML
+
+- **Given** the user has pasted malformed YAML into the Import dialog
+- **When** the user clicks Import
+- **Then** the backend's error message is surfaced inline in the dialog
+  and the dialog remains open
+
+### Auto-Layout on Import
+
+- **Given** a user imports a preset YAML with three hats `a → b → c`
+- **When** the Builder mounts with the imported collection
+- **Then** the three nodes are positioned in ascending x-columns
+  (`a.x < b.x < c.x`) and the dirty indicator is set
+
+### Auto-Layout Does Not Re-Run on Subsequent Opens
+
+- **Given** a previously imported collection has been saved with its
+  auto-laid-out positions
+- **When** the user reopens the same collection from the list
+- **Then** the graph uses the persisted positions without re-layout
+  and the dirty indicator is not set
+
+### Auto-Layout Handles Cycles
+
+- **Given** a graph `a → b → c → a`
+- **When** `autoLayout` runs on it
+- **Then** every node receives a finite position and the function
+  terminates (no infinite loop)
+
+### Role-Based Emoji and Border
+
+- **Given** a user drops a `planner` template from the palette
+- **When** the node renders
+- **Then** its header shows `📋` and its border uses the violet
+  role-specific class
+
+### Unknown Role Fallback
+
+- **Given** a hat node whose `data.key` does not match any known role
+- **When** the node renders
+- **Then** it shows the default `🎩` emoji and neutral border instead
+  of crashing
+
+### Dirty Flag — Graph Edit
+
+- **Given** a saved collection with no pending changes
+- **When** the user drags a node to a new position
+- **Then** the "Unsaved changes" badge appears in the toolbar
+
+### Dirty Flag — Metadata Edit
+
+- **Given** a saved collection with no pending changes
+- **When** the user edits the Collection Name input
+- **Then** the "Unsaved changes" badge appears in the toolbar
+
+### Save Feedback — Success
+
+- **Given** the user has unsaved changes and clicks Save
+- **When** the server responds successfully
+- **Then** the badge disappears and "Saved" text with a check icon
+  appears for three seconds before clearing
+
+### Save Feedback — Error
+
+- **Given** the user has unsaved changes and the Save mutation fails
+- **When** the error comes back from the server
+- **Then** "Error saving" text with an alert icon is shown and the
+  dirty flag remains set
+
+### Back Button Confirm
+
+- **Given** the user has unsaved changes
+- **When** the user clicks Back
+- **Then** a confirm dialog asks whether to discard unsaved changes,
+  and navigation only proceeds if the user confirms
+
+### Tab Close Protection
+
+- **Given** the user has unsaved changes
+- **When** the user tries to close the tab or reload
+- **Then** the browser's native `beforeunload` prompt appears
+
+### Just-Imported One-Shot
+
+- **Given** the user has imported a collection and saved it
+- **When** the user navigates back to the list and reopens the same
+  collection
+- **Then** `justImported` is false, auto-layout does not re-run,
+  and the dirty indicator is not set
+
+## Implementation Notes
+
+### Component Placement
+
+| Component | File |
+|-----------|------|
+| `CollectionBuilder` | `frontend/ralph-web/src/components/builder/CollectionBuilder.tsx` |
+| `HatNode` | `frontend/ralph-web/src/components/builder/HatNode.tsx` |
+| `OffsetEdge` | `frontend/ralph-web/src/components/builder/OffsetEdge.tsx` |
+| `ImportYamlDialog` | `frontend/ralph-web/src/components/builder/ImportYamlDialog.tsx` |
+| `BuilderPage` | `frontend/ralph-web/src/pages/BuilderPage.tsx` |
+| Role metadata | `frontend/ralph-web/src/components/builder/roles.ts` |
+| Layout algorithm | `frontend/ralph-web/src/components/builder/layout.ts` |
+
+### Dependencies
+
+No new runtime or dev dependencies. The modal reuses the `fixed inset-0`
++ `Card` pattern from `PlanSession`. No dagre, no YAML parser, no toast
+library.
+
+### Test Coverage
+
+Pure logic is unit-tested; UI interactions are manually verified:
+
+| Module | Tests |
+|--------|-------|
+| `layout.ts` | `layout.test.ts` — linear chain, branching, cycle, disconnected nodes, empty input; `needsLayout` with stacked / varied / single / empty inputs |
+| `roles.ts` | `roles.test.ts` — fallback returns the `custom` entry for unknown roles (protects against a crash in `HatNode`) |
+| Builder UI flows | Covered by manual verification against the acceptance criteria above |
+
+### Backend Contract
+
+No backend changes. The existing `collection.import` and
+`collection.export` RPCs on `ralph-api` carry the full round-trip. The
+Rust YAML serializer's stacked output (`x = 250`, `y += 200`) is
+compensated for client-side by `autoLayout`.
+
+### Known Limitations
+
+- Sidebar navigation with unsaved changes does not prompt because the
+  app uses `<BrowserRouter>` rather than a data router. The Back button
+  and `beforeunload` cover the most common exit paths.
+- Exported YAML uses the node's full id (e.g. `planner-a1b2c3d4`) as the
+  hat dictionary key because the drop handler overwrites `data.key` with
+  the node id. Re-importable but cosmetically ugly. Pre-existing
+  behavior; not addressed by this spec.
+- Reroute nodes saved with empty `data` will fail backend schema
+  validation on save because the backend's `HatNodeData` schema is
+  required. Pre-existing behavior; not addressed by this spec.
+
+## Future Considerations
+
+- **Auto-layout toolbar button** — expose `autoLayout` as a manual action
+  for users who want to tidy up existing messy collections, not just imports
+- **Toast notifications** — replace `console.info` edge-removal feedback
+  with a visible toast so users notice the cleanup without opening DevTools
+- **Router migration** — moving from `<BrowserRouter>` to `createBrowserRouter`
+  would enable `useBlocker` for full in-app navigation guarding
+- **Inline edge label editing** — double-click an edge label to rename the
+  event; deferred because it creates invariant violations with the hat's
+  `publishes` / `triggersOn` arrays (the label must stay in sync with the
+  handle ids)

--- a/crates/ralph-api/data/rpc-v1-schema.json
+++ b/crates/ralph-api/data/rpc-v1-schema.json
@@ -61,6 +61,7 @@
         "collection.delete",
         "collection.import",
         "collection.export",
+        "collection.run",
         "stream.subscribe",
         "stream.unsubscribe",
         "stream.ack"
@@ -637,6 +638,24 @@
         "name"
       ]
     },
+    "collectionRunParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prompt": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "id",
+        "prompt"
+      ]
+    },
     "streamSubscribeParams": {
       "type": "object",
       "additionalProperties": false,
@@ -749,6 +768,7 @@
         { "properties": { "method": { "const": "collection.delete" }, "params": { "$ref": "#/$defs/idOnlyParams" } }, "required": ["method", "params"] },
         { "properties": { "method": { "const": "collection.import" }, "params": { "$ref": "#/$defs/collectionImportParams" } }, "required": ["method", "params"] },
         { "properties": { "method": { "const": "collection.export" }, "params": { "$ref": "#/$defs/idOnlyParams" } }, "required": ["method", "params"] },
+        { "properties": { "method": { "const": "collection.run" }, "params": { "$ref": "#/$defs/collectionRunParams" } }, "required": ["method", "params"] },
 
         { "properties": { "method": { "const": "stream.subscribe" }, "params": { "$ref": "#/$defs/streamSubscribeParams" } }, "required": ["method", "params"] },
         { "properties": { "method": { "const": "stream.unsubscribe" }, "params": { "$ref": "#/$defs/streamUnsubscribeParams" } }, "required": ["method", "params"] },
@@ -998,6 +1018,16 @@
       },
       "required": ["yaml"]
     },
+    "collectionRunResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "success": { "type": "boolean" },
+        "configPath": { "type": "string" },
+        "pid": { "type": "integer" }
+      },
+      "required": ["success", "configPath", "pid"]
+    },
     "streamSubscribeResult": {
       "type": "object",
       "additionalProperties": false,
@@ -1061,6 +1091,7 @@
         { "properties": { "method": { "const": "collection.delete" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] },
         { "properties": { "method": { "const": "collection.import" }, "result": { "$ref": "#/$defs/collectionResult" } }, "required": ["method", "result"] },
         { "properties": { "method": { "const": "collection.export" }, "result": { "$ref": "#/$defs/collectionExportResult" } }, "required": ["method", "result"] },
+        { "properties": { "method": { "const": "collection.run" }, "result": { "$ref": "#/$defs/collectionRunResult" } }, "required": ["method", "result"] },
 
         { "properties": { "method": { "const": "stream.subscribe" }, "result": { "$ref": "#/$defs/streamSubscribeResult" } }, "required": ["method", "result"] },
         { "properties": { "method": { "const": "stream.unsubscribe" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] },

--- a/crates/ralph-api/src/collection_domain.rs
+++ b/crates/ralph-api/src/collection_domain.rs
@@ -39,6 +39,26 @@ pub struct CollectionImportParams {
     pub description: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionRunParams {
+    pub id: String,
+    pub prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionRunResult {
+    pub success: bool,
+    pub config_path: String,
+    pub pid: u32,
+    /// The hat that will activate first, derived from the graph topology.
+    /// The frontend uses this to highlight the entry node immediately
+    /// without waiting for the first WebSocket event (timing-race fix).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starting_hat: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionSummary {
@@ -187,6 +207,12 @@ impl CollectionDomain {
     }
 
     pub fn create(&mut self, params: CollectionCreateParams) -> Result<CollectionRecord, ApiError> {
+        if params.name.trim().is_empty() {
+            return Err(ApiError::invalid_params(
+                "collection name must not be empty",
+            ));
+        }
+
         let graph = params
             .graph
             .map(parse_graph)
@@ -216,8 +242,13 @@ impl CollectionDomain {
             .get_mut(&params.id)
             .ok_or_else(|| collection_not_found_error(&params.id))?;
 
-        if let Some(name) = params.name {
-            record.name = name;
+        if let Some(ref name) = params.name {
+            if name.trim().is_empty() {
+                return Err(ApiError::invalid_params(
+                    "collection name must not be empty",
+                ));
+            }
+            record.name = name.clone();
         }
 
         if let Some(description) = params.description {
@@ -255,6 +286,115 @@ impl CollectionDomain {
     pub fn export(&self, id: &str) -> Result<String, ApiError> {
         let collection = self.get(id)?;
         export_collection_yaml(&collection)
+    }
+
+    /// Export the collection's hats to a temp YAML file and spawn `ralph run`
+    /// with it via the `-H` flag. The user's existing `ralph.yml` provides
+    /// core config (backend, max_iterations, backpressure). The collection
+    /// only provides hats and events.
+    ///
+    /// Returns the PID so the frontend can track the process.
+    pub fn run(
+        &self,
+        params: CollectionRunParams,
+        ralph_command: &str,
+        workspace_root: &Path,
+    ) -> Result<CollectionRunResult, ApiError> {
+        let yaml = self.export(&params.id)?;
+
+        // Write the exported YAML to a predictable path.
+        let collections_dir = workspace_root.join(".ralph/collections");
+        fs::create_dir_all(&collections_dir).map_err(|error| {
+            ApiError::internal(format!(
+                "failed creating collections run directory: {error}"
+            ))
+        })?;
+
+        let config_path = collections_dir.join(format!("{}-run.yml", params.id));
+        fs::write(&config_path, &yaml).map_err(|error| {
+            ApiError::internal(format!(
+                "failed writing collection run config '{}': {error}",
+                config_path.display()
+            ))
+        })?;
+
+        // Spawn ralph run with -H (hats overlay) so the user's ralph.yml
+        // provides backend/max_iterations/backpressure and the collection
+        // provides hats/events. -a (autonomous) forces headless mode, which
+        // is required when the API spawns ralph: interactive mode tries to
+        // read from a tty the background process doesn't own and gets
+        // SIGSTOP'd by the OS. Autonomous mode implies --no-tui.
+        let child = std::process::Command::new(ralph_command)
+            .current_dir(workspace_root)
+            .args([
+                "run",
+                "-H",
+                &config_path.to_string_lossy(),
+                "-a",
+                "-p",
+                &params.prompt,
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|error| {
+                ApiError::internal(format!(
+                    "ralph CLI not found or failed to start. Install ralph or set RALPH_API_RALPH_COMMAND. Error: {error}"
+                ))
+            })?;
+
+        let pid = child.id();
+
+        // Wait briefly to check if the process died immediately.
+        let mut child = child;
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        match child.try_wait() {
+            Ok(Some(status)) if !status.success() => {
+                let mut stderr_output = String::new();
+                if let Some(mut stderr) = child.stderr.take() {
+                    use std::io::Read;
+                    let _ = stderr.read_to_string(&mut stderr_output);
+                }
+                let trimmed = stderr_output.trim();
+                // `status.code()` is `Some(code)` on normal exit; `None` means
+                // signal-terminated on Unix. We format both cleanly to avoid
+                // the double "exit status:" prefix that `ExitStatus: Display`
+                // would produce.
+                let status_label = match status.code() {
+                    Some(code) => format!("exit code {code}"),
+                    None => format!("{status}"),
+                };
+                let message = if trimmed.is_empty() {
+                    format!("ralph run exited with {status_label} (no stderr)")
+                } else {
+                    // Pass ralph's stderr through verbatim. Spawn-failure
+                    // output is small; truncation risks hiding the actual
+                    // error line.
+                    format!("ralph run exited with {status_label}:\n{trimmed}")
+                };
+                return Err(ApiError::internal(message));
+            }
+            _ => {
+                // Still running or exited successfully. Detach a reaper so
+                // the eventual exit doesn't leave a zombie process — the
+                // API may outlive many loop runs.
+                std::thread::spawn(move || {
+                    let _ = child.wait();
+                });
+            }
+        }
+
+        // Compute the starting hat from the collection's topology so the
+        // frontend can highlight it immediately (timing-race fix).
+        let collection = self.get(&params.id)?;
+        let starting_hat = yaml::starting_hat_for_collection(&collection);
+
+        Ok(CollectionRunResult {
+            success: true,
+            config_path: config_path.to_string_lossy().to_string(),
+            pid,
+            starting_hat,
+        })
     }
 
     fn next_collection_id(&mut self) -> String {
@@ -345,4 +485,121 @@ fn parse_graph(raw: Value) -> Result<GraphData, ApiError> {
 fn collection_not_found_error(collection_id: &str) -> ApiError {
     ApiError::collection_not_found(format!("Collection with id '{collection_id}' not found"))
         .with_details(serde_json::json!({ "collectionId": collection_id }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Create a minimal collection in a fresh domain so `run()` has something
+    /// to export.
+    fn fixture_with_collection() -> (TempDir, CollectionDomain, String) {
+        let temp = TempDir::new().expect("tempdir");
+        let mut domain = CollectionDomain::new(temp.path());
+        let record = domain
+            .create(CollectionCreateParams {
+                name: "Test".to_string(),
+                description: None,
+                graph: None,
+            })
+            .expect("create collection");
+        (temp, domain, record.id)
+    }
+
+    #[test]
+    fn run_surfaces_stderr_from_failed_spawn() {
+        // A stub "ralph" that prints a distinctive error and exits non-zero.
+        // /bin/sh is universally available on macOS + Linux (Ralph's only
+        // supported platforms).
+        let (temp, domain, id) = fixture_with_collection();
+
+        // We invoke /bin/sh with `-c` so the arg list ralph.run() builds
+        // (`run -H <path> --no-tui -p <prompt>`) gets passed as extra
+        // positional args; sh echoes to stderr and exits 1 regardless.
+        let script = r#"echo "pi: command not found (simulated)" >&2; exit 1"#;
+
+        // Build a wrapper script that always writes the marker to stderr
+        // and exits 1. We'll point ralph_command at it.
+        let wrapper_path = temp.path().join("fake-ralph.sh");
+        std::fs::write(&wrapper_path, format!("#!/bin/sh\n{script}\n")).expect("write wrapper");
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&wrapper_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&wrapper_path, perms).expect("chmod");
+
+        let result = domain.run(
+            CollectionRunParams {
+                id,
+                prompt: "hello".to_string(),
+            },
+            wrapper_path.to_str().expect("wrapper path"),
+            temp.path(),
+        );
+
+        let err = result.expect_err("fake ralph should fail");
+        let message = format!("{err:?}");
+        assert!(
+            message.contains("pi: command not found (simulated)"),
+            "error should contain the underlying stderr; got: {message}"
+        );
+        assert!(
+            message.contains("exit code 1"),
+            "error should name the exit code; got: {message}"
+        );
+        assert!(
+            !message.contains("..."),
+            "error should not truncate stderr; got: {message}"
+        );
+    }
+
+    #[test]
+    fn create_rejects_empty_name() {
+        let temp = TempDir::new().expect("tempdir");
+        let mut domain = CollectionDomain::new(temp.path());
+        let err = domain
+            .create(CollectionCreateParams {
+                name: "  ".to_string(),
+                description: None,
+                graph: None,
+            })
+            .expect_err("empty name should fail");
+        assert!(format!("{err:?}").contains("name must not be empty"));
+    }
+
+    #[test]
+    fn update_rejects_empty_name() {
+        let (_temp, mut domain, id) = fixture_with_collection();
+        let err = domain
+            .update(CollectionUpdateParams {
+                id,
+                name: Some(String::new()),
+                description: None,
+                graph: None,
+            })
+            .expect_err("empty name should fail");
+        assert!(format!("{err:?}").contains("name must not be empty"));
+    }
+
+    #[test]
+    fn run_handles_missing_ralph_binary() {
+        let (temp, domain, id) = fixture_with_collection();
+        let missing = temp.path().join("definitely-not-here");
+
+        let result = domain.run(
+            CollectionRunParams {
+                id,
+                prompt: "hello".to_string(),
+            },
+            missing.to_str().expect("missing path"),
+            temp.path(),
+        );
+
+        let err = result.expect_err("missing binary should fail");
+        let message = format!("{err:?}");
+        assert!(
+            message.contains("ralph CLI not found"),
+            "error should name the spawn failure; got: {message}"
+        );
+    }
 }

--- a/crates/ralph-api/src/collection_domain/yaml.rs
+++ b/crates/ralph-api/src/collection_domain/yaml.rs
@@ -62,12 +62,7 @@ pub fn starting_hat_for_collection(collection: &CollectionRecord) -> Option<Stri
         .flat_map(|t| t.iter())
         .find(|t| !all_published.contains(t.as_str()))
         .cloned()
-        .or_else(|| {
-            hat_triggers
-                .values()
-                .find_map(|t| t.iter().next())
-                .cloned()
-        })?;
+        .or_else(|| hat_triggers.values().find_map(|t| t.iter().next()).cloned())?;
 
     // Find which hat triggers on the starting_event.
     for (node_id, triggers) in &hat_triggers {
@@ -342,11 +337,7 @@ pub(super) fn export_collection_yaml(collection: &CollectionRecord) -> Result<St
         // Fallback for pure cycles (all triggers are internal): use the
         // first trigger of the first hat. It's internal, but at least it
         // matches a real hat and will activate the cycle.
-        .or_else(|| {
-            hats.values()
-                .find_map(|h| h.triggers.first())
-                .cloned()
-        })
+        .or_else(|| hats.values().find_map(|h| h.triggers.first()).cloned())
         .unwrap_or_else(|| "work.start".to_string());
 
     let preset = ExportPreset {

--- a/crates/ralph-api/src/collection_domain/yaml.rs
+++ b/crates/ralph-api/src/collection_domain/yaml.rs
@@ -8,6 +8,80 @@ use super::{
     CollectionRecord, GraphData, GraphEdge, GraphNode, HatNodeData, NodePosition, Viewport, now_ts,
 };
 
+/// Returns the hat key that will activate first when the collection runs.
+///
+/// Derives the `starting_event` from the graph topology (same logic as the
+/// YAML exporter), then finds which hat triggers on that event. The frontend
+/// uses this to highlight the entry node immediately after Run, avoiding the
+/// timing race between the RPC response and the first WebSocket event.
+pub fn starting_hat_for_collection(collection: &CollectionRecord) -> Option<String> {
+    let graph = &collection.graph;
+
+    // Build triggers and publishes from node data + edges (same as the
+    // YAML exporter: node.data.triggers_on seeds the set, edges add more).
+    let mut hat_triggers: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut hat_publishes: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    for node in &graph.nodes {
+        hat_triggers.insert(
+            node.id.clone(),
+            node.data.triggers_on.iter().cloned().collect(),
+        );
+        hat_publishes.insert(
+            node.id.clone(),
+            node.data.publishes.iter().cloned().collect(),
+        );
+    }
+
+    for edge in &graph.edges {
+        let event_name = edge
+            .label
+            .clone()
+            .or_else(|| edge.source_handle.clone())
+            .unwrap_or_default();
+        if event_name.is_empty() {
+            continue;
+        }
+        if let Some(publishes) = hat_publishes.get_mut(&edge.source) {
+            publishes.insert(event_name.clone());
+        }
+        if let Some(triggers) = hat_triggers.get_mut(&edge.target) {
+            triggers.insert(event_name);
+        }
+    }
+
+    // Collect all published topics.
+    let all_published: std::collections::HashSet<&str> = hat_publishes
+        .values()
+        .flat_map(|s| s.iter().map(String::as_str))
+        .collect();
+
+    // Find the starting_event (first external trigger).
+    let starting_event = hat_triggers
+        .values()
+        .flat_map(|t| t.iter())
+        .find(|t| !all_published.contains(t.as_str()))
+        .cloned()
+        .or_else(|| {
+            hat_triggers
+                .values()
+                .find_map(|t| t.iter().next())
+                .cloned()
+        })?;
+
+    // Find which hat triggers on the starting_event.
+    for (node_id, triggers) in &hat_triggers {
+        if triggers.contains(&starting_event) {
+            // Return the hat key (from node data), not the node id.
+            if let Some(node) = graph.nodes.iter().find(|n| n.id == *node_id) {
+                return Some(node.data.key.clone());
+            }
+        }
+    }
+
+    None
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]
 struct ExportPreset {
@@ -251,10 +325,34 @@ pub(super) fn export_collection_yaml(collection: &CollectionRecord) -> Result<St
         })
         .collect();
 
+    // Derive starting_event from the graph topology: find the first
+    // trigger that no hat publishes (an "external" entry point). This
+    // ensures the starting event actually reaches a hat instead of
+    // falling through to Ralph's coordinator fallback as an orphan.
+    let all_published: std::collections::HashSet<&str> = hats
+        .values()
+        .flat_map(|h| h.publishes.iter().map(String::as_str))
+        .collect();
+
+    let starting_event = hats
+        .values()
+        .flat_map(|h| h.triggers.iter())
+        .find(|t| !all_published.contains(t.as_str()))
+        .cloned()
+        // Fallback for pure cycles (all triggers are internal): use the
+        // first trigger of the first hat. It's internal, but at least it
+        // matches a real hat and will activate the cycle.
+        .or_else(|| {
+            hats.values()
+                .find_map(|h| h.triggers.first())
+                .cloned()
+        })
+        .unwrap_or_else(|| "work.start".to_string());
+
     let preset = ExportPreset {
         event_loop: ExportEventLoop {
             completion_promise: "LOOP_COMPLETE".to_string(),
-            starting_event: "task.start".to_string(),
+            starting_event,
             max_iterations: 50,
         },
         cli: ExportCli {
@@ -303,4 +401,328 @@ fn yaml_string_list(mapping: &serde_yaml::Mapping, key: &str) -> Vec<String> {
 
 fn mapping_get<'a>(mapping: &'a serde_yaml::Mapping, key: &str) -> Option<&'a serde_yaml::Value> {
     mapping.get(serde_yaml::Value::String(key.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_node(id: &str, key: &str, triggers: &[&str], publishes: &[&str]) -> GraphNode {
+        GraphNode {
+            id: id.to_string(),
+            node_type: "hatNode".to_string(),
+            position: NodePosition { x: 0.0, y: 0.0 },
+            data: HatNodeData {
+                key: key.to_string(),
+                name: key.to_string(),
+                description: format!("Test hat {key}"),
+                triggers_on: triggers.iter().map(|s| s.to_string()).collect(),
+                publishes: publishes.iter().map(|s| s.to_string()).collect(),
+                instructions: None,
+            },
+        }
+    }
+
+    fn make_edge(source: &str, target: &str, label: &str) -> GraphEdge {
+        GraphEdge {
+            id: format!("{source}-{target}"),
+            source: source.to_string(),
+            target: target.to_string(),
+            source_handle: Some(label.to_string()),
+            target_handle: Some(label.to_string()),
+            label: Some(label.to_string()),
+        }
+    }
+
+    fn make_collection(nodes: Vec<GraphNode>, edges: Vec<GraphEdge>) -> CollectionRecord {
+        CollectionRecord {
+            id: "test-collection".to_string(),
+            name: "Test".to_string(),
+            description: None,
+            graph: GraphData {
+                nodes,
+                edges,
+                viewport: Viewport {
+                    x: 0.0,
+                    y: 0.0,
+                    zoom: 1.0,
+                },
+            },
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn export_derives_starting_event_from_entry_hat() {
+        // planner triggers on build.start (external) + queue.advance (internal from finalizer)
+        // builder triggers on tasks.ready (internal from planner)
+        // -> starting_event should be build.start
+        let collection = make_collection(
+            vec![
+                make_node(
+                    "p",
+                    "planner",
+                    &["build.start", "queue.advance"],
+                    &["tasks.ready"],
+                ),
+                make_node("b", "builder", &["tasks.ready"], &["review.ready"]),
+                make_node(
+                    "f",
+                    "finalizer",
+                    &["review.ready"],
+                    &["LOOP_COMPLETE", "queue.advance"],
+                ),
+            ],
+            vec![
+                make_edge("p", "b", "tasks.ready"),
+                make_edge("b", "f", "review.ready"),
+                make_edge("f", "p", "queue.advance"),
+            ],
+        );
+
+        let yaml = export_collection_yaml(&collection).unwrap();
+        assert!(
+            yaml.contains("starting_event: build.start"),
+            "expected starting_event: build.start, got:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn export_falls_back_to_first_trigger_when_all_triggers_are_internal() {
+        // Pure cycle: a -> b -> a. All triggers are internal.
+        // Fallback: use the first trigger of the first hat (event.b for hat-a).
+        let collection = make_collection(
+            vec![
+                make_node("a", "hat-a", &["event.b"], &["event.a"]),
+                make_node("b", "hat-b", &["event.a"], &["event.b"]),
+            ],
+            vec![
+                make_edge("a", "b", "event.a"),
+                make_edge("b", "a", "event.b"),
+            ],
+        );
+
+        let yaml = export_collection_yaml(&collection).unwrap();
+        // Should use the first hat's first trigger (event.b) not work.start
+        assert!(
+            yaml.contains("starting_event: event.b"),
+            "expected fallback starting_event: event.b (first hat's first trigger), got:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn export_does_not_use_task_start_when_no_hat_triggers_on_it() {
+        let collection = make_collection(
+            vec![
+                make_node("p", "planner", &["go.start"], &["build.task"]),
+                make_node("b", "builder", &["build.task"], &["LOOP_COMPLETE"]),
+            ],
+            vec![make_edge("p", "b", "build.task")],
+        );
+
+        let yaml = export_collection_yaml(&collection).unwrap();
+        assert!(
+            !yaml.contains("starting_event: task.start"),
+            "should not hardcode task.start when no hat triggers on it, got:\n{yaml}"
+        );
+        assert!(
+            yaml.contains("starting_event: go.start"),
+            "expected starting_event: go.start, got:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn export_empty_collection_produces_valid_yaml() {
+        let collection = make_collection(vec![], vec![]);
+        let yaml = export_collection_yaml(&collection).unwrap();
+        // Should still produce valid YAML with the fallback starting_event.
+        assert!(yaml.contains("starting_event:"));
+        assert!(yaml.contains("completion_promise: LOOP_COMPLETE"));
+        assert!(yaml.contains("hats:"));
+    }
+}
+
+#[cfg(test)]
+mod starting_hat_tests {
+    use super::*;
+
+    fn make_node(id: &str, key: &str, triggers: &[&str], publishes: &[&str]) -> GraphNode {
+        GraphNode {
+            id: id.to_string(),
+            node_type: "hatNode".to_string(),
+            position: NodePosition { x: 0.0, y: 0.0 },
+            data: HatNodeData {
+                key: key.to_string(),
+                name: key.to_string(),
+                description: format!("Test hat {key}"),
+                triggers_on: triggers.iter().map(|s| s.to_string()).collect(),
+                publishes: publishes.iter().map(|s| s.to_string()).collect(),
+                instructions: None,
+            },
+        }
+    }
+
+    fn make_edge(source: &str, target: &str, label: &str) -> GraphEdge {
+        GraphEdge {
+            id: format!("{source}-{target}"),
+            source: source.to_string(),
+            target: target.to_string(),
+            source_handle: Some(label.to_string()),
+            target_handle: Some(label.to_string()),
+            label: Some(label.to_string()),
+        }
+    }
+
+    fn make_collection(nodes: Vec<GraphNode>, edges: Vec<GraphEdge>) -> CollectionRecord {
+        CollectionRecord {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            description: None,
+            graph: GraphData {
+                nodes,
+                edges,
+                viewport: Viewport {
+                    x: 0.0,
+                    y: 0.0,
+                    zoom: 1.0,
+                },
+            },
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn finds_planner_via_node_triggers_not_just_edges() {
+        // planner has triggersOn: ["work.start", "subtask.done"]
+        // "work.start" is external (no hat publishes it)
+        // The function must find planner, not builder.
+        let collection = make_collection(
+            vec![
+                make_node(
+                    "p",
+                    "planner",
+                    &["work.start", "subtask.done"],
+                    &["subtask.ready"],
+                ),
+                make_node(
+                    "b",
+                    "builder",
+                    &["subtask.ready"],
+                    &["subtask.done", "impl.done"],
+                ),
+                make_node("r", "reviewer", &["impl.done"], &["review.approved"]),
+                make_node("f", "finalizer", &["review.approved"], &["LOOP_COMPLETE"]),
+            ],
+            vec![
+                make_edge("p", "b", "subtask.ready"),
+                make_edge("b", "p", "subtask.done"),
+                make_edge("b", "r", "impl.done"),
+                make_edge("r", "f", "review.approved"),
+            ],
+        );
+
+        assert_eq!(
+            starting_hat_for_collection(&collection).as_deref(),
+            Some("planner"),
+            "should find planner via its triggersOn, not just edges"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_collection() {
+        let collection = make_collection(vec![], vec![]);
+        assert_eq!(starting_hat_for_collection(&collection), None);
+    }
+
+    #[test]
+    fn single_hat_returns_its_key() {
+        let collection = make_collection(
+            vec![make_node("n1", "solo-hat", &["kick.off"], &["done"])],
+            vec![],
+        );
+        assert_eq!(
+            starting_hat_for_collection(&collection).as_deref(),
+            Some("solo-hat")
+        );
+    }
+
+    #[test]
+    fn linear_chain_returns_entry_hat() {
+        // A -> B -> C; only A has an external trigger
+        let collection = make_collection(
+            vec![
+                make_node("a", "hat-a", &["external.start"], &["evt.ab"]),
+                make_node("b", "hat-b", &["evt.ab"], &["evt.bc"]),
+                make_node("c", "hat-c", &["evt.bc"], &["done"]),
+            ],
+            vec![make_edge("a", "b", "evt.ab"), make_edge("b", "c", "evt.bc")],
+        );
+        assert_eq!(
+            starting_hat_for_collection(&collection).as_deref(),
+            Some("hat-a")
+        );
+    }
+
+    #[test]
+    fn diamond_fork_returns_entry_hat() {
+        // A -> B and A -> C; A has external trigger
+        let collection = make_collection(
+            vec![
+                make_node("a", "hat-a", &["external.go"], &["fork.b", "fork.c"]),
+                make_node("b", "hat-b", &["fork.b"], &["done.b"]),
+                make_node("c", "hat-c", &["fork.c"], &["done.c"]),
+            ],
+            vec![make_edge("a", "b", "fork.b"), make_edge("a", "c", "fork.c")],
+        );
+        assert_eq!(
+            starting_hat_for_collection(&collection).as_deref(),
+            Some("hat-a")
+        );
+    }
+
+    #[test]
+    fn all_internal_triggers_uses_fallback() {
+        // Pure cycle: every trigger is published by another hat.
+        // Fallback should return the hat whose first trigger is chosen.
+        let collection = make_collection(
+            vec![
+                make_node("a", "hat-a", &["evt.ba"], &["evt.ab"]),
+                make_node("b", "hat-b", &["evt.ab"], &["evt.ba"]),
+            ],
+            vec![make_edge("a", "b", "evt.ab"), make_edge("b", "a", "evt.ba")],
+        );
+        let result = starting_hat_for_collection(&collection);
+        // Fallback picks first trigger of first hat (evt.ba), which hat-a triggers on.
+        assert_eq!(result.as_deref(), Some("hat-a"));
+    }
+
+    #[test]
+    fn hat_with_no_triggers_is_skipped() {
+        // One hat has no triggers, the other has an external trigger.
+        let collection = make_collection(
+            vec![
+                make_node("empty", "no-trigger-hat", &[], &["some.event"]),
+                make_node("real", "real-hat", &["external.evt"], &["done"]),
+            ],
+            vec![],
+        );
+        assert_eq!(
+            starting_hat_for_collection(&collection).as_deref(),
+            Some("real-hat")
+        );
+    }
+
+    #[test]
+    fn returns_key_not_node_id() {
+        // node id and data key differ; function must return the key.
+        let collection = make_collection(
+            vec![make_node("node-1", "my-hat-key", &["kick.off"], &["done"])],
+            vec![],
+        );
+        let result = starting_hat_for_collection(&collection).unwrap();
+        assert_eq!(result, "my-hat-key", "should return data.key, not node id");
+        assert_ne!(result, "node-1");
+    }
 }

--- a/crates/ralph-api/src/event_watcher.rs
+++ b/crates/ralph-api/src/event_watcher.rs
@@ -1,0 +1,303 @@
+//! Polls the active `.ralph/events-*.jsonl` file for new event records and
+//! publishes them to the stream domain as `loop.orchestration` events.
+//!
+//! The watcher runs as an independent tokio task spawned at server startup.
+//! It has no interaction with the RPC mutex or any other shared state beyond
+//! the [`StreamDomain`] publish interface.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use std::{fs, io};
+
+use ralph_core::EventRecord;
+use serde_json::json;
+use tracing::{debug, trace, warn};
+
+use crate::stream_domain::StreamDomain;
+
+/// How often the watcher checks for new lines.
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Spawns the event-file watcher as a background tokio task.
+///
+/// The task runs until the provided `shutdown` future resolves (typically
+/// wired to the server's graceful-shutdown signal).
+pub fn spawn_watcher(
+    workspace_root: PathBuf,
+    streams: StreamDomain,
+    shutdown: tokio::sync::watch::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        run_watcher(workspace_root, streams, shutdown).await;
+    })
+}
+
+async fn run_watcher(
+    workspace_root: PathBuf,
+    streams: StreamDomain,
+    mut shutdown: tokio::sync::watch::Receiver<()>,
+) {
+    let marker_path = workspace_root.join(".ralph/current-events");
+    let mut current_file: Option<PathBuf> = None;
+    let mut offset: u64 = 0;
+
+    debug!(
+        "event watcher started, polling every {}ms",
+        POLL_INTERVAL.as_millis()
+    );
+
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                debug!("event watcher shutting down");
+                return;
+            }
+            _ = tokio::time::sleep(POLL_INTERVAL) => {
+                poll_once(&marker_path, &workspace_root, &streams, &mut current_file, &mut offset);
+            }
+        }
+    }
+}
+
+fn poll_once(
+    marker_path: &Path,
+    workspace_root: &Path,
+    streams: &StreamDomain,
+    current_file: &mut Option<PathBuf>,
+    offset: &mut u64,
+) {
+    // Resolve the active events file from the marker.
+    let active_path = match resolve_active_events_path(marker_path, workspace_root) {
+        Some(path) => path,
+        None => {
+            trace!("no active events file (marker missing or unreadable)");
+            return;
+        }
+    };
+
+    // Detect file switch (new loop started).
+    if current_file.as_ref() != Some(&active_path) {
+        debug!(path = %active_path.display(), "switching to new events file");
+        *current_file = Some(active_path.clone());
+        *offset = 0;
+    }
+
+    // Read new lines from the current offset.
+    let new_lines = match read_new_lines(&active_path, offset) {
+        Ok(lines) => lines,
+        Err(err) => {
+            if err.kind() != io::ErrorKind::NotFound {
+                warn!(error = %err, path = %active_path.display(), "failed reading events file");
+            }
+            return;
+        }
+    };
+
+    for line in new_lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<EventRecord>(&line) {
+            Ok(record) => publish_record(streams, &record),
+            Err(err) => {
+                trace!(error = %err, "skipping unparseable event line");
+            }
+        }
+    }
+}
+
+fn resolve_active_events_path(marker_path: &Path, workspace_root: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(marker_path).ok()?;
+    let relative = content.trim();
+    if relative.is_empty() {
+        return None;
+    }
+    Some(workspace_root.join(relative))
+}
+
+/// Reads all complete lines from `offset` to EOF, advancing `offset`.
+fn read_new_lines(path: &Path, offset: &mut u64) -> io::Result<Vec<String>> {
+    let metadata = fs::metadata(path)?;
+    let file_len = metadata.len();
+
+    // File was recreated or truncated (shouldn't happen with per-run files,
+    // but handle defensively).
+    if file_len < *offset {
+        *offset = 0;
+    }
+
+    if file_len == *offset {
+        return Ok(Vec::new());
+    }
+
+    // Read the new bytes.
+    let content = fs::read_to_string(path)?;
+    let new_content = if (*offset as usize) < content.len() {
+        &content[(*offset as usize)..]
+    } else {
+        ""
+    };
+
+    let mut lines = Vec::new();
+    for line in new_content.lines() {
+        lines.push(line.to_string());
+    }
+
+    *offset = file_len;
+    Ok(lines)
+}
+
+fn publish_record(streams: &StreamDomain, record: &EventRecord) {
+    // Skip internal/meta events that aren't useful for the UI.
+    if record.topic.is_empty() {
+        return;
+    }
+
+    streams.publish(
+        "loop.orchestration",
+        "loop",
+        &record.hat,
+        json!({
+            "iteration": record.iteration,
+            "hat": record.hat,
+            "topic": record.topic,
+            "triggered": record.triggered,
+            "ts": record.ts,
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn write_marker(dir: &Path, events_file: &str) {
+        let marker = dir.join(".ralph/current-events");
+        fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        fs::write(&marker, events_file).unwrap();
+    }
+
+    fn write_event_line(dir: &Path, file: &str, record: &EventRecord) {
+        let path = dir.join(file);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .unwrap();
+        let mut json = serde_json::to_string(record).unwrap();
+        json.push('\n');
+        f.write_all(json.as_bytes()).unwrap();
+    }
+
+    fn sample_record(iteration: u32, hat: &str, topic: &str) -> EventRecord {
+        EventRecord {
+            ts: "2026-04-23T12:00:00Z".to_string(),
+            iteration,
+            hat: hat.to_string(),
+            topic: topic.to_string(),
+            triggered: Some("reviewer".to_string()),
+            payload: String::new(),
+            blocked_count: None,
+            wave_id: None,
+            wave_index: None,
+            wave_total: None,
+        }
+    }
+
+    #[test]
+    fn read_new_lines_returns_appended_content() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("events.jsonl");
+        fs::write(&path, "line1\nline2\n").unwrap();
+
+        let mut offset = 0u64;
+        let lines = read_new_lines(&path, &mut offset).unwrap();
+        assert_eq!(lines, vec!["line1", "line2"]);
+        assert_eq!(offset, 12); // "line1\nline2\n" = 12 bytes
+
+        // Append more
+        let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        f.write_all(b"line3\n").unwrap();
+
+        let lines = read_new_lines(&path, &mut offset).unwrap();
+        assert_eq!(lines, vec!["line3"]);
+    }
+
+    #[test]
+    fn read_new_lines_handles_missing_file() {
+        let mut offset = 0u64;
+        let result = read_new_lines(Path::new("/nonexistent/events.jsonl"), &mut offset);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn resolve_active_events_path_reads_marker() {
+        let tmp = TempDir::new().unwrap();
+        write_marker(tmp.path(), ".ralph/events-20260423.jsonl");
+
+        let result =
+            resolve_active_events_path(&tmp.path().join(".ralph/current-events"), tmp.path());
+        assert_eq!(
+            result,
+            Some(tmp.path().join(".ralph/events-20260423.jsonl"))
+        );
+    }
+
+    #[test]
+    fn resolve_active_events_path_returns_none_when_missing() {
+        let result = resolve_active_events_path(
+            Path::new("/nonexistent/.ralph/current-events"),
+            Path::new("/nonexistent"),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn poll_once_detects_file_switch() {
+        let tmp = TempDir::new().unwrap();
+        let marker_path = tmp.path().join(".ralph/current-events");
+
+        // First file
+        write_marker(tmp.path(), ".ralph/events-a.jsonl");
+        write_event_line(
+            tmp.path(),
+            ".ralph/events-a.jsonl",
+            &sample_record(1, "planner", "build.task"),
+        );
+
+        let streams = StreamDomain::new();
+        let mut current_file: Option<PathBuf> = None;
+        let mut offset = 0u64;
+
+        poll_once(
+            &marker_path,
+            tmp.path(),
+            &streams,
+            &mut current_file,
+            &mut offset,
+        );
+        assert_eq!(current_file, Some(tmp.path().join(".ralph/events-a.jsonl")));
+        assert!(offset > 0);
+
+        // Switch to second file
+        write_marker(tmp.path(), ".ralph/events-b.jsonl");
+        write_event_line(
+            tmp.path(),
+            ".ralph/events-b.jsonl",
+            &sample_record(1, "builder", "build.done"),
+        );
+
+        poll_once(
+            &marker_path,
+            tmp.path(),
+            &streams,
+            &mut current_file,
+            &mut offset,
+        );
+        assert_eq!(current_file, Some(tmp.path().join(".ralph/events-b.jsonl")));
+    }
+}

--- a/crates/ralph-api/src/lib.rs
+++ b/crates/ralph-api/src/lib.rs
@@ -3,6 +3,7 @@ pub mod collection_domain;
 pub mod config;
 pub mod config_domain;
 pub mod errors;
+pub mod event_watcher;
 pub mod idempotency;
 pub mod loop_domain;
 pub mod loop_side_effects;

--- a/crates/ralph-api/src/mcp.rs
+++ b/crates/ralph-api/src/mcp.rs
@@ -582,6 +582,7 @@ fn build_tool(
         "preset.list" => "List all available Ralph presets.".into(),
         "collection.import" => "Import a preset collection from YAML.".into(),
         "collection.export" => "Export a preset collection to YAML.".into(),
+        "collection.run" => "Run a loop using a collection's hats with a given prompt.".into(),
         "stream.subscribe" => "Create a Ralph event stream subscription.".into(),
         "stream.unsubscribe" => "Close a Ralph event stream subscription.".into(),
         "stream.ack" => "Advance a Ralph event stream subscription cursor.".into(),

--- a/crates/ralph-api/src/protocol.rs
+++ b/crates/ralph-api/src/protocol.rs
@@ -56,6 +56,7 @@ pub const KNOWN_METHODS: &[&str] = &[
     "collection.delete",
     "collection.import",
     "collection.export",
+    "collection.run",
     "stream.subscribe",
     "stream.unsubscribe",
     "stream.ack",
@@ -89,6 +90,7 @@ pub const MUTATING_METHODS: &[&str] = &[
     "collection.update",
     "collection.delete",
     "collection.import",
+    "collection.run",
 ];
 
 pub const STREAM_TOPICS: &[&str] = &[
@@ -98,6 +100,7 @@ pub const STREAM_TOPICS: &[&str] = &[
     "task.status.changed",
     "loop.status.changed",
     "loop.merge.progress",
+    "loop.orchestration",
     "planning.prompt.issued",
     "planning.response.recorded",
     "planning.artifact.updated",

--- a/crates/ralph-api/src/runtime/dispatch.rs
+++ b/crates/ralph-api/src/runtime/dispatch.rs
@@ -310,6 +310,16 @@ impl RpcRuntime {
                 let yaml = self.collection_domain_mut()?.export(&params.id)?;
                 Ok(json!({ "yaml": yaml }))
             }
+            "collection.run" => {
+                let params: crate::collection_domain::CollectionRunParams =
+                    self.parse_params(request)?;
+                let result = self.collection_domain_mut()?.run(
+                    params,
+                    &self.config.ralph_command,
+                    &self.config.workspace_root,
+                )?;
+                Ok(json!(result))
+            }
             _ => Err(ApiError::service_unavailable(format!(
                 "method '{}' is recognized but not implemented",
                 request.method

--- a/crates/ralph-api/src/transport.rs
+++ b/crates/ralph-api/src/transport.rs
@@ -85,10 +85,23 @@ where
         .context("failed to read listener local_addr")?;
     info!(%local_addr, "ralph-api listening");
 
+    // Spawn the event-file watcher for live observation in the Builder.
+    let (watcher_shutdown_tx, watcher_shutdown_rx) = tokio::sync::watch::channel(());
+    let _watcher_handle = crate::event_watcher::spawn_watcher(
+        runtime.config.workspace_root.clone(),
+        runtime.stream_domain(),
+        watcher_shutdown_rx,
+    );
+
     axum::serve(listener, router(runtime))
         .with_graceful_shutdown(shutdown)
         .await
-        .context("axum server terminated with error")
+        .context("axum server terminated with error")?;
+
+    // Signal the watcher to stop after the HTTP server shuts down.
+    let _ = watcher_shutdown_tx.send(());
+
+    Ok(())
 }
 
 async fn health_handler(State(state): State<AppState>) -> Json<serde_json::Value> {

--- a/frontend/ralph-web/e2e/builder.spec.ts
+++ b/frontend/ralph-web/e2e/builder.spec.ts
@@ -1,0 +1,653 @@
+/**
+ * Builder page end-to-end tests.
+ *
+ * Covers:
+ *  Collection List: top-level heading and primary actions
+ *  New Collection + Save/Edit: editor opens, dirty flag, save feedback
+ *  Import YAML: dialog open/close, validation, success, error
+ *  Run + Observation Mode: RPC invocation, UI transitions, agent-live
+ *    indicator, edge-fire animation, Stop exits cleanly
+ *  Node/Edge Deletion: Backspace and Delete both remove selected nodes
+ *  Role-Based Visual Identity: palette exposes role templates
+ *  Blueprints: cards render, clicking creates a pre-populated collection
+ *  Run Error Feedback: error banner appears on failure, can be dismissed
+ *
+ * Conventions:
+ *  Tests that need a saved collection use {@link createAndSaveCollection}.
+ *  Tests that need `collection.run` to succeed without a real backend use
+ *    {@link mockCollectionRunSuccess} to intercept the RPC and return a
+ *    canned success payload.
+ *  Observation-state tests drive the exposed `window.__observationStore`
+ *    directly via {@link driveHatActive} / {@link driveHatPending} /
+ *    {@link fireEdgeInStore} instead of mocking the WebSocket. The store
+ *    is only attached in dev builds (see `stores/observationStore.ts`);
+ *    production bundles are unaffected.
+ */
+
+import { expect, test, type Page } from "@playwright/test";
+
+// ─── Timeouts (named so intent is obvious in assertions) ──────────────────
+/** Visible duration of the "Saved" badge before it fades back to idle. */
+const SAVE_FEEDBACK_MS = 5000;
+/** How long the "Saved" status lingers before auto-clearing to idle. */
+const SAVE_STATUS_CLEAR_MS = 3500;
+/** Wait for the collection.run RPC round-trip to settle. */
+const RPC_SETTLE_MS = 2000;
+/** Generic short wait for a dialog or popover to render. */
+const SHORT_WAIT_MS = 3000;
+
+// ─── Reusable helpers ─────────────────────────────────────────────────────
+
+/**
+ * Creates a new collection with the given name and saves it.
+ * Leaves the user on the editor page with the Run button enabled.
+ */
+async function createAndSaveCollection(page: Page, name: string): Promise<void> {
+  await page.getByRole("button", { name: "New Collection" }).click();
+  const nameInput = page.getByPlaceholder("Collection name");
+  await nameInput.clear();
+  await nameInput.fill(name);
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("Saved")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+}
+
+/**
+ * Intercepts all `/rpc/v1` calls and returns a canned success response for
+ * `collection.run`. All other methods fall through to the real API.
+ */
+async function mockCollectionRunSuccess(page: Page): Promise<void> {
+  await page.route("**/rpc/v1", async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.method === "collection.run") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          apiVersion: "v1",
+          id: body.id,
+          method: "collection.run",
+          meta: { servedAt: new Date().toISOString(), servedBy: "mock" },
+          result: { success: true, configPath: "/tmp/mock.yml", pid: 1 },
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+/**
+ * Intercepts `/rpc/v1` and returns a canned failure for `collection.run`.
+ * Used to test the error-banner UI without depending on the local backend
+ * being absent or broken.
+ */
+async function mockCollectionRunFailure(page: Page, message = "ralph run exited with exit code 1:\nbackend not found"): Promise<void> {
+  await page.route("**/rpc/v1", async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.method === "collection.run") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          apiVersion: "v1",
+          id: body.id,
+          method: "collection.run",
+          meta: { servedAt: new Date().toISOString(), servedBy: "mock" },
+          error: { code: "INTERNAL", message, retryable: false },
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+/**
+ * Dispatches a synthetic observation transition into the store.
+ *
+ * The store API is action-based (`setHatActive`, `setHatPending`, etc.);
+ * the hook owns the event→action mapping. Tests call actions directly so
+ * the assertions aren't coupled to Ralph's event shape.
+ */
+async function driveHatActive(page: Page, hatId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const store = (window as unknown as {
+      __observationStore: {
+        getState: () => { setHatActive: (hatId: string) => void };
+      };
+    }).__observationStore;
+    store.getState().setHatActive(id);
+  }, hatId);
+}
+
+async function driveHatPending(page: Page, hatId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const store = (window as unknown as {
+      __observationStore: {
+        getState: () => { setHatPending: (hatId: string) => void };
+      };
+    }).__observationStore;
+    store.getState().setHatPending(id);
+  }, hatId);
+}
+
+/** Fires the given edge id in the observation store (drives pulse animation). */
+async function fireEdgeInStore(page: Page, edgeId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const store = (window as unknown as {
+      __observationStore: { getState: () => { fireEdge: (id: string) => void } };
+    }).__observationStore;
+    store.getState().fireEdge(id);
+  }, edgeId);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+test.describe("Builder Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/builder");
+    await page.waitForLoadState("networkidle");
+  });
+
+  /** Collection list: entry point rendering and primary actions. */
+  test.describe("Collection List", () => {
+    test("shows the Hat Builder heading", async ({ page }) => {
+      await expect(page.getByText("Hat Builder")).toBeVisible();
+    });
+
+    test("shows New Collection and Import YAML buttons", async ({ page }) => {
+      await expect(page.getByRole("button", { name: "New Collection" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Import YAML" })).toBeVisible();
+    });
+  });
+
+  /** New Collection: editor opens with the expected shell elements. */
+  test.describe("New Collection", () => {
+    test("clicking New Collection opens the editor", async ({ page }) => {
+      await page.getByRole("button", { name: "New Collection" }).click();
+
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible();
+      await expect(page.getByText("Hat Palette")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
+    });
+
+    test("Back button returns to list", async ({ page }) => {
+      await page.getByRole("button", { name: "New Collection" }).click();
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible();
+
+      await page.getByRole("button", { name: "Back" }).click();
+      await expect(page.getByText("Hat Builder")).toBeVisible();
+    });
+  });
+
+  /** Save and Edit flow: dirty indicator, success feedback. */
+  test.describe("Save and Edit Flow", () => {
+    test("can save a collection and see Saved feedback", async ({ page }) => {
+      await createAndSaveCollection(page, "Test Collection");
+    });
+
+    test("editing name after save shows Unsaved changes badge", async ({ page }) => {
+      await createAndSaveCollection(page, "Test Collection");
+
+      // Wait for the "Saved" status to auto-clear so it doesn't mask the badge.
+      await page.waitForTimeout(SAVE_STATUS_CLEAR_MS);
+
+      await page.getByPlaceholder("Collection name").fill("Renamed Collection");
+      await expect(page.getByText("Unsaved changes")).toBeVisible();
+    });
+  });
+
+  /** Import YAML dialog: open/close, validation, happy path, error path. */
+  test.describe("Import YAML Dialog", () => {
+    test("opens and closes the import dialog", async ({ page }) => {
+      await page.getByRole("button", { name: "Import YAML" }).click();
+
+      await expect(page.locator("text=Paste a preset YAML")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await expect(page.getByLabel("Name", { exact: true })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Import", exact: true })).toBeVisible();
+
+      await page.getByRole("button", { name: "Cancel" }).click();
+      await expect(page.getByText("Hat Builder")).toBeVisible();
+    });
+
+    test("Import button is disabled without name and YAML", async ({ page }) => {
+      await page.getByRole("button", { name: "Import YAML" }).click();
+      await expect(page.locator("text=Paste a preset YAML")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await expect(page.getByRole("button", { name: "Import", exact: true })).toBeDisabled();
+    });
+
+    test("can import a valid YAML and land in editor", async ({ page }) => {
+      await page.getByRole("button", { name: "Import YAML" }).click();
+      await expect(page.locator("text=Paste a preset YAML")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await page.getByLabel("Name", { exact: true }).fill("Imported Flow");
+      await page.getByLabel("YAML").fill(
+        `hats:
+  planner:
+    name: Planner
+    description: Plans work
+    triggers: [work.start]
+    publishes: [build.task]
+  builder:
+    name: Builder
+    description: Builds things
+    triggers: [build.task]
+    publishes: [build.done]`
+      );
+      await page.getByRole("button", { name: "Import", exact: true }).click();
+
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+    });
+
+    test("shows error for invalid YAML", async ({ page }) => {
+      await page.getByRole("button", { name: "Import YAML" }).click();
+      await expect(page.locator("text=Paste a preset YAML")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await page.getByLabel("Name", { exact: true }).fill("Bad Import");
+      await page.getByLabel("YAML").fill("not: [valid: yaml: [[[");
+      await page.getByRole("button", { name: "Import", exact: true }).click();
+
+      await expect(page.getByRole("alert")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+    });
+  });
+
+  /**
+   * Run + Observation: the critical path. Verifies the RPC is invoked,
+   * observation UI appears, agent-live state and edge animations reflect
+   * store updates, and Stop cleanly exits back to edit mode.
+   */
+  test.describe("Run and Observation Mode", () => {
+    test("Run button is visible and enabled after saving a collection", async ({ page }) => {
+      await createAndSaveCollection(page, "Runnable Collection");
+
+      const runButton = page.getByRole("button", { name: "Run" });
+      await expect(runButton).toBeVisible();
+      await expect(runButton).toBeEnabled();
+    });
+
+    test("Run button is disabled when collection has unsaved changes", async ({ page }) => {
+      await createAndSaveCollection(page, "Dirty Test");
+
+      // Let the "Saved" badge auto-clear before we modify — otherwise the
+      // dirty-flag detection can race with the save-status state.
+      await page.waitForTimeout(SAVE_STATUS_CLEAR_MS);
+
+      await page.getByPlaceholder("Collection name").fill("Dirty Test Modified");
+
+      const runButton = page.getByRole("button", { name: "Run" });
+      await expect(runButton).toBeVisible();
+      await expect(runButton).toBeDisabled();
+    });
+
+    test("clicking Run opens the prompt dialog and invokes collection.run", async ({ page }) => {
+      const rpcMethods: string[] = [];
+      page.on("response", async (response) => {
+        if (!response.url().includes("/rpc/v1")) return;
+        try {
+          const body = await response.json();
+          rpcMethods.push(body.method ?? "unknown");
+        } catch { /* non-JSON response, ignore */ }
+      });
+
+      await createAndSaveCollection(page, "Observable Collection");
+
+      const runButton = page.getByRole("button", { name: "Run" });
+      await expect(runButton).toBeEnabled();
+      await runButton.click();
+
+      await expect(page.getByText("What should")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await expect(page.getByLabel("Prompt")).toBeVisible();
+
+      await page.getByLabel("Prompt").fill("Add input validation");
+      await page.getByRole("button", { name: "Run" }).last().click();
+
+      // Always expect the RPC to be attempted. Backend success or failure is
+      // orthogonal; we just require the call was issued.
+      await expect
+        .poll(() => rpcMethods.includes("collection.run"), {
+          timeout: SAVE_FEEDBACK_MS,
+          message: "expected collection.run RPC to be attempted",
+        })
+        .toBe(true);
+    });
+
+    test("Run success transitions the UI into observation mode", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+      await createAndSaveCollection(page, "Mocked Run Collection");
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("mocked task");
+      await page.getByRole("button", { name: "Run" }).last().click();
+
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await expect(page.getByText("Observing live loop execution")).toBeVisible();
+
+      // Edit-only affordances are hidden during observation.
+      await expect(page.getByRole("button", { name: "Back" })).toHaveCount(0);
+      await expect(page.getByText("Hat Palette")).toHaveCount(0);
+    });
+
+    test("observation overlay shows which agent is live and transitions on events", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+
+      // Load the Code Assist blueprint so we have deterministic hats.
+      await page.locator("text=⚡").first().click();
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("Saved")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("mocked observation");
+      await page.getByRole("button", { name: "Run" }).last().click();
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      // All hats start idle.
+      const nodes = page.locator("[data-hat-key]");
+      await expect(nodes.first()).toBeVisible();
+      const nodeCount = await nodes.count();
+      for (let i = 0; i < nodeCount; i++) {
+        await expect(nodes.nth(i)).toHaveAttribute("data-observation-state", "idle");
+      }
+
+      // First hat-level event equivalent: planner is emitting (active),
+      // builder is its downstream trigger (pending).
+      await driveHatActive(page, "planner");
+      await driveHatPending(page, "builder");
+
+      await expect(page.locator('[data-hat-key="planner"]'))
+        .toHaveAttribute("data-observation-state", "active", { timeout: RPC_SETTLE_MS });
+      await expect(page.locator('[data-hat-key="builder"]'))
+        .toHaveAttribute("data-observation-state", "pending");
+
+      // Second transition: builder takes over (previous active → completed),
+      // reviewer becomes pending.
+      await driveHatActive(page, "builder");
+      await driveHatPending(page, "reviewer");
+
+      await expect(page.locator('[data-hat-key="planner"]'))
+        .toHaveAttribute("data-observation-state", "completed");
+      await expect(page.locator('[data-hat-key="builder"]'))
+        .toHaveAttribute("data-observation-state", "active");
+      await expect(page.locator('[data-hat-key="reviewer"]'))
+        .toHaveAttribute("data-observation-state", "pending");
+    });
+
+    test("edge fire attribute toggles via store during observation", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+
+      await page.locator("text=⚡").first().click();
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("Saved")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("mocked fire");
+      await page.getByRole("button", { name: "Run" }).last().click();
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      // Edges only get data-edge-id once the auto-layout has run.
+      const firstEdge = page.locator("[data-edge-id]").first();
+      await expect(firstEdge).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      const firstEdgeId = await firstEdge.getAttribute("data-edge-id");
+      expect(firstEdgeId).toBeTruthy();
+
+      await expect(firstEdge).toHaveAttribute("data-fired", "false");
+
+      await fireEdgeInStore(page, firstEdgeId!);
+
+      await expect(page.locator(`[data-edge-id="${firstEdgeId}"]`))
+        .toHaveAttribute("data-fired", "true", { timeout: 1000 });
+    });
+
+    test("Stop exits observation mode and restores edit affordances", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+      await createAndSaveCollection(page, "Stoppable Collection");
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("mocked task");
+      await page.getByRole("button", { name: "Run" }).last().click();
+
+      const stopButton = page.getByRole("button", { name: "Stop" });
+      await expect(stopButton).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await stopButton.click();
+
+      await expect(page.getByRole("button", { name: "Run" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await expect(page.getByRole("button", { name: "Back" })).toBeVisible();
+      await expect(page.getByText("Hat Palette")).toBeVisible();
+    });
+
+    test("Properties panel is hidden during observation", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+      await createAndSaveCollection(page, "Properties Hidden Test");
+
+      // Before running: properties panel visible on the right.
+      await expect(page.getByText("Properties", { exact: true })).toBeVisible();
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("mocked task");
+      await page.getByRole("button", { name: "Run" }).last().click();
+
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      // During observation: properties panel is hidden.
+      await expect(page.getByText("Properties", { exact: true })).toHaveCount(0);
+
+      // Stop brings the properties panel back.
+      await page.getByRole("button", { name: "Stop" }).click();
+      await expect(page.getByText("Properties", { exact: true })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+    });
+
+    test("completeAll terminal transition marks every node completed", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+
+      await page.locator("text=⚡").first().click();
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("Saved")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("mocked terminal");
+      await page.getByRole("button", { name: "Run" }).last().click();
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      // Seed with a couple of hat states so completeAll has something to transition.
+      await driveHatActive(page, "planner");
+      await driveHatPending(page, "builder");
+
+      // Trigger the terminal transition via the store.
+      await page.evaluate(() => {
+        const store = (window as unknown as {
+          __observationStore: { getState: () => { completeAll: () => void } };
+        }).__observationStore;
+        store.getState().completeAll();
+      });
+
+      // Both touched nodes end up completed. (completeAll leaves nodes
+      // that were never seen in their default "idle" — only nodes that
+      // already appeared in nodeStates are marked completed.)
+      await expect(page.locator('[data-hat-key="planner"]'))
+        .toHaveAttribute("data-observation-state", "completed", { timeout: RPC_SETTLE_MS });
+      await expect(page.locator('[data-hat-key="builder"]'))
+        .toHaveAttribute("data-observation-state", "completed");
+    });
+
+    test("full 4-hat chain: every node transitions idle -> active -> completed in order", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+
+      // Load the Code Assist blueprint (4 hats: planner, builder, reviewer, finalizer).
+      await page.locator("text=⚡").first().click();
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await page.getByRole("button", { name: "Save" }).click();
+      await expect(page.getByText("Saved")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      // Enter observation mode.
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("full chain test");
+      await page.getByRole("button", { name: "Run" }).last().click();
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      // All nodes start idle.
+      for (const hat of ["planner", "builder", "reviewer", "finalizer"]) {
+        await expect(page.locator(`[data-hat-key="${hat}"]`))
+          .toHaveAttribute("data-observation-state", "idle");
+      }
+
+      // Step 1: planner active.
+      await driveHatActive(page, "planner");
+      await expect(page.locator('[data-hat-key="planner"]'))
+        .toHaveAttribute("data-observation-state", "active", { timeout: RPC_SETTLE_MS });
+
+      // Step 2: builder active, planner completed.
+      await driveHatActive(page, "builder");
+      await expect(page.locator('[data-hat-key="planner"]'))
+        .toHaveAttribute("data-observation-state", "completed");
+      await expect(page.locator('[data-hat-key="builder"]'))
+        .toHaveAttribute("data-observation-state", "active");
+
+      // Step 3: reviewer active, builder completed.
+      await driveHatActive(page, "reviewer");
+      await expect(page.locator('[data-hat-key="builder"]'))
+        .toHaveAttribute("data-observation-state", "completed");
+      await expect(page.locator('[data-hat-key="reviewer"]'))
+        .toHaveAttribute("data-observation-state", "active");
+
+      // Step 4: finalizer active, reviewer completed.
+      await driveHatActive(page, "finalizer");
+      await expect(page.locator('[data-hat-key="reviewer"]'))
+        .toHaveAttribute("data-observation-state", "completed");
+      await expect(page.locator('[data-hat-key="finalizer"]'))
+        .toHaveAttribute("data-observation-state", "active");
+
+      // Terminal: all completed.
+      await page.evaluate(() => {
+        const store = (window as unknown as {
+          __observationStore: { getState: () => { completeAll: () => void } };
+        }).__observationStore;
+        store.getState().completeAll();
+      });
+
+      for (const hat of ["planner", "builder", "reviewer", "finalizer"]) {
+        await expect(page.locator(`[data-hat-key="${hat}"]`))
+          .toHaveAttribute("data-observation-state", "completed", { timeout: RPC_SETTLE_MS });
+      }
+    });
+
+    test("observation legend is visible with colored dots during observation", async ({ page }) => {
+      await mockCollectionRunSuccess(page);
+      await createAndSaveCollection(page, "Legend Test");
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("legend check");
+      await page.getByRole("button", { name: "Run" }).last().click();
+      await expect(page.getByRole("button", { name: "Stop" })).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      // Legend should show three labeled states.
+      await expect(page.getByText("pending")).toBeVisible();
+      await expect(page.getByText("active")).toBeVisible();
+      await expect(page.getByText("done")).toBeVisible();
+    });
+  });
+
+  /**
+   * Edge and Node Deletion: Backspace and Delete are both supported (Mac
+   * keyboards often don't have a standalone Delete key).
+   */
+  test.describe("Edge and Node Deletion", () => {
+    for (const key of ["Backspace", "Delete"] as const) {
+      test(`${key} removes a selected node`, async ({ page }) => {
+        // Load a blueprint so the canvas has nodes without drag-drop.
+        await page.locator("text=⚡").first().click();
+        await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+        const nodes = page.locator("[data-hat-key]");
+        await expect(nodes.first()).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+        const initialCount = await nodes.count();
+        expect(initialCount).toBeGreaterThan(0);
+
+        await nodes.first().click();
+        await page.keyboard.press(key);
+
+        await expect(nodes).toHaveCount(initialCount - 1, { timeout: SHORT_WAIT_MS });
+      });
+    }
+  });
+
+  /** Role-Based Visual Identity: palette exposes the role templates. */
+  test.describe("Role-Based Visual Identity", () => {
+    test("palette shows hat templates with role names", async ({ page }) => {
+      await page.getByRole("button", { name: "New Collection" }).click();
+
+      await expect(page.getByText("Planner").first()).toBeVisible();
+      await expect(page.getByText("Builder").first()).toBeVisible();
+      await expect(page.getByText("Reviewer").first()).toBeVisible();
+      await expect(page.getByText("Validator").first()).toBeVisible();
+      await expect(page.getByText("Confessor").first()).toBeVisible();
+      await expect(page.getByText("Custom Hat").first()).toBeVisible();
+    });
+  });
+
+  /** Blueprints: cards render on list page and materialize into collections. */
+  test.describe("Blueprints", () => {
+    test("shows blueprint template cards on the list page", async ({ page }) => {
+      await expect(page.getByText("Start from a blueprint")).toBeVisible();
+      // Use exact match because user-written collection descriptions may
+      // contain strings like "4 hats" and shadow the blueprint badges.
+      await expect(page.getByText("4 hats", { exact: true })).toBeVisible();
+      await expect(page.getByText("3 hats", { exact: true })).toBeVisible();
+      await expect(page.getByText("2 hats", { exact: true })).toBeVisible();
+    });
+
+    test("clicking the Debug blueprint creates a collection with 3 hats", async ({ page }) => {
+      await page.locator("text=🔍").first().click();
+      await expect(page.getByPlaceholder("Collection name")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      const nodes = page.locator("[data-hat-key]");
+      await expect(nodes.first()).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await expect(nodes).toHaveCount(3);
+    });
+  });
+
+  /** Run Error Feedback: failure surfaces a dismissable banner. */
+  test.describe("Run Error Feedback", () => {
+    test("shows error banner when collection.run fails", async ({ page }) => {
+      await mockCollectionRunFailure(page);
+      await createAndSaveCollection(page, "Error Test");
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: SHORT_WAIT_MS });
+      await page.getByLabel("Prompt").fill("Test prompt");
+      await page.getByRole("button", { name: "Run" }).last().click();
+
+      // Error banner shows ralph's own stderr. We anchor on the Dismiss
+      // affordance since the exact message depends on the mock payload.
+      await expect(page.getByText("Dismiss")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+
+      await page.getByText("Dismiss").click();
+      await expect(page.getByText("Dismiss")).not.toBeVisible();
+    });
+
+    test("Run button remains enabled after error dismissal", async ({ page }) => {
+      await mockCollectionRunFailure(page);
+      await createAndSaveCollection(page, "Retry Test");
+
+      await page.getByRole("button", { name: "Run" }).click();
+      await page.getByLabel("Prompt").fill("Test");
+      await page.getByRole("button", { name: "Run" }).last().click();
+
+      await expect(page.getByText("Dismiss")).toBeVisible({ timeout: SAVE_FEEDBACK_MS });
+      await page.getByText("Dismiss").click();
+
+      await expect(page.getByRole("button", { name: "Run" })).toBeEnabled();
+    });
+  });
+});

--- a/frontend/ralph-web/src/components/builder/CollectionBuilder.tsx
+++ b/frontend/ralph-web/src/components/builder/CollectionBuilder.tsx
@@ -12,37 +12,42 @@
  * This is the n8n-style builder the user requested.
  */
 
-import { useCallback, useState, useRef, DragEvent, useMemo } from "react";
 import {
-  ReactFlow,
-  ReactFlowProvider,
-  Controls,
-  Background,
-  MiniMap,
-  addEdge,
-  applyNodeChanges,
-  applyEdgeChanges,
-  type Node,
-  type Edge,
-  type EdgeTypes,
-  type OnNodesChange,
-  type OnEdgesChange,
-  type OnConnect,
-  type NodeTypes,
-  BackgroundVariant,
+    Background,
+    BackgroundVariant,
+    Controls,
+    MiniMap,
+    ReactFlow,
+    ReactFlowProvider,
+    addEdge,
+    applyEdgeChanges,
+    applyNodeChanges,
+    type Edge,
+    type EdgeTypes,
+    type Node,
+    type NodeTypes,
+    type OnConnect,
+    type OnEdgesChange,
+    type OnNodesChange,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { DragEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { HatNode, type HatNodeData } from "./HatNode";
-import { RerouteNode } from "./RerouteNode";
-import { OffsetEdge } from "./OffsetEdge";
-import { HatPalette } from "./HatPalette";
-import { PropertiesPanel } from "./PropertiesPanel";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useLoopObservation } from "@/hooks/useLoopObservation";
 import { cn } from "@/lib/utils";
-import { Save, Download } from "lucide-react";
+import { useObservationStore } from "@/stores/observationStore";
+import { AlertCircle, CheckCircle2, Download, Save } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
+import { HatNode, type HatNodeData } from "./HatNode";
+import { HatPalette } from "./HatPalette";
+import { autoLayout, needsLayout } from "./layout";
+import { OffsetEdge } from "./OffsetEdge";
+import { PropertiesPanel } from "./PropertiesPanel";
+import { RerouteNode } from "./RerouteNode";
+import { getRoleMeta } from "./roles";
 
 /** Custom node types for React Flow - using 'any' to work around strict React Flow types */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,6 +59,29 @@ const nodeTypes: NodeTypes = {
 const edgeTypes: EdgeTypes = {
   offset: OffsetEdge,
 };
+
+/**
+ * Inline legend shown in the observation toolbar. Explains what each
+ * node-ring color means so the user doesn't have to guess.
+ */
+function ObservationLegend() {
+  return (
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block w-3 h-3 rounded border-2 border-sky-400 bg-transparent" aria-hidden />
+        pending
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block w-3 h-3 rounded border-2 border-red-500 bg-transparent animate-border-pulse" aria-hidden />
+        active
+      </span>
+      <span className="flex items-center gap-1.5">
+        <span className="inline-block w-3 h-3 rounded border-2 border-teal-400 bg-transparent" aria-hidden />
+        done ✓
+      </span>
+    </div>
+  );
+}
 
 interface CollectionBuilderProps {
   /** Collection ID (null for new collection) */
@@ -76,6 +104,14 @@ interface CollectionBuilderProps {
   onDescriptionChange: (description: string) => void;
   /** Whether save is in progress */
   isSaving?: boolean;
+  /** Parent-owned dirty flag. Controls Badge + beforeunload. */
+  isDirty?: boolean;
+  /** Called whenever an internal change occurs so the parent can flip isDirty. */
+  onMarkDirty?: () => void;
+  /** Post-save feedback driven by the parent's mutation result. */
+  saveStatus?: "idle" | "success" | "error";
+  /** True when the collection was just imported — triggers auto-layout on mount. */
+  justImported?: boolean;
   /** Optional className */
   className?: string;
 }
@@ -92,12 +128,47 @@ function CollectionBuilderInner({
   onNameChange,
   onDescriptionChange,
   isSaving,
+  isDirty,
+  onMarkDirty,
+  saveStatus,
+  justImported,
   className,
 }: CollectionBuilderProps) {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
-  const [nodes, setNodes] = useState<Node[]>(initialData?.nodes ?? []);
+  // On mount, auto-layout freshly imported collections so the user lands on a
+  // sensible graph instead of the Rust importer's stacked column. Uses lazy
+  // initial state so autoLayout only runs once (useState initialiser semantics).
+  const [initialNodes] = useState<Node[]>(() => {
+    const raw = initialData?.nodes ?? [];
+    if (justImported && needsLayout(raw)) {
+      return autoLayout(raw, initialData?.edges ?? []);
+    }
+    return raw;
+  });
+  const [nodes, setNodes] = useState<Node[]>(initialNodes);
   const [edges, setEdges] = useState<Edge[]>(initialData?.edges ?? []);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  // If auto-layout ran, the rendered graph differs from the persisted one —
+  // mark dirty so the user saves the nicer positions.
+  useEffect(() => {
+    if (justImported && initialData && needsLayout(initialData.nodes)) {
+      onMarkDirty?.();
+    }
+    // Intentionally only on mount: subsequent re-renders should not re-fire.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Browser-level guard for tab close / reload while there are unsaved changes.
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
 
   // Get selected node with data (only hat nodes have editable properties)
   const selectedNode = useMemo(() => {
@@ -115,14 +186,29 @@ function CollectionBuilderInner({
     for (const change of changes) {
       if (change.type === "select") {
         setSelectedNodeId(change.selected ? change.id : null);
+      } else if (change.type === "position" || change.type === "add" || change.type === "remove") {
+        onMarkDirty?.();
       }
     }
-  }, []);
+  }, [onMarkDirty]);
 
   // Handle edge changes
   const onEdgesChange: OnEdgesChange = useCallback((changes) => {
     setEdges((eds) => applyEdgeChanges(changes, eds));
-  }, []);
+    for (const change of changes) {
+      if (change.type === "add" || change.type === "remove") {
+        onMarkDirty?.();
+      }
+    }
+  }, [onMarkDirty]);
+
+  // Keyboard-driven node deletion removes the node via onNodesChange but
+  // leaves connected edges orphaned — clean them up here.
+  const handleNodesDelete = useCallback((deleted: Node[]) => {
+    const ids = new Set(deleted.map((n) => n.id));
+    setEdges((eds) => eds.filter((e) => !ids.has(e.source) && !ids.has(e.target)));
+    onMarkDirty?.();
+  }, [onMarkDirty]);
 
   // Trace back through reroute nodes to find the original event name
   const resolveEventLabel = useCallback(
@@ -157,8 +243,9 @@ function CollectionBuilderInner({
         type: "offset",
       };
       setEdges((eds) => addEdge(newEdge, eds));
+      onMarkDirty?.();
     },
-    [nodes, edges, resolveEventLabel]
+    [nodes, edges, resolveEventLabel, onMarkDirty]
   );
 
   // Handle drop from palette
@@ -180,6 +267,7 @@ function CollectionBuilderInner({
           ...nds,
           { id: nodeId, type: "reroute", position, data: {} },
         ]);
+        onMarkDirty?.();
         return;
       }
 
@@ -208,8 +296,9 @@ function CollectionBuilderInner({
 
       setNodes((nds) => [...nds, newNode]);
       setSelectedNodeId(nodeId);
+      onMarkDirty?.();
     },
-    []
+    [onMarkDirty]
   );
 
   const onDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
@@ -217,7 +306,8 @@ function CollectionBuilderInner({
     event.dataTransfer.dropEffect = "move";
   }, []);
 
-  // Update node data from properties panel
+  // Update node data from properties panel. When publishes/triggersOn change,
+  // remove any edges that reference handles the node no longer exposes.
   const handleUpdateNode = useCallback((nodeId: string, data: Partial<HatNodeData>) => {
     setNodes((nds) =>
       nds.map((node) => {
@@ -230,14 +320,75 @@ function CollectionBuilderInner({
         return node;
       })
     );
-  }, []);
+
+    if (data.publishes !== undefined) {
+      const pubs = new Set(data.publishes);
+      setEdges((eds) => {
+        const before = eds.length;
+        const filtered = eds.filter(
+          (e) => !(e.source === nodeId && e.sourceHandle && !pubs.has(e.sourceHandle))
+        );
+        const removed = before - filtered.length;
+        if (removed > 0) console.info(`Removed ${removed} invalid edge(s)`);
+        return filtered;
+      });
+    }
+
+    if (data.triggersOn !== undefined) {
+      const trigs = new Set(data.triggersOn);
+      setEdges((eds) => {
+        const before = eds.length;
+        const filtered = eds.filter(
+          (e) => !(e.target === nodeId && e.targetHandle && !trigs.has(e.targetHandle))
+        );
+        const removed = before - filtered.length;
+        if (removed > 0) console.info(`Removed ${removed} invalid edge(s)`);
+        return filtered;
+      });
+    }
+
+    onMarkDirty?.();
+  }, [onMarkDirty]);
 
   // Delete node
   const handleDeleteNode = useCallback((nodeId: string) => {
     setNodes((nds) => nds.filter((n) => n.id !== nodeId));
     setEdges((eds) => eds.filter((e) => e.source !== nodeId && e.target !== nodeId));
     setSelectedNodeId(null);
-  }, []);
+    onMarkDirty?.();
+  }, [onMarkDirty]);
+
+  // ── Live observation overlay ──────────────────────────────────────────
+  const observing = useObservationStore((s) => s.active);
+  const obsNodeStates = useObservationStore((s) => s.nodeStates);
+  const lastFiredEdgeId = useObservationStore((s) => s.lastFiredEdgeId);
+  const obsIteration = useObservationStore((s) => s.iteration);
+  const obsActiveHat = useObservationStore((s) => s.activeHatId);
+
+  // Subscribe to loop.orchestration events when observing.
+  useLoopObservation(edges);
+
+  // Overlay observation state onto nodes for rendering.
+  const displayNodes = useMemo(() => {
+    if (!observing) return nodes;
+    return nodes.map((node) => {
+      const obsState = obsNodeStates[node.id];
+      if (!obsState || obsState === "idle") return node;
+      return {
+        ...node,
+        data: { ...node.data, observationState: obsState },
+      };
+    });
+  }, [nodes, observing, obsNodeStates]);
+
+  // Overlay fired state onto edges for rendering.
+  const displayEdges = useMemo(() => {
+    if (!observing || !lastFiredEdgeId) return edges;
+    return edges.map((edge) => {
+      if (edge.id !== lastFiredEdgeId) return edge;
+      return { ...edge, data: { ...edge.data, fired: true } };
+    });
+  }, [edges, observing, lastFiredEdgeId]);
 
   // Save handler
   const handleSave = useCallback(() => {
@@ -247,46 +398,87 @@ function CollectionBuilderInner({
   return (
     <div className={cn("flex flex-col h-full", className)}>
       {/* Toolbar */}
-      <div className="flex items-center gap-3 p-3 border-b bg-background">
-        <Input
-          value={name}
-          onChange={(e) => onNameChange(e.target.value)}
-          placeholder="Collection name"
-          className="w-48 h-8"
-        />
-        <Input
-          value={description}
-          onChange={(e) => onDescriptionChange(e.target.value)}
-          placeholder="Description"
-          className="flex-1 h-8"
-        />
+      <div className="flex items-center gap-3 p-3 border-b bg-background flex-wrap">
+        {observing ? (
+          <>
+            <Badge variant="secondary" className="bg-indigo-500/10 text-indigo-400 border-indigo-500/30">
+              ● Observing
+            </Badge>
+            <span className="text-sm text-muted-foreground">
+              Iteration <span className="font-mono font-bold text-foreground">{obsIteration}</span>
+            </span>
+            {obsActiveHat && obsActiveHat !== "loop" && (
+              <Badge variant="outline" className="text-indigo-400 border-indigo-400/40">
+                {getRoleMeta(obsActiveHat).emoji} {obsActiveHat}
+              </Badge>
+            )}
+            <div className="flex-1" />
+            <ObservationLegend />
+          </>
+        ) : (
+          <>
+            <Input
+              value={name}
+              onChange={(e) => onNameChange(e.target.value)}
+              placeholder="Collection name"
+              className="w-48 h-8"
+            />
+            <Input
+              value={description}
+              onChange={(e) => onDescriptionChange(e.target.value)}
+              placeholder="Description"
+              className="flex-1 h-8"
+            />
+          </>
+        )}
         <div className="flex items-center gap-2">
-          {onExportYaml && (
+          {!observing && isDirty && (
+            <Badge variant="outline" className="text-yellow-600 border-yellow-600">
+              Unsaved changes
+            </Badge>
+          )}
+          {!observing && saveStatus === "success" && (
+            <span className="flex items-center gap-1 text-sm text-green-600">
+              <CheckCircle2 className="h-4 w-4" />
+              Saved
+            </span>
+          )}
+          {!observing && saveStatus === "error" && (
+            <span className="flex items-center gap-1 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              Error saving
+            </span>
+          )}
+          {!observing && onExportYaml && (
             <Button variant="outline" size="sm" onClick={onExportYaml}>
               <Download className="h-4 w-4 mr-2" />
               Export YAML
             </Button>
           )}
-          <Button size="sm" onClick={handleSave} disabled={isSaving || !name.trim()}>
-            <Save className="h-4 w-4 mr-2" />
-            {isSaving ? "Saving..." : "Save"}
-          </Button>
+          {!observing && (
+            <Button size="sm" onClick={handleSave} disabled={isSaving || !name.trim()}>
+              <Save className="h-4 w-4 mr-2" />
+              {isSaving ? "Saving..." : "Save"}
+            </Button>
+          )}
         </div>
       </div>
 
       {/* Main content area */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left sidebar - Hat palette */}
-        <HatPalette />
+        {/* Left sidebar - Hat palette (hidden during observation) */}
+        {!observing && <HatPalette />}
 
         {/* Canvas */}
-        <div ref={reactFlowWrapper} className="flex-1" onDrop={onDrop} onDragOver={onDragOver}>
+        <div ref={reactFlowWrapper} className="flex-1" onDrop={observing ? undefined : onDrop} onDragOver={observing ? undefined : onDragOver}>
           <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={onConnect}
+            nodes={displayNodes}
+            edges={displayEdges}
+            onNodesChange={observing ? undefined : onNodesChange}
+            onEdgesChange={observing ? undefined : onEdgesChange}
+            onConnect={observing ? undefined : onConnect}
+            onNodesDelete={observing ? undefined : handleNodesDelete}
+            deleteKeyCode={observing ? [] : ["Backspace", "Delete"]}
             nodeTypes={nodeTypes}
             fitView
             minZoom={0.1}
@@ -306,15 +498,7 @@ function CollectionBuilderInner({
               position="bottom-right"
               nodeColor={(node) => {
                 const key = (node.data as unknown as HatNodeData)?.key ?? "";
-                const prefix = key.split("-")[0];
-                const colors: Record<string, string> = {
-                  planner: "#8b5cf6",
-                  builder: "#3b82f6",
-                  reviewer: "#22c55e",
-                  validator: "#f59e0b",
-                  confessor: "#ef4444",
-                };
-                return colors[prefix] ?? "#6b7280";
+                return getRoleMeta(key).color;
               }}
               maskColor="rgba(0, 0, 0, 0.1)"
               className="!bg-background/80"
@@ -322,12 +506,14 @@ function CollectionBuilderInner({
           </ReactFlow>
         </div>
 
-        {/* Right sidebar - Properties panel */}
-        <PropertiesPanel
-          selectedNode={selectedNode}
-          onUpdateNode={handleUpdateNode}
-          onDeleteNode={handleDeleteNode}
-        />
+        {/* Right sidebar - Properties panel (hidden during observation) */}
+        {!observing && (
+          <PropertiesPanel
+            selectedNode={selectedNode}
+            onUpdateNode={handleUpdateNode}
+            onDeleteNode={handleDeleteNode}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/ralph-web/src/components/builder/HatNode.tsx
+++ b/frontend/ralph-web/src/components/builder/HatNode.tsx
@@ -13,9 +13,10 @@
  * - Compact layout optimized for workflow canvas
  */
 
-import { memo } from "react";
-import { Handle, Position } from "@xyflow/react";
 import { cn } from "@/lib/utils";
+import { Handle, Position } from "@xyflow/react";
+import { memo } from "react";
+import { getRoleMeta } from "./roles";
 
 /**
  * Data structure for a hat node
@@ -27,6 +28,8 @@ export interface HatNodeData {
   triggersOn: string[];
   publishes: string[];
   instructions?: string;
+  /** Observation state set by the live observation overlay. */
+  observationState?: "idle" | "pending" | "active" | "completed";
 }
 
 /**
@@ -37,22 +40,40 @@ interface HatNodeProps {
   selected?: boolean;
 }
 
+const OBSERVATION_BORDER: Record<string, string> = {
+  pending: "!border-sky-400 !border-2",
+  active: "!border-2 animate-border-pulse",
+  completed: "!border-teal-400 !border-2",
+};
+
 /**
  * HatNode - visual representation of a hat in the workflow
  */
 function HatNodeComponent({ data, selected }: HatNodeProps) {
   const hatData = data;
+  const role = getRoleMeta(hatData.key);
+  const obsState = hatData.observationState;
+  const obsBorder = obsState ? OBSERVATION_BORDER[obsState] : undefined;
 
   return (
     <div
+      data-hat-key={hatData.key}
+      data-observation-state={obsState ?? "idle"}
       className={cn(
         "bg-card border rounded-lg shadow-md min-w-[180px] max-w-[280px]",
-        "transition-all duration-200",
+        "transition-all duration-200 relative",
         selected
           ? "border-primary ring-2 ring-primary/30 shadow-lg"
-          : "border-border hover:border-muted-foreground/50"
+          : cn("hover:border-muted-foreground/50", role.borderClass || "border-border"),
+        obsBorder
       )}
     >
+      {/* Completed badge */}
+      {obsState === "completed" && (
+        <span className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-teal-500 text-white text-xs flex items-center justify-center font-bold shadow">
+          ✓
+        </span>
+      )}
       {/* Input handles (triggers) - placed on left side */}
       <div className="absolute -left-[9px] top-0 h-full flex flex-col justify-center gap-2 py-3">
         {hatData.triggersOn.map((trigger, index) => (
@@ -90,7 +111,7 @@ function HatNodeComponent({ data, selected }: HatNodeProps) {
       <div className="p-3">
         {/* Header with name */}
         <div className="flex items-center gap-2 mb-1">
-          <span className="text-lg">🎩</span>
+          <span className="text-lg">{role.emoji}</span>
           <h3 className="font-semibold text-sm truncate">{hatData.name}</h3>
         </div>
 

--- a/frontend/ralph-web/src/components/builder/ImportYamlDialog.tsx
+++ b/frontend/ralph-web/src/components/builder/ImportYamlDialog.tsx
@@ -1,0 +1,192 @@
+/**
+ * ImportYamlDialog
+ *
+ * Modal for importing a preset YAML as a new collection. Accepts either a
+ * file upload or pasted YAML text, plus a required name and optional
+ * description. Delegates parsing to the backend via collection.import RPC.
+ * On success, calls onImported with the created collection.
+ *
+ * Follows the inline-modal pattern from PlanSession (fixed overlay + Card)
+ * so no new dependency is introduced for a dialog primitive.
+ */
+
+import { Button } from "@/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { trpc } from "@/trpc";
+import { AlertCircle, Upload, X } from "lucide-react";
+import { useCallback, useRef, useState, type ChangeEvent } from "react";
+
+interface ImportYamlDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called with the created collection record after a successful import. */
+  onImported: (collection: { id: string; name: string }) => void;
+}
+
+export function ImportYamlDialog({ open, onClose, onImported }: ImportYamlDialogProps) {
+  const [yaml, setYaml] = useState("");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [fileError, setFileError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const importMutation = trpc.collection.importYaml.useMutation({
+    onSuccess: (collection: { id: string; name: string }) => {
+      onImported(collection);
+      // Reset local state after propagation so re-opening the dialog starts clean.
+      setYaml("");
+      setName("");
+      setDescription("");
+      setFileError(null);
+    },
+  });
+
+  const handleFile = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setFileError(null);
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        setFileError("Selected file could not be read as text.");
+        return;
+      }
+      setYaml(result);
+      // Seed name from filename if the user hasn't entered one yet.
+      if (!name.trim()) {
+        const base = file.name.replace(/\.(ya?ml)$/i, "");
+        if (base) setName(base);
+      }
+    };
+    reader.onerror = () => {
+      setFileError(reader.error?.message ?? "Failed to read file.");
+    };
+    reader.readAsText(file);
+  }, [name]);
+
+  const handleImport = useCallback(() => {
+    const trimmedYaml = yaml.trim();
+    const trimmedName = name.trim();
+    if (!trimmedYaml || !trimmedName) return;
+    importMutation.mutate({
+      yaml: trimmedYaml,
+      name: trimmedName,
+      description: description.trim() || undefined,
+    });
+  }, [yaml, name, description, importMutation]);
+
+  if (!open) return null;
+
+  const canImport =
+    yaml.trim().length > 0 && name.trim().length > 0 && !importMutation.isPending;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <Card
+        className="w-full max-w-2xl max-h-[90vh] flex flex-col"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <CardHeader className="flex-shrink-0 flex flex-row items-center justify-between space-y-0 pb-2">
+          <div>
+            <CardTitle>Import YAML</CardTitle>
+            <CardDescription>
+              Paste a preset YAML or upload a file to create a new collection.
+            </CardDescription>
+          </div>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+            <X className="h-4 w-4" />
+          </Button>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-y-auto space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="import-name">Name</Label>
+            <Input
+              id="import-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Collection name"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="import-description">Description (optional)</Label>
+            <Input
+              id="import-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="What is this collection for?"
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="import-yaml">YAML</Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="h-4 w-4 mr-2" />
+                Upload file
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".yml,.yaml,text/yaml,application/x-yaml"
+                className="hidden"
+                onChange={handleFile}
+              />
+            </div>
+            <Textarea
+              id="import-yaml"
+              value={yaml}
+              onChange={(event) => setYaml(event.target.value)}
+              placeholder={"hats:\n  planner:\n    name: Planner\n    triggers: [work.start]\n    publishes: [build.task]"}
+              className="min-h-[240px] font-mono text-xs"
+              spellCheck={false}
+            />
+          </div>
+          {fileError && (
+            <div
+              className="flex items-center gap-2 p-3 rounded-md bg-destructive/10 text-destructive text-sm"
+              role="alert"
+            >
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              <span>{fileError}</span>
+            </div>
+          )}
+          {importMutation.isError && (
+            <div
+              className="flex items-center gap-2 p-3 rounded-md bg-destructive/10 text-destructive text-sm"
+              role="alert"
+            >
+              <AlertCircle className="h-4 w-4 flex-shrink-0" />
+              <span>{importMutation.error.message}</span>
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="flex-shrink-0 justify-end gap-2 pt-4 border-t">
+          <Button variant="outline" onClick={onClose} disabled={importMutation.isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleImport} disabled={!canImport}>
+            {importMutation.isPending ? "Importing..." : "Import"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/ralph-web/src/components/builder/OffsetEdge.tsx
+++ b/frontend/ralph-web/src/components/builder/OffsetEdge.tsx
@@ -6,11 +6,11 @@
  */
 
 import {
-  BaseEdge,
-  EdgeLabelRenderer,
-  getBezierPath,
-  useStore,
-  type EdgeProps,
+    BaseEdge,
+    EdgeLabelRenderer,
+    getBezierPath,
+    useStore,
+    type EdgeProps,
 } from "@xyflow/react";
 
 /** Assign a stable color based on the event/label string */
@@ -54,6 +54,8 @@ export function OffsetEdge({
   targetPosition,
   label,
   markerEnd,
+  selected,
+  data,
 }: EdgeProps) {
   // Find sibling edges (same source→target pair, either direction)
   const siblingInfo = useStore((s) => {
@@ -82,26 +84,34 @@ export function OffsetEdge({
   });
 
   const color = getEdgeColor(label as string | undefined);
+  const fired = (data as Record<string, unknown> | undefined)?.fired === true;
 
   return (
     <>
-      {/* Glow layer */}
+      {/* Glow layer — brighter when selected or fired */}
       <path
         d={path}
         fill="none"
         stroke={color}
-        strokeWidth={10}
-        strokeOpacity={0.15}
+        strokeWidth={fired ? 16 : selected ? 14 : 10}
+        strokeOpacity={fired ? 0.5 : selected ? 0.35 : 0.15}
       />
       {/* Main edge — solid, thick */}
       <BaseEdge
         path={path}
         markerEnd={markerEnd}
-        style={{ stroke: color, strokeWidth: 4 }}
+        style={{
+          stroke: color,
+          strokeWidth: fired ? 6 : selected ? 5 : 4,
+          strokeDasharray: fired ? "8 4" : undefined,
+          animation: fired ? "edgePulse 1.5s linear" : undefined,
+        }}
       />
       {label && (
         <EdgeLabelRenderer>
           <div
+            data-edge-id={id}
+            data-fired={fired ? "true" : "false"}
             style={{
               position: "absolute",
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,

--- a/frontend/ralph-web/src/components/builder/PropertiesPanel.tsx
+++ b/frontend/ralph-web/src/components/builder/PropertiesPanel.tsx
@@ -62,6 +62,12 @@ function TagEditor({
       return;
     }
 
+    // Event names must be lowercase dot-separated identifiers (e.g. build.done)
+    if (!/^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$/.test(tag)) {
+      setError("Use lowercase dot-separated names (e.g. build.done)");
+      return;
+    }
+
     setError(null);
     onChange([...value, tag]);
     setInputValue("");
@@ -151,13 +157,16 @@ export function PropertiesPanel({
 }: PropertiesPanelProps) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [localData, setLocalData] = useState<HatNodeData | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
 
   // Sync local state when selection changes
   useEffect(() => {
     if (selectedNode) {
       setLocalData({ ...selectedNode.data });
+      setNameError(null);
     } else {
       setLocalData(null);
+      setNameError(null);
     }
   }, [selectedNode]);
 
@@ -235,10 +244,17 @@ export function PropertiesPanel({
               <Label className="text-xs">Name</Label>
               <Input
                 value={localData.name}
-                onChange={(e) => updateField("name", e.target.value)}
-                className="h-8 text-xs"
+                onChange={(e) => {
+                  updateField("name", e.target.value);
+                  if (e.target.value.trim()) setNameError(null);
+                }}
+                onBlur={() => {
+                  if (!localData.name.trim()) setNameError("Hat name is required");
+                }}
+                className={cn("h-8 text-xs", nameError && "border-destructive")}
                 placeholder="Hat name"
               />
+              {nameError && <p className="text-xs text-destructive">{nameError}</p>}
             </div>
 
             {/* Description */}

--- a/frontend/ralph-web/src/components/builder/RunPromptDialog.tsx
+++ b/frontend/ralph-web/src/components/builder/RunPromptDialog.tsx
@@ -1,0 +1,99 @@
+/**
+ * RunPromptDialog
+ *
+ * Small modal that asks the user what the workflow should do before
+ * starting a loop. The prompt is the "what"; the hat collection is the "how."
+ */
+
+import { Button } from "@/components/ui/button";
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Play } from "lucide-react";
+import { useCallback, useState } from "react";
+
+interface RunPromptDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onRun: (prompt: string) => void;
+  isRunning?: boolean;
+  collectionName: string;
+}
+
+export function RunPromptDialog({
+  open,
+  onClose,
+  onRun,
+  isRunning,
+  collectionName,
+}: RunPromptDialogProps) {
+  const [prompt, setPrompt] = useState("");
+
+  const handleRun = useCallback(() => {
+    const trimmed = prompt.trim();
+    if (!trimmed) return;
+    onRun(trimmed);
+  }, [prompt, onRun]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <Card
+        className="w-full max-w-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CardHeader>
+          <CardTitle>Run Workflow</CardTitle>
+          <CardDescription>
+            What should <strong>{collectionName}</strong> do?
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Label htmlFor="run-prompt">Prompt</Label>
+            <Textarea
+              id="run-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder='e.g. "Add input validation to the /users endpoint"'
+              className="min-h-[100px]"
+              autoFocus
+              onKeyDown={(e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                  e.preventDefault();
+                  handleRun();
+                }
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              ⌘+Enter to run
+            </p>
+          </div>
+        </CardContent>
+        <CardFooter className="justify-end gap-2">
+          <Button variant="outline" onClick={onClose} disabled={isRunning}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleRun}
+            disabled={!prompt.trim() || isRunning}
+          >
+            <Play className="h-4 w-4 mr-2" />
+            {isRunning ? "Starting..." : "Run"}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/ralph-web/src/components/builder/blueprints.ts
+++ b/frontend/ralph-web/src/components/builder/blueprints.ts
@@ -1,0 +1,127 @@
+/**
+ * Pre-built workflow blueprints.
+ *
+ * Each blueprint is a complete hat collection with nodes, edges, and
+ * metadata. When the user picks a blueprint, a new collection is created
+ * with these nodes and edges pre-populated and auto-laid-out.
+ */
+
+import type { HatNodeData } from "./HatNode";
+
+export interface Blueprint {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  hats: HatNodeData[];
+  /** Edges as [sourceKey, targetKey, eventName] tuples. */
+  edges: [string, string, string][];
+}
+
+export const BLUEPRINTS: Blueprint[] = [
+  {
+    id: "code-assist",
+    name: "Code Assist",
+    description: "Plan → Build → Review → Finalize. The standard development workflow.",
+    emoji: "⚡",
+    hats: [
+      {
+        key: "planner",
+        name: "📋 Planner",
+        description: "Breaks the task into ordered sub-tasks",
+        triggersOn: ["work.start", "subtask.done"],
+        publishes: ["subtask.ready", "all_steps.done"],
+      },
+      {
+        key: "builder",
+        name: "⚡ Builder",
+        description: "Implements one sub-task at a time, runs tests",
+        triggersOn: ["subtask.ready", "review.changes_requested"],
+        publishes: ["subtask.done", "implementation.done"],
+      },
+      {
+        key: "reviewer",
+        name: "👀 Reviewer",
+        description: "Reviews code quality and AGENTS.md compliance",
+        triggersOn: ["all_steps.done", "implementation.done"],
+        publishes: ["review.approved", "review.changes_requested"],
+      },
+      {
+        key: "finalizer",
+        name: "📝 Finalizer",
+        description: "Documents changes and emits LOOP_COMPLETE",
+        triggersOn: ["review.approved"],
+        publishes: ["LOOP_COMPLETE"],
+      },
+    ],
+    edges: [
+      ["planner", "builder", "subtask.ready"],
+      ["builder", "planner", "subtask.done"],
+      ["planner", "reviewer", "all_steps.done"],
+      ["builder", "reviewer", "implementation.done"],
+      ["reviewer", "finalizer", "review.approved"],
+      ["reviewer", "builder", "review.changes_requested"],
+    ],
+  },
+  {
+    id: "debug",
+    name: "Debug",
+    description: "Investigate → Test → Fix → Verify. For hunting bugs.",
+    emoji: "🔍",
+    hats: [
+      {
+        key: "investigator",
+        name: "🔍 Investigator",
+        description: "Reproduces the bug and identifies root cause",
+        triggersOn: ["work.start", "fix.failed"],
+        publishes: ["hypothesis.ready"],
+      },
+      {
+        key: "fixer",
+        name: "🔧 Fixer",
+        description: "Applies the fix based on the hypothesis",
+        triggersOn: ["hypothesis.ready"],
+        publishes: ["fix.done", "fix.failed"],
+      },
+      {
+        key: "verifier",
+        name: "✅ Verifier",
+        description: "Runs tests to confirm the fix works",
+        triggersOn: ["fix.done"],
+        publishes: ["LOOP_COMPLETE", "fix.failed"],
+      },
+    ],
+    edges: [
+      ["investigator", "fixer", "hypothesis.ready"],
+      ["fixer", "verifier", "fix.done"],
+      ["fixer", "investigator", "fix.failed"],
+      ["verifier", "investigator", "fix.failed"],
+    ],
+  },
+  {
+    id: "research",
+    name: "Research",
+    description: "Explore → Synthesize. For code exploration without changes.",
+    emoji: "📚",
+    hats: [
+      {
+        key: "researcher",
+        name: "🔬 Researcher",
+        description: "Explores the codebase and gathers information",
+        triggersOn: ["work.start", "synthesis.needs_more"],
+        publishes: ["research.done"],
+      },
+      {
+        key: "synthesizer",
+        name: "📝 Synthesizer",
+        description: "Summarizes findings into a coherent report",
+        triggersOn: ["research.done"],
+        publishes: ["LOOP_COMPLETE", "synthesis.needs_more"],
+      },
+    ],
+    edges: [
+      ["researcher", "synthesizer", "research.done"],
+      ["synthesizer", "researcher", "synthesis.needs_more"],
+    ],
+  },
+];

--- a/frontend/ralph-web/src/components/builder/index.ts
+++ b/frontend/ralph-web/src/components/builder/index.ts
@@ -7,4 +7,6 @@
 export { CollectionBuilder } from "./CollectionBuilder";
 export { HatNode, type HatNodeData } from "./HatNode";
 export { HatPalette } from "./HatPalette";
+export { ImportYamlDialog } from "./ImportYamlDialog";
 export { PropertiesPanel } from "./PropertiesPanel";
+

--- a/frontend/ralph-web/src/components/builder/layout.test.ts
+++ b/frontend/ralph-web/src/components/builder/layout.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the builder layout helpers.
+ *
+ * Covers autoLayout (linear, branching, cyclic graphs) and needsLayout
+ * (Rust-stacked input vs user-placed positions).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { LayoutEdge, LayoutNode } from "./layout";
+import { autoLayout, needsLayout } from "./layout";
+
+function makeNode(id: string, x = 0, y = 0): LayoutNode {
+  return { id, position: { x, y } };
+}
+
+function makeEdge(source: string, target: string): LayoutEdge {
+  return { source, target };
+}
+
+function xAt(nodes: LayoutNode[], id: string): number {
+  const node = nodes.find((n) => n.id === id);
+  if (!node) throw new Error(`node ${id} not found`);
+  return node.position.x;
+}
+
+function yAt(nodes: LayoutNode[], id: string): number {
+  const node = nodes.find((n) => n.id === id);
+  if (!node) throw new Error(`node ${id} not found`);
+  return node.position.y;
+}
+
+describe("autoLayout", () => {
+  describe("linear chain", () => {
+    it("places A → B → C in ascending columns", () => {
+      const nodes = [makeNode("a"), makeNode("b"), makeNode("c")];
+      const edges = [makeEdge("a", "b"), makeEdge("b", "c")];
+
+      const positioned = autoLayout(nodes, edges);
+
+      expect(xAt(positioned, "a")).toBeLessThan(xAt(positioned, "b"));
+      expect(xAt(positioned, "b")).toBeLessThan(xAt(positioned, "c"));
+    });
+  });
+
+  describe("branching", () => {
+    it("places siblings at the same x column, different y", () => {
+      const nodes = [makeNode("root"), makeNode("left"), makeNode("right")];
+      const edges = [makeEdge("root", "left"), makeEdge("root", "right")];
+
+      const positioned = autoLayout(nodes, edges);
+
+      expect(xAt(positioned, "left")).toBe(xAt(positioned, "right"));
+      expect(yAt(positioned, "left")).not.toBe(yAt(positioned, "right"));
+      expect(xAt(positioned, "root")).toBeLessThan(xAt(positioned, "left"));
+    });
+  });
+
+  describe("cycle", () => {
+    it("terminates and assigns every node a level", () => {
+      const nodes = [makeNode("a"), makeNode("b"), makeNode("c")];
+      const edges = [makeEdge("a", "b"), makeEdge("b", "c"), makeEdge("c", "a")];
+
+      const positioned = autoLayout(nodes, edges);
+
+      // Every node must receive a finite position.
+      expect(positioned).toHaveLength(3);
+      for (const node of positioned) {
+        expect(Number.isFinite(node.position.x)).toBe(true);
+        expect(Number.isFinite(node.position.y)).toBe(true);
+      }
+    });
+  });
+
+  describe("disconnected nodes", () => {
+    it("places an isolated node at level 0 alongside other roots", () => {
+      const nodes = [makeNode("a"), makeNode("b"), makeNode("orphan")];
+      const edges = [makeEdge("a", "b")];
+
+      const positioned = autoLayout(nodes, edges);
+
+      // `orphan` has in-degree 0, so it's treated as a root just like `a`.
+      // Both share level 0 (x = LEVEL_X_START); `b` is one level deeper.
+      expect(xAt(positioned, "orphan")).toBe(xAt(positioned, "a"));
+      expect(xAt(positioned, "b")).toBeGreaterThan(xAt(positioned, "orphan"));
+    });
+  });
+
+  describe("empty input", () => {
+    it("returns the input unchanged when there are no nodes", () => {
+      const result = autoLayout([], []);
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+describe("needsLayout", () => {
+  it("returns true when every node shares an x-coordinate (Rust-stacked import)", () => {
+    const nodes = [makeNode("a", 250, 50), makeNode("b", 250, 250), makeNode("c", 250, 450)];
+    expect(needsLayout(nodes)).toBe(true);
+  });
+
+  it("returns false when x-coordinates vary (user-placed)", () => {
+    const nodes = [makeNode("a", 0, 0), makeNode("b", 280, 0)];
+    expect(needsLayout(nodes)).toBe(false);
+  });
+
+  it("returns false for a single node", () => {
+    expect(needsLayout([makeNode("only", 250, 50)])).toBe(false);
+  });
+
+  it("returns false for an empty graph", () => {
+    expect(needsLayout([])).toBe(false);
+  });
+});

--- a/frontend/ralph-web/src/components/builder/layout.ts
+++ b/frontend/ralph-web/src/components/builder/layout.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure layout utilities for the collection builder.
+ *
+ * `autoLayout` runs a Kahn-style BFS to assign each node a level based on
+ * its distance from the graph's roots, then positions nodes in a left-to-right
+ * column-per-level grid. Handles cycles by ignoring back-edges (first-seen
+ * level wins) and handles pure-cycle graphs by seeding level 0 with the
+ * first node. `needsLayout` is a heuristic that detects the Rust YAML
+ * importer's stacked output (all nodes at the same x-coordinate).
+ *
+ * The structural `LayoutNode` / `LayoutEdge` types keep this module free of
+ * a runtime dependency on `@xyflow/react` so it can be imported in vitest
+ * without pulling the React Flow bundle (which breaks the test runner
+ * under the @tailwindcss/vite plugin).
+ */
+
+export interface LayoutNode {
+  id: string;
+  position: { x: number; y: number };
+}
+
+export interface LayoutEdge {
+  source: string;
+  target: string;
+}
+
+
+const LEVEL_X_SPACING = 280;
+const LEVEL_Y_SPACING = 160;
+const LEVEL_X_START = 40;
+const LEVEL_Y_START = 40;
+
+/**
+ * Detect the "freshly imported from YAML" layout pattern where every node
+ * is stacked at the same x-coordinate. Used to decide whether to run
+ * autoLayout on mount without disturbing user-placed graphs.
+ */
+export function needsLayout(nodes: LayoutNode[]): boolean {
+  if (nodes.length < 2) return false;
+  const xs = new Set(nodes.map((n) => n.position.x));
+  return xs.size === 1;
+}
+
+/**
+ * Assign a level (x-column) to every node via BFS from in-degree-0 roots.
+ * Returns a Map<nodeId, level>. Nodes unreachable from any root are placed
+ * after the deepest reachable level.
+ */
+function computeLevels(nodes: LayoutNode[], edges: LayoutEdge[]): Map<string, number> {
+  const adjacency = new Map<string, string[]>();
+  const inDegree = new Map<string, number>();
+
+  for (const node of nodes) {
+    adjacency.set(node.id, []);
+    inDegree.set(node.id, 0);
+  }
+
+  for (const edge of edges) {
+    const neighbors = adjacency.get(edge.source);
+    if (neighbors) {
+      neighbors.push(edge.target);
+    }
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+  }
+
+  const levels = new Map<string, number>();
+  const queue: string[] = [];
+
+  for (const [id, degree] of inDegree) {
+    if (degree === 0) {
+      levels.set(id, 0);
+      queue.push(id);
+    }
+  }
+
+  // Pure-cycle fallback: no roots at all.
+  if (queue.length === 0 && nodes.length > 0) {
+    const seedId = nodes[0].id;
+    levels.set(seedId, 0);
+    queue.push(seedId);
+  }
+
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+    const currentLevel = levels.get(currentId) ?? 0;
+    for (const neighborId of adjacency.get(currentId) ?? []) {
+      // First-seen wins: if the neighbor already has a level, this is a
+      // back-edge in a cycle — skip it to guarantee termination.
+      if (levels.has(neighborId)) continue;
+      levels.set(neighborId, currentLevel + 1);
+      queue.push(neighborId);
+    }
+  }
+
+  // Unreached nodes (disconnected subgraphs that were cycles without an
+  // entry point, or islands) go after the deepest reached level.
+  let maxLevel = -1;
+  for (const level of levels.values()) {
+    if (level > maxLevel) maxLevel = level;
+  }
+  for (const node of nodes) {
+    if (!levels.has(node.id)) {
+      levels.set(node.id, maxLevel + 1);
+    }
+  }
+
+  return levels;
+}
+
+/**
+ * Position nodes in a left-to-right layered grid based on graph topology.
+ * Node identities are preserved; only `position` is rewritten.
+ */
+export function autoLayout<N extends LayoutNode>(nodes: N[], edges: LayoutEdge[]): N[] {
+  if (nodes.length === 0) return nodes;
+
+  const levels = computeLevels(nodes, edges);
+
+  // Group nodes by their level so we can stack them vertically within each column.
+  const byLevel = new Map<number, N[]>();
+  for (const node of nodes) {
+    const level = levels.get(node.id) ?? 0;
+    const bucket = byLevel.get(level);
+    if (bucket) {
+      bucket.push(node);
+    } else {
+      byLevel.set(level, [node]);
+    }
+  }
+
+  const positioned: N[] = [];
+  for (const [level, bucket] of byLevel) {
+    bucket.forEach((node, indexInLevel) => {
+      positioned.push({
+        ...node,
+        position: {
+          x: LEVEL_X_START + level * LEVEL_X_SPACING,
+          y: LEVEL_Y_START + indexInLevel * LEVEL_Y_SPACING,
+        },
+      });
+    });
+  }
+
+  // Preserve the original node ordering so downstream consumers (React Flow)
+  // receive a stable list.
+  const order = new Map(nodes.map((node, index) => [node.id, index]));
+  positioned.sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0));
+
+  return positioned;
+}

--- a/frontend/ralph-web/src/components/builder/roles.test.ts
+++ b/frontend/ralph-web/src/components/builder/roles.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Tests for the role metadata helpers.
+ *
+ * The only test here is for the "unknown role" fallback, because losing it
+ * would crash HatNode (which reads `getRoleMeta(...).emoji` unconditionally)
+ * rather than just producing wrong colors.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ROLE_META, getRoleMeta } from "./roles";
+
+describe("getRoleMeta", () => {
+  it("returns the custom fallback for unknown roles", () => {
+    expect(getRoleMeta("unknown-role")).toBe(ROLE_META.custom);
+  });
+});

--- a/frontend/ralph-web/src/components/builder/roles.ts
+++ b/frontend/ralph-web/src/components/builder/roles.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared role metadata for hat nodes.
+ *
+ * Consumed by HatNode (border + emoji) and CollectionBuilder's MiniMap
+ * (node color). Single source of truth so the two views never drift.
+ */
+
+export interface RoleMeta {
+  emoji: string;
+  borderClass: string;
+  color: string;
+}
+
+/**
+ * Map of role key → visual metadata. Keys match the values used by
+ * HatPalette's HAT_TEMPLATES (planner, builder, reviewer, validator,
+ * confessor, custom). Unknown roles fall back to the "custom" entry.
+ */
+export const ROLE_META: Record<string, RoleMeta> = {
+  planner: { emoji: "📋", borderClass: "border-violet-500/60", color: "#8b5cf6" },
+  builder: { emoji: "⚡", borderClass: "border-blue-500/60", color: "#3b82f6" },
+  reviewer: { emoji: "👀", borderClass: "border-green-500/60", color: "#22c55e" },
+  validator: { emoji: "✅", borderClass: "border-amber-500/60", color: "#f59e0b" },
+  confessor: { emoji: "🔍", borderClass: "border-red-500/60", color: "#ef4444" },
+  custom: { emoji: "🎩", borderClass: "", color: "#6b7280" },
+};
+
+const UUID_SUFFIX_RE = /-[0-9a-f]{8}$/i;
+
+/**
+ * Extract the role from a node key. Nodes dropped from the palette receive
+ * IDs like `planner-a1b2c3d4`; strip the uuid suffix to recover "planner".
+ * If no suffix is present, the key is used as-is.
+ */
+export function getRole(key: string): string {
+  return key.replace(UUID_SUFFIX_RE, "");
+}
+
+/**
+ * Look up role metadata with a fallback to the "custom" entry.
+ */
+export function getRoleMeta(key: string): RoleMeta {
+  const role = getRole(key);
+  return ROLE_META[role] ?? ROLE_META.custom;
+}

--- a/frontend/ralph-web/src/components/layout/AppShell.tsx
+++ b/frontend/ralph-web/src/components/layout/AppShell.tsx
@@ -17,7 +17,7 @@ export function AppShell() {
 
       {/* Main content area - renders active route via Outlet */}
       <main className="flex-1 overflow-auto">
-        <div className="p-6">
+        <div className="p-6 h-full">
           <Outlet />
         </div>
       </main>

--- a/frontend/ralph-web/src/hooks/useLoopObservation.ts
+++ b/frontend/ralph-web/src/hooks/useLoopObservation.ts
@@ -1,0 +1,205 @@
+/**
+ * useLoopObservation
+ *
+ * Subscribes to `loop.orchestration` stream events and drives the
+ * observation zustand store. Owns the topology-aware inference that
+ * lets us handle both event shapes Ralph produces:
+ *
+ *  1. Loop-level events (Ralph itself): carry `hat`, `iteration`, and
+ *     `triggered` — explicit transition.
+ *  2. Agent-level events (kiro-acp, claude, etc. via tool calls): only
+ *     `ts`, `topic`, `payload`. We infer the transition by matching
+ *     `topic` to an edge label in the current graph and applying
+ *     `edge.source → completed`, `edge.target → active`.
+ *
+ * The store stays graph-agnostic; the hook owns edge topology.
+ */
+
+import { buildStreamWebSocketUrl, rpcSubscribe, rpcUnsubscribe, type StreamEventEnvelope } from "@/rpc/client";
+import {
+    useObservationStore,
+    type OrchestrationEventPayload,
+} from "@/stores/observationStore";
+import type { Edge } from "@xyflow/react";
+import { useCallback, useEffect, useRef } from "react";
+
+const OBSERVATION_TOPICS = ["loop.orchestration", "stream.keepalive"];
+const EDGE_ANIMATION_MS = 1500;
+const TERMINAL_TOPICS = new Set(["LOOP_COMPLETE", "loop.terminate"]);
+
+/**
+ * Subscribes to loop orchestration events when observation is active.
+ *
+ * @param edges - The current graph edges. Used to map topics (agent-level
+ *   events that lack a `hat` field) to source/target hats.
+ */
+export function useLoopObservation(edges: Edge[]) {
+  const active = useObservationStore((s) => s.active);
+  const taskId = useObservationStore((s) => s.taskId);
+  const setHatActive = useObservationStore((s) => s.setHatActive);
+  const setHatPending = useObservationStore((s) => s.setHatPending);
+  const setIteration = useObservationStore((s) => s.setIteration);
+  const completeAll = useObservationStore((s) => s.completeAll);
+  const fireEdge = useObservationStore((s) => s.fireEdge);
+  const clearFiredEdge = useObservationStore((s) => s.clearFiredEdge);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const subscriptionIdRef = useRef<string | null>(null);
+  const edgeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Keep latest edges accessible to the WebSocket message handler without
+  // re-subscribing on every edge change (which would drop replay position).
+  const edgesRef = useRef(edges);
+  edgesRef.current = edges;
+
+  /** Return all edges whose label exactly matches `topic`. */
+  const edgesForTopic = useCallback((topic: string): Edge[] => {
+    return edgesRef.current.filter(
+      (e) => typeof e.label === "string" && e.label === topic
+    );
+  }, []);
+
+  /** Start the edge pulse animation, canceling any in-flight pulse. */
+  const pulseEdge = useCallback(
+    (edgeId: string) => {
+      if (edgeTimerRef.current) {
+        clearTimeout(edgeTimerRef.current);
+      }
+      fireEdge(edgeId);
+      edgeTimerRef.current = setTimeout(() => {
+        clearFiredEdge();
+        edgeTimerRef.current = null;
+      }, EDGE_ANIMATION_MS);
+    },
+    [fireEdge, clearFiredEdge]
+  );
+
+  /**
+   * Apply an event to the observation state.
+   *
+   * Exported via ref + useEffect so the WebSocket handler always uses the
+   * latest closure without re-subscribing.
+   */
+  const dispatchEvent = useCallback(
+    (payload: OrchestrationEventPayload) => {
+      // Iteration counter updates regardless of hat context.
+      if (typeof payload.iteration === "number") {
+        setIteration(payload.iteration);
+      }
+
+      // Terminal events always override hat-level logic.
+      if (payload.topic && TERMINAL_TOPICS.has(payload.topic)) {
+        completeAll();
+        return;
+      }
+
+      // Case 1: Loop-level event — `hat: "loop"` with a `triggered` target.
+      // The framework is handing control to `triggered`.
+      if (payload.hat === "loop" && payload.triggered) {
+        setHatActive(payload.triggered);
+        return;
+      }
+
+      // Case 2: Hat-level event — a real hat is emitting.
+      // It is currently active; its `triggered` target (if any) is pending.
+      if (payload.hat && payload.hat !== "loop") {
+        setHatActive(payload.hat);
+        if (payload.triggered) {
+          setHatPending(payload.triggered);
+        }
+        // Also fire the matching edge so the UI shows the handoff path.
+        if (payload.topic) {
+          for (const edge of edgesForTopic(payload.topic)) {
+            pulseEdge(edge.id);
+          }
+        }
+        return;
+      }
+
+      // Case 3: Agent-level event — no `hat`, only `topic`. Infer from graph.
+      if (payload.topic) {
+        const matching = edgesForTopic(payload.topic);
+        for (const edge of matching) {
+          setHatActive(edge.target);
+          pulseEdge(edge.id);
+        }
+      }
+    },
+    [completeAll, edgesForTopic, pulseEdge, setHatActive, setHatPending, setIteration]
+  );
+
+  // Stable ref to the latest dispatcher — lets the WebSocket handler
+  // run through an `useEffect` that only cares about (active, taskId).
+  const dispatchRef = useRef(dispatchEvent);
+  dispatchRef.current = dispatchEvent;
+
+  useEffect(() => {
+    if (!active || !taskId) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const subscription = await rpcSubscribe({
+          topics: OBSERVATION_TOPICS,
+          replayLimit: 100,
+        });
+
+        if (cancelled) {
+          void rpcUnsubscribe(subscription.subscriptionId).catch(() => {});
+          return;
+        }
+
+        subscriptionIdRef.current = subscription.subscriptionId;
+
+        const ws = new WebSocket(buildStreamWebSocketUrl(subscription.subscriptionId));
+        wsRef.current = ws;
+
+        ws.onmessage = (message) => {
+          if (cancelled) return;
+
+          let event: StreamEventEnvelope;
+          try {
+            event = JSON.parse(String(message.data)) as StreamEventEnvelope;
+          } catch {
+            return;
+          }
+
+          if (event.topic !== "loop.orchestration") return;
+
+          const payload = event.payload as unknown as OrchestrationEventPayload;
+          if (!payload || typeof payload !== "object") return;
+
+          dispatchRef.current(payload);
+        };
+
+        ws.onerror = () => {
+          // Reconnection is not implemented for MVP — the user can
+          // stop and re-run if the connection drops.
+        };
+      } catch {
+        // Subscription failed — observation stays active but no events arrive.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+
+      if (edgeTimerRef.current) {
+        clearTimeout(edgeTimerRef.current);
+        edgeTimerRef.current = null;
+      }
+
+      if (wsRef.current) {
+        wsRef.current.onclose = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+
+      const subId = subscriptionIdRef.current;
+      subscriptionIdRef.current = null;
+      if (subId) {
+        void rpcUnsubscribe(subId).catch(() => {});
+      }
+    };
+  }, [active, taskId]);
+}

--- a/frontend/ralph-web/src/index.css
+++ b/frontend/ralph-web/src/index.css
@@ -166,3 +166,29 @@
     margin: 1.5em 0;
   }
 }
+
+/* Edge pulse animation for live observation mode */
+@keyframes edgePulse {
+  from {
+    stroke-dashoffset: 24;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+/* Border pulse for active hat nodes during observation.
+   Animates only border-color (not opacity), so the node content stays stable. */
+@keyframes borderPulse {
+  0%, 100% { border-color: rgb(239 68 68); }
+  50% { border-color: rgb(239 68 68 / 0.3); }
+}
+
+.animate-border-pulse {
+  animation: borderPulse 2s ease-in-out infinite;
+}
+
+/* Smooth border-color transitions for hat node state changes. */
+[data-hat-key] {
+  transition: border-color 0.3s ease-in-out;
+}

--- a/frontend/ralph-web/src/pages/BuilderPage.tsx
+++ b/frontend/ralph-web/src/pages/BuilderPage.tsx
@@ -11,21 +11,28 @@
  * This implements the n8n-style builder for hat collections.
  */
 
-import { useState, useCallback } from "react";
-import { trpc } from "../trpc";
-import { CollectionBuilder } from "@/components/builder";
+import { CollectionBuilder, ImportYamlDialog } from "@/components/builder";
+import { BLUEPRINTS, type Blueprint } from "@/components/builder/blueprints";
+import { RunPromptDialog } from "@/components/builder/RunPromptDialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  Plus,
-  FolderOpen,
-  Pencil,
-  Trash2,
-  ArrowLeft,
-  Clock,
-} from "lucide-react";
+import { useObservationStore } from "@/stores/observationStore";
+import type { Edge, Node } from "@xyflow/react";
 import { formatDistanceToNow } from "date-fns";
-import type { Node, Edge } from "@xyflow/react";
+import {
+    AlertCircle,
+    ArrowLeft,
+    Clock,
+    FolderOpen,
+    Pencil,
+    Play,
+    Plus,
+    Square,
+    Trash2,
+    Upload
+} from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+import { trpc } from "../trpc";
 
 type ViewMode = "list" | "edit" | "create";
 
@@ -35,9 +42,13 @@ type ViewMode = "list" | "edit" | "create";
 function CollectionList({
   onSelect,
   onCreate,
+  onImport,
+  onBlueprint,
 }: {
   onSelect: (id: string) => void;
   onCreate: () => void;
+  onImport: () => void;
+  onBlueprint: (blueprint: Blueprint) => void;
 }) {
   const collectionsQuery = trpc.collection.list.useQuery();
   const deleteMutation = trpc.collection.delete.useMutation({
@@ -77,10 +88,43 @@ function CollectionList({
             Visual hat workflows you've created
           </p>
         </div>
-        <Button onClick={onCreate}>
-          <Plus className="h-4 w-4 mr-2" />
-          New Collection
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={onImport}>
+            <Upload className="h-4 w-4 mr-2" />
+            Import YAML
+          </Button>
+          <Button onClick={onCreate}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Collection
+          </Button>
+        </div>
+      </div>
+
+      {/* Blueprints — pre-built workflow templates */}
+      <div className="mb-6">
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">Start from a blueprint</h3>
+        <div className="grid grid-cols-3 gap-3">
+          {BLUEPRINTS.map((bp) => (
+            <Card
+              key={bp.id}
+              className="cursor-pointer hover:border-primary/50 transition-colors"
+              onClick={() => onBlueprint(bp)}
+            >
+              <CardContent className="p-4">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-lg">{bp.emoji}</span>
+                  <span className="font-medium text-sm">{bp.name}</span>
+                </div>
+                <p className="text-xs text-muted-foreground">{bp.description}</p>
+                <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
+                  <span>{bp.hats.length} hats</span>
+                  <span>·</span>
+                  <span>{bp.edges.length} connections</span>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </div>
 
       {collections.length === 0 ? (
@@ -159,47 +203,139 @@ export function BuilderPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [isDirty, setIsDirty] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
+  const [showImport, setShowImport] = useState(false);
+  const justImportedId = useRef<string | null>(null);
 
   // Query for selected collection
   const collectionQuery = trpc.collection.get.useQuery(
     { id: selectedId! },
     { enabled: viewMode === "edit" && !!selectedId }
   );
+  const collectionsQuery = trpc.collection.list.useQuery();
 
   // Mutations
   const createMutation = trpc.collection.create.useMutation({
     onSuccess: (data: any) => {
       setSelectedId(data.id);
       setViewMode("edit");
+      setIsDirty(false);
+      setSaveStatus("success");
+      setTimeout(() => setSaveStatus("idle"), 3000);
+      collectionsQuery.refetch();
+    },
+    onError: () => {
+      setSaveStatus("error");
     },
   });
 
-  const updateMutation = trpc.collection.update.useMutation();
+  const updateMutation = trpc.collection.update.useMutation({
+    onSuccess: () => {
+      setIsDirty(false);
+      setSaveStatus("success");
+      justImportedId.current = null;
+      setTimeout(() => setSaveStatus("idle"), 3000);
+      collectionsQuery.refetch();
+    },
+    onError: () => {
+      setSaveStatus("error");
+    },
+  });
 
   const exportYamlQuery = trpc.collection.exportYaml.useQuery(
     { id: selectedId! },
     { enabled: false }
   );
 
+  const markDirty = useCallback(() => {
+    setIsDirty(true);
+    setSaveStatus("idle");
+  }, []);
+
   // Handlers
   const handleCreate = useCallback(() => {
     setName("New Collection");
     setDescription("");
     setSelectedId(null);
+    setIsDirty(false);
+    setSaveStatus("idle");
     setViewMode("create");
   }, []);
 
+  const handleBlueprint = useCallback((blueprint: Blueprint) => {
+    // Convert blueprint hats to graph nodes with temporary positions.
+    const nodes = blueprint.hats.map((hat, i) => ({
+      id: hat.key,
+      type: "hatNode",
+      position: { x: 250, y: 50 + i * 200 },
+      data: { ...hat },
+    }));
+
+    // Convert edge tuples to graph edges.
+    const edges = blueprint.edges.map(([source, target, event], i) => ({
+      id: `edge-${i}`,
+      source,
+      target,
+      sourceHandle: event,
+      targetHandle: event,
+      label: event,
+      type: "offset",
+    }));
+
+    // Create the collection with the blueprint graph.
+    const graph = {
+      nodes,
+      edges,
+      viewport: { x: 0, y: 0, zoom: 1 },
+    };
+
+    setName(blueprint.name);
+    setDescription(blueprint.description);
+    createMutation.mutate({
+      name: blueprint.name,
+      description: blueprint.description,
+      graph,
+    });
+  }, [createMutation]);
+
   const handleSelect = useCallback((id: string) => {
     setSelectedId(id);
+    setIsDirty(false);
+    setSaveStatus("idle");
     setViewMode("edit");
   }, []);
 
+  const handleImported = useCallback((collection: { id: string; name: string }) => {
+    justImportedId.current = collection.id;
+    setShowImport(false);
+    setSelectedId(collection.id);
+    setIsDirty(false);
+    setSaveStatus("idle");
+    setViewMode("edit");
+    collectionsQuery.refetch();
+  }, [collectionsQuery]);
+
   const handleBack = useCallback(() => {
+    if (isDirty && !confirm("Discard unsaved changes?")) return;
     setViewMode("list");
     setSelectedId(null);
     setName("");
     setDescription("");
-  }, []);
+    setIsDirty(false);
+    setSaveStatus("idle");
+    justImportedId.current = null;
+  }, [isDirty]);
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+    markDirty();
+  }, [markDirty]);
+
+  const handleDescriptionChange = useCallback((value: string) => {
+    setDescription(value);
+    markDirty();
+  }, [markDirty]);
 
   const handleSave = useCallback(
     (data: { nodes: Node[]; edges: Edge[]; name: string; description: string }) => {
@@ -265,8 +401,54 @@ export function BuilderPage() {
     }
   }, [selectedId, exportYamlQuery, name]);
 
-  // Sync name/description when collection loads
-  if (viewMode === "edit" && collectionQuery.data && name !== collectionQuery.data.name) {
+  // ── Run / Stop loop from the Builder ──────────────────────────────────
+  const observing = useObservationStore((s) => s.active);
+  const startObserving = useObservationStore((s) => s.startObserving);
+  const stopObserving = useObservationStore((s) => s.stopObserving);
+
+  const setHatActive = useObservationStore((s) => s.setHatActive);
+
+  const [showRunPrompt, setShowRunPrompt] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const collectionRunMutation = trpc.collection.run.useMutation();
+  const stopLoopMutation = trpc.loops.stop.useMutation();
+
+  const handleRunWithPrompt = useCallback(async (prompt: string) => {
+    if (!selectedId) return;
+    setShowRunPrompt(false);
+    setRunError(null);
+    try {
+      const result = await collectionRunMutation.mutateAsync({ id: selectedId, prompt });
+      startObserving(selectedId);
+      // Immediately highlight the entry hat so the user sees feedback
+      // before the first WebSocket event arrives (timing-race fix).
+      if (result.startingHat) {
+        setHatActive(result.startingHat);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to start loop";
+      setRunError(message);
+    }
+  }, [selectedId, collectionRunMutation, startObserving, setHatActive]);
+
+  const handleStop = useCallback(async () => {
+    stopObserving();
+    // loop.stop reads the PID from .ralph/loop.lock and kills the process.
+    try {
+      await stopLoopMutation.mutateAsync({ id: "primary" });
+    } catch {
+      // Best effort — loop may have already terminated.
+    }
+  }, [stopObserving, stopLoopMutation]);
+
+  // Sync name/description when collection loads. Only fire when we don't yet
+  // have the collection's name populated (avoids flipping dirty on every render).
+  if (
+    viewMode === "edit" &&
+    collectionQuery.data &&
+    name === "" &&
+    collectionQuery.data.name
+  ) {
     setName(collectionQuery.data.name);
     setDescription(collectionQuery.data.description || "");
   }
@@ -276,7 +458,7 @@ export function BuilderPage() {
       {/* Page header */}
       <header className="px-6 py-4 border-b flex items-center justify-between">
         <div className="flex items-center gap-4">
-          {viewMode !== "list" && (
+          {viewMode !== "list" && !observing && (
             <Button variant="ghost" size="sm" onClick={handleBack}>
               <ArrowLeft className="h-4 w-4 mr-2" />
               Back
@@ -289,17 +471,53 @@ export function BuilderPage() {
             <p className="text-muted-foreground text-sm">
               {viewMode === "list"
                 ? "Create visual workflows for hat collections"
-                : "Drag hats from the palette and connect them"}
+                : observing
+                  ? "Observing live loop execution"
+                  : "Drag hats from the palette and connect them"}
             </p>
           </div>
         </div>
+        {viewMode !== "list" && (
+          <div className="flex items-center gap-2">
+            {observing ? (
+              <Button variant="destructive" size="sm" onClick={handleStop}>
+                <Square className="h-4 w-4 mr-2" />
+                Stop
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                onClick={() => setShowRunPrompt(true)}
+                disabled={isDirty || !name.trim() || collectionRunMutation.isPending}
+                title={isDirty ? "Save the collection before running" : "Start a loop with this collection"}
+              >
+                <Play className="h-4 w-4 mr-2" />
+                {collectionRunMutation.isPending ? "Starting..." : "Run"}
+              </Button>
+            )}
+          </div>
+        )}
       </header>
+
+      {/* Run error banner */}
+      {runError && (
+        <div className="mx-6 mt-3 flex items-center gap-2 p-3 rounded-md bg-destructive/10 text-destructive text-sm">
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+          <span className="flex-1">{runError}</span>
+          <button className="text-xs underline" onClick={() => setRunError(null)}>Dismiss</button>
+        </div>
+      )}
 
       {/* Content */}
       <div className="flex-1 overflow-hidden">
         {viewMode === "list" ? (
           <div className="p-6 max-w-4xl mx-auto">
-            <CollectionList onSelect={handleSelect} onCreate={handleCreate} />
+            <CollectionList
+              onSelect={handleSelect}
+              onCreate={handleCreate}
+              onImport={() => setShowImport(true)}
+              onBlueprint={handleBlueprint}
+            />
           </div>
         ) : viewMode === "edit" && collectionQuery.isLoading ? (
           <div className="flex items-center justify-center h-full">
@@ -325,15 +543,33 @@ export function BuilderPage() {
             }
             name={name}
             description={description}
-            onNameChange={setName}
-            onDescriptionChange={setDescription}
+            onNameChange={handleNameChange}
+            onDescriptionChange={handleDescriptionChange}
             onSave={handleSave}
             onExportYaml={selectedId ? handleExportYaml : undefined}
             isSaving={createMutation.isPending || updateMutation.isPending}
+            isDirty={isDirty}
+            onMarkDirty={markDirty}
+            saveStatus={saveStatus}
+            justImported={!!selectedId && justImportedId.current === selectedId}
             className="h-full"
           />
         )}
       </div>
+
+      <ImportYamlDialog
+        open={showImport}
+        onClose={() => setShowImport(false)}
+        onImported={handleImported}
+      />
+
+      <RunPromptDialog
+        open={showRunPrompt}
+        onClose={() => setShowRunPrompt(false)}
+        onRun={handleRunWithPrompt}
+        isRunning={collectionRunMutation.isPending}
+        collectionName={name}
+      />
     </div>
   );
 }

--- a/frontend/ralph-web/src/rpc/client.ts
+++ b/frontend/ralph-web/src/rpc/client.ts
@@ -28,6 +28,7 @@ const MUTATING_METHODS = new Set<string>([
   "collection.update",
   "collection.delete",
   "collection.import",
+  "collection.run",
 ]);
 
 let requestCounter = 0;

--- a/frontend/ralph-web/src/stores/observationStore.ts
+++ b/frontend/ralph-web/src/stores/observationStore.ts
@@ -1,0 +1,177 @@
+/**
+ * Observation Store
+ *
+ * Zustand store for live loop observation state in the Builder.
+ * Survives navigation via zustand persistence semantics (module-level
+ * singleton) so the user can leave /builder and return without losing
+ * context.
+ *
+ * Design: the store is intentionally graph-agnostic. It knows nothing
+ * about edges or hat keys beyond the id strings the hook passes in.
+ * Topology-aware inference (matching stream events to the collection's
+ * edges) lives in `useLoopObservation` where the current `edges` prop
+ * is available.
+ */
+
+import { create } from "zustand";
+
+export type NodeObservationState = "idle" | "pending" | "active" | "completed";
+
+export interface ObservationStore {
+  /** Whether observation mode is active. */
+  active: boolean;
+  /** The task / collection id being observed. */
+  taskId: string | null;
+  /** Current iteration number. */
+  iteration: number;
+  /** Hat id currently executing (excludes the synthetic `loop` framework marker). */
+  activeHatId: string | null;
+  /** Per-node observation state keyed by node id. */
+  nodeStates: Record<string, NodeObservationState>;
+  /** Edge id that most recently fired (for pulse animation). */
+  lastFiredEdgeId: string | null;
+  /** Timestamp of the last edge fire (for timer reset). */
+  lastFiredAt: number;
+
+  /** Enter observation mode for a given task / collection. */
+  startObserving: (taskId: string) => void;
+  /** Exit observation mode and reset all state. */
+  stopObserving: () => void;
+
+  /**
+   * Mark `hatId` as active. The previously active hat transitions to
+   * completed. No-op if `hatId` is already active.
+   */
+  setHatActive: (hatId: string) => void;
+
+  /**
+   * Mark `hatId` as pending ("up next"). Does not change the currently
+   * active hat. No-op if `hatId` is already active or completed.
+   */
+  setHatPending: (hatId: string) => void;
+
+  /** Update the iteration counter (monotonic — ignores lower values). */
+  setIteration: (iteration: number) => void;
+
+  /**
+   * Terminal transition: every known node → completed, observation exits
+   * after a short delay so the user sees the final state.
+   */
+  completeAll: () => void;
+
+  /** Mark an edge as fired (triggers pulse animation). */
+  fireEdge: (edgeId: string) => void;
+  /** Clear the fired edge (called after animation completes). */
+  clearFiredEdge: () => void;
+}
+
+/**
+ * Shape of the `loop.orchestration` stream event payload.
+ *
+ * Ralph-emitted events (loop-level) set all fields. Agent-emitted events
+ * (via tool calls) may only set `ts`, `topic`, and `payload` — `hat`
+ * defaults to empty string and `iteration` to 0 via `#[serde(default)]`
+ * in ralph-core's `EventRecord`.
+ */
+export interface OrchestrationEventPayload {
+  iteration: number;
+  hat: string;
+  topic: string;
+  triggered: string | null;
+  ts: string;
+}
+
+export const useObservationStore = create<ObservationStore>((set, get) => ({
+  active: false,
+  taskId: null,
+  iteration: 0,
+  activeHatId: null,
+  nodeStates: {},
+  lastFiredEdgeId: null,
+  lastFiredAt: 0,
+
+  startObserving: (taskId: string) => {
+    set({
+      active: true,
+      taskId,
+      iteration: 0,
+      activeHatId: null,
+      nodeStates: {},
+      lastFiredEdgeId: null,
+      lastFiredAt: 0,
+    });
+  },
+
+  stopObserving: () => {
+    set({
+      active: false,
+      taskId: null,
+      iteration: 0,
+      activeHatId: null,
+      nodeStates: {},
+      lastFiredEdgeId: null,
+      lastFiredAt: 0,
+    });
+  },
+
+  setHatActive: (hatId: string) => {
+    const state = get();
+    if (!state.active || !hatId || hatId === state.activeHatId) return;
+
+    const nextStates = { ...state.nodeStates };
+    if (state.activeHatId) {
+      nextStates[state.activeHatId] = "completed";
+    }
+    nextStates[hatId] = "active";
+    set({ activeHatId: hatId, nodeStates: nextStates });
+  },
+
+  setHatPending: (hatId: string) => {
+    const state = get();
+    if (!state.active || !hatId) return;
+    const current = state.nodeStates[hatId];
+    // Never downgrade active or completed → pending.
+    if (current === "active" || current === "completed") return;
+    set({ nodeStates: { ...state.nodeStates, [hatId]: "pending" } });
+  },
+
+  setIteration: (iteration: number) => {
+    const state = get();
+    if (!state.active || iteration <= state.iteration) return;
+    set({ iteration });
+  },
+
+  completeAll: () => {
+    const state = get();
+    if (!state.active) return;
+    const next: Record<string, NodeObservationState> = { ...state.nodeStates };
+    for (const key of Object.keys(next)) {
+      next[key] = "completed";
+    }
+    if (state.activeHatId) {
+      next[state.activeHatId] = "completed";
+    }
+    set({ nodeStates: next });
+    // Delay so the user sees the final "all completed" state.
+    setTimeout(() => {
+      get().stopObserving();
+    }, 2000);
+  },
+
+  fireEdge: (edgeId: string) => {
+    set({ lastFiredEdgeId: edgeId, lastFiredAt: Date.now() });
+  },
+
+  clearFiredEdge: () => {
+    set({ lastFiredEdgeId: null });
+  },
+}));
+
+// Expose the store on `window` outside of production builds so Playwright
+// can drive observation state deterministically without a real backend.
+// This is a no-op in production bundles (Vite strips `import.meta.env.DEV`
+// branches via dead-code elimination).
+if (typeof window !== "undefined" && import.meta.env.DEV) {
+  (window as unknown as { __observationStore?: typeof useObservationStore }).__observationStore =
+    useObservationStore;
+}

--- a/frontend/ralph-web/src/trpc.ts
+++ b/frontend/ralph-web/src/trpc.ts
@@ -472,6 +472,10 @@ export const trpc = {
       method: "collection.import",
       mapResult: (result) => result.collection,
     }),
+
+    run: createMutationProcedure<{ id: string; prompt: string }, { success: boolean; configPath: string; pid: number; startingHat?: string }, { success: boolean; configPath: string; pid: number; startingHat?: string }>({
+      method: "collection.run",
+    }),
   },
 };
 

--- a/frontend/ralph-web/src/vite-env.d.ts
+++ b/frontend/ralph-web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Design agent workflows visually and watch them execute in real time. Drag hats onto a canvas, wire them with events, click Run, and follow each agent as it progresses through the pipeline you built.

Edit Controls
  Select + Backspace/Delete to remove nodes and edges
  Edge auto-cleanup when publishes/triggers change
  Import YAML dialog (file upload + paste) with BFS auto-layout
  Visual identity per hat role (planner, builder, reviewer, etc.)
  Unsaved changes detection with save feedback
  Pre-built blueprints (Code Assist, Debug, Research) can be used
  as starters

Live Observation
  Rust event_watcher tails .ralph/events-*.jsonl every 500ms and
  publishes to the stream as loop.orchestration events
  Topology-aware event dispatch infers which agent is active by
  matching event topics to edge labels in the graph
  Active nodes pulse red, completed nodes turn green with a
  checkmark, pending nodes show a blue border
  Inline legend in the observation toolbar
  Properties panel hidden during observation

Run Button
  collection.run RPC exports hats-only YAML and spawns ralph run
  in autonomous mode with the users prompt
  collection.run added to the RPC schema and MCP tool descriptions
  Entry node highlighted immediately when the loop starts
  Reaper thread cleans up child processes after loop completion
  Error banner shows ralphs stderr when the loop fails to start

Topology
  YAML exporter derives starting_event from the graph so the first
  hat activates correctly for any collection shape
  starting_hat_for_collection identifies the entry hat from node
  triggers and graph edges

Tests: 30 Playwright, 13 Rust, 154 vitest