### PR TITLE
fix(clippy): resolve rust 1.95 duration_suboptimal_units warnings

### DIFF
--- a/crates/ralph-api/src/idempotency.rs
+++ b/crates/ralph-api/src/idempotency.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn replays_same_method_key_and_params() {
-        let store = InMemoryIdempotencyStore::new(Duration::from_secs(60));
+        let store = InMemoryIdempotencyStore::new(Duration::from_mins(1));
         let params = json!({ "value": 1 });
         let response = StoredResponse {
             status: 200,
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn detects_conflict_for_same_key_with_different_params() {
-        let store = InMemoryIdempotencyStore::new(Duration::from_secs(60));
+        let store = InMemoryIdempotencyStore::new(Duration::from_mins(1));
         store.store(
             "task.create",
             "idem-2",

--- a/crates/ralph-cli/src/wave.rs
+++ b/crates/ralph-cli/src/wave.rs
@@ -128,10 +128,10 @@ pub fn write_wave_events(topic: &str, payloads: &[String], events_file: &Path) -
 ///
 /// Priority: RALPH_EVENTS_FILE env > .ralph/current-events marker > default .ralph/events.jsonl
 pub fn resolve_events_file() -> PathBuf {
-    if let Ok(path) = std::env::var("RALPH_EVENTS_FILE") {
-        if !path.is_empty() {
-            return PathBuf::from(path);
-        }
+    if let Ok(path) = std::env::var("RALPH_EVENTS_FILE")
+        && !path.is_empty()
+    {
+        return PathBuf::from(path);
     }
     fs::read_to_string(".ralph/current-events")
         .map(|s| PathBuf::from(s.trim()))

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -3287,7 +3287,7 @@ fn test_format_duration_variants() {
 
     assert_eq!(format_duration(Duration::from_secs(45)), "45s");
     assert_eq!(format_duration(Duration::from_secs(61)), "1m 1s");
-    assert_eq!(format_duration(Duration::from_secs(3600)), "1h 0m 0s");
+    assert_eq!(format_duration(Duration::from_hours(1)), "1h 0m 0s");
     assert_eq!(format_duration(Duration::from_secs(3661)), "1h 1m 1s");
 }
 

--- a/crates/ralph-core/src/testing/smoke_runner.rs
+++ b/crates/ralph-core/src/testing/smoke_runner.rs
@@ -462,12 +462,12 @@ coverage: pass
     #[test]
     fn test_config_builder_pattern() {
         let config = SmokeTestConfig::new("test.jsonl")
-            .with_timeout(Duration::from_secs(60))
+            .with_timeout(Duration::from_mins(1))
             .with_expected_iterations(5)
             .with_expected_termination("Completed");
 
         assert_eq!(config.fixture_path, PathBuf::from("test.jsonl"));
-        assert_eq!(config.timeout, Duration::from_secs(60));
+        assert_eq!(config.timeout, Duration::from_mins(1));
         assert_eq!(config.expected_iterations, Some(5));
         assert_eq!(config.expected_termination, Some("Completed".to_string()));
     }

--- a/crates/ralph-core/src/utils.rs
+++ b/crates/ralph-core/src/utils.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn format_elapsed_one_minute() {
-        assert_eq!(format_elapsed(Duration::from_secs(60)), "01:00");
+        assert_eq!(format_elapsed(Duration::from_mins(1)), "01:00");
     }
 
     #[test]

--- a/crates/ralph-core/src/wave_tracker.rs
+++ b/crates/ralph-core/src/wave_tracker.rs
@@ -366,7 +366,7 @@ mod tests {
         tracker.register_wave("w-fresh".into(), 3);
 
         // Just registered — should not be timed out with any reasonable timeout
-        let timed_out = tracker.timed_out_waves(Duration::from_secs(300));
+        let timed_out = tracker.timed_out_waves(Duration::from_mins(5));
         assert!(timed_out.is_empty());
     }
 

--- a/crates/ralph-core/tests/smoke_runner.rs
+++ b/crates/ralph-core/tests/smoke_runner.rs
@@ -624,10 +624,10 @@ Still working..."#;
         let line = make_write_line("Quick output", 0);
         let fixture_path = create_fixture(temp_dir.path(), "quick.jsonl", &line);
 
-        let config = SmokeTestConfig::new(&fixture_path).with_timeout(Duration::from_secs(60));
+        let config = SmokeTestConfig::new(&fixture_path).with_timeout(Duration::from_mins(1));
 
         // Verify config was set
-        assert_eq!(config.timeout, Duration::from_secs(60));
+        assert_eq!(config.timeout, Duration::from_mins(1));
 
         let result = SmokeRunner::run(&config).expect("Should complete within 60s");
         assert!(result.completed_successfully());

--- a/crates/ralph-e2e/src/analyzer.rs
+++ b/crates/ralph-e2e/src/analyzer.rs
@@ -80,7 +80,7 @@ pub struct AnalyzerConfig {
 impl Default for AnalyzerConfig {
     fn default() -> Self {
         Self {
-            timeout: Duration::from_secs(120),
+            timeout: Duration::from_mins(2),
             max_iterations: 1,
             backend: "claude".to_string(),
         }
@@ -733,7 +733,7 @@ mod tests {
         let workspace = PathBuf::from(".e2e-tests");
         let analyzer = MetaRalphAnalyzer::new(workspace.clone());
         assert_eq!(analyzer.workspace(), &workspace);
-        assert_eq!(analyzer.config().timeout, Duration::from_secs(120));
+        assert_eq!(analyzer.config().timeout, Duration::from_mins(2));
         assert_eq!(analyzer.config().max_iterations, 1);
         assert_eq!(analyzer.config().backend, "claude");
     }
@@ -742,12 +742,12 @@ mod tests {
     fn test_analyzer_with_config() {
         let workspace = PathBuf::from(".e2e-tests");
         let config = AnalyzerConfig {
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             max_iterations: 2,
             backend: "kiro".to_string(),
         };
         let analyzer = MetaRalphAnalyzer::with_config(workspace.clone(), config);
-        assert_eq!(analyzer.config().timeout, Duration::from_secs(60));
+        assert_eq!(analyzer.config().timeout, Duration::from_mins(1));
         assert_eq!(analyzer.config().max_iterations, 2);
         assert_eq!(analyzer.config().backend, "kiro");
     }
@@ -804,7 +804,7 @@ mod tests {
     #[test]
     fn test_generate_analyzer_config_custom() {
         let config = AnalyzerConfig {
-            timeout: Duration::from_secs(60),
+            timeout: Duration::from_mins(1),
             max_iterations: 3,
             backend: "kiro".to_string(),
         };

--- a/crates/ralph-e2e/src/backend.rs
+++ b/crates/ralph-e2e/src/backend.rs
@@ -35,8 +35,8 @@ impl Backend {
     /// Returns the default timeout for this backend.
     pub fn default_timeout(&self) -> Duration {
         match self {
-            Backend::Claude => Duration::from_secs(600), // 10 minutes - Claude iterations can take 60-120s each
-            Backend::Kiro | Backend::OpenCode => Duration::from_secs(300), // 5 minutes
+            Backend::Claude => Duration::from_mins(10), // 10 minutes - Claude iterations can take 60-120s each
+            Backend::Kiro | Backend::OpenCode => Duration::from_mins(5), // 5 minutes
         }
     }
 

--- a/crates/ralph-e2e/src/executor.rs
+++ b/crates/ralph-e2e/src/executor.rs
@@ -59,7 +59,7 @@ impl ScenarioConfig {
             config_file: PathBuf::from("ralph.yml"),
             prompt: PromptSource::Inline(prompt.into()),
             max_iterations: 1,
-            timeout: Duration::from_secs(300), // 5 minutes - Claude iterations can take 60-120s
+            timeout: Duration::from_mins(5), // 5 minutes - Claude iterations can take 60-120s
             extra_args: vec![],
         }
     }
@@ -535,7 +535,7 @@ mod tests {
         assert_eq!(config.config_file, PathBuf::from("ralph.yml"));
         assert!(matches!(config.prompt, PromptSource::Inline(p) if p == "Say hello"));
         assert_eq!(config.max_iterations, 1);
-        assert_eq!(config.timeout, Duration::from_secs(300));
+        assert_eq!(config.timeout, Duration::from_mins(5));
         assert!(config.extra_args.is_empty());
     }
 

--- a/crates/ralph-e2e/src/hooks_bdd.rs
+++ b/crates/ralph-e2e/src/hooks_bdd.rs
@@ -914,7 +914,7 @@ fn assert_runtime_integration_coverage(
             &workspace_root,
             Path::new("cargo"),
             &args,
-            Duration::from_secs(180),
+            Duration::from_mins(3),
         )?;
 
         if artifact.timed_out {

--- a/crates/ralph-e2e/src/scenarios/incremental.rs
+++ b/crates/ralph-e2e/src/scenarios/incremental.rs
@@ -525,7 +525,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase1_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_secs(120),
+            timeout: std::time::Duration::from_mins(2),
             extra_args: vec![],
         };
 
@@ -551,7 +551,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase2_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_secs(120),
+            timeout: std::time::Duration::from_mins(2),
             extra_args: vec![],
         };
 
@@ -578,7 +578,7 @@ IMPORTANT: Use Bash for ralph commands and Write/Edit for files."#;
             config_file: "ralph.yml".into(),
             prompt: PromptSource::Inline(phase3_prompt.to_string()),
             max_iterations: 3,
-            timeout: std::time::Duration::from_secs(120),
+            timeout: std::time::Duration::from_mins(2),
             extra_args: vec![],
         };
 

--- a/crates/ralph-tui/src/widgets/header.rs
+++ b/crates/ralph-tui/src/widgets/header.rs
@@ -839,7 +839,7 @@ mod tests {
         let event = Event::new("task.start", "");
         state.update(&event);
         if let Some(iteration) = state.iterations.get_mut(0) {
-            iteration.elapsed = Some(Duration::from_secs(300));
+            iteration.elapsed = Some(Duration::from_mins(5));
         }
 
         let text = render_to_string(&state);
@@ -984,7 +984,7 @@ mod tests {
         );
         // Mark iteration as finished (elapsed is set)
         if let Some(iteration) = state.iterations.first_mut() {
-            iteration.elapsed = Some(Duration::from_secs(60));
+            iteration.elapsed = Some(Duration::from_mins(1));
         }
         // current_view = 0 (still viewing the finished iteration, following latest)
         state.current_view = 0;


### PR DESCRIPTION
## Why

CI uses rust stable, which just rolled to 1.95. 1.95 added `clippy::duration_suboptimal_units` to the pedantic group, and the workspace's CI gate runs `cargo clippy --all-targets --all-features -- -D warnings`. Result: **every open PR's Test check is red**, including main itself (latest [CI run](https://github.com/mikeyobrien/ralph-orchestrator/actions) on `3c01301` fails with the same 15 errors).

## What

Mechanical rewrite via `cargo clippy --fix`:

| old | new |
|---|---|
| `Duration::from_secs(60)`   | `Duration::from_mins(1)` |
| `Duration::from_secs(120)`  | `Duration::from_mins(2)` |
| `Duration::from_secs(180)`  | `Duration::from_mins(3)` |
| `Duration::from_secs(300)`  | `Duration::from_mins(5)` |
| `Duration::from_secs(3600)` | `Duration::from_hours(1)` |

15 call sites across `ralph-api`, `ralph-cli`, `ralph-core`, `ralph-e2e`, `ralph-tui`. Semantics identical — `Duration::from_mins` and `from_hours` are stable as of 1.95.

Also collapses one nested `if let Ok(x) = ... { if !x.is_empty() { ... } }` in `ralph-cli/src/wave.rs` into a `let-chain` — collateral from `cargo clippy --fix`, same semantics. Reformatted with rust 1.95 rustfmt.

## Test plan

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — **clean on stable 1.95**
- `cargo fmt --all -- --check` — clean
- `cargo test --workspace` — tests that passed on main still pass

Two pre-existing failures remain and **reproduce on clean main** (not introduced here):
- `ralph_cli::loop_runner::tests::test_process_pending_merges_redirects_subprocess_output_to_log_file` — documented flaky (known race, passes standalone)
- `ralph_cli integration_hooks_validate::test_hooks_validate_json_success_report_and_exit_code` — fails on main too (`Number(3) != 1`)

## Unblocks

- #313 (kiro-acp plan support)
- Any other PR whose Test gate is red on this lint.