### PR TITLE
feat(cli): unify preset mechanism under `-H <name>` (YAML + TOML)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2850,6 +2850,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3550,6 +3551,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4328,6 +4338,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -5267,6 +5318,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ rmcp = { version = "1.1.0", default-features = false, features = ["server", "cli
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+toml = "0.8"
 
 # CLI parsing
 clap = { version = "4", features = ["derive", "std", "cargo"] }

--- a/crates/ralph-cli/src/hats.rs
+++ b/crates/ralph-cli/src/hats.rs
@@ -9,14 +9,15 @@
 use crate::backend_support;
 use crate::display::colors;
 use crate::preflight;
-use crate::{ConfigSource, HatsSource};
+use crate::{ConfigSource, HatsSource, is_autoloop_preset_dir};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use indicatif::{ProgressBar, ProgressStyle};
 use ralph_adapters::{CliBackend, detect_backend_default};
 use ralph_core::{HatRegistry, RalphConfig, truncate_with_ellipsis};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -48,6 +49,21 @@ pub enum HatsCommands {
     },
     /// Show detailed configuration for a specific hat
     Show(ShowArgs),
+    /// List autoloop preset directories discoverable on this system.
+    ///
+    /// Walks the same resolver paths used by `-H autoloop:<name>`:
+    ///   1. `./presets/<name>/`
+    ///   2. `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/`
+    ///   3. `$HOME/.config/autoloop/presets/<name>/`
+    ///   4. `$AUTOLOOP_PRESETS_DIR/<name>/`
+    ///
+    /// A directory counts as a preset if it contains both `autoloops.toml`
+    /// and `topology.toml`.
+    ListPresets {
+        /// Output format (table, json)
+        #[arg(long, default_value = "table")]
+        format: ListFormat,
+    },
 }
 
 #[derive(ValueEnum, Clone, Debug, Default)]
@@ -83,12 +99,24 @@ pub async fn execute(
     args: HatsArgs,
     use_colors: bool,
 ) -> Result<()> {
+    let mut stdout = std::io::stdout();
+
+    // ListPresets doesn't need a loaded config; it's pure filesystem discovery.
+    // Short-circuit before preflight so users can run it outside any ralph
+    // workspace (matches `kubectl config get-contexts` style ergonomics).
+    if let Some(HatsCommands::ListPresets { format }) = &args.command {
+        let presets = discover_autoloop_presets();
+        return match format {
+            ListFormat::Table => list_presets_table(&mut stdout, &presets, use_colors),
+            ListFormat::Json => list_presets_json(&mut stdout, &presets),
+        };
+    }
+
     let config = preflight::load_config_for_preflight(config_sources, hats_source)
         .await
         .context("Failed to load config for hats")?;
 
     let registry = HatRegistry::from_config(&config);
-    let mut stdout = std::io::stdout();
 
     match args.command {
         None
@@ -105,7 +133,162 @@ pub async fn execute(
         Some(HatsCommands::Graph { format, backend }) => {
             graph_hats(&mut stdout, &config, &registry, format, backend.as_deref())
         }
+        Some(HatsCommands::ListPresets { .. }) => unreachable!("handled above"),
     }
+}
+
+/// A single discovered autoloop preset.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DiscoveredPreset {
+    /// Preset name (directory basename).
+    pub name: String,
+    /// Absolute path to the preset directory.
+    pub path: PathBuf,
+    /// Which resolver path class matched (`project`, `xdg`, `home`, `env`).
+    pub source: &'static str,
+    /// One-line description if discoverable (README.md first non-empty line, or autoloops.toml comment).
+    pub description: Option<String>,
+}
+
+/// Walk the autoloop preset resolver paths and return every preset found.
+///
+/// Ordering: project-local first, then XDG, then HOME/.config, then
+/// `$AUTOLOOP_PRESETS_DIR`. If the same preset name appears in multiple
+/// paths, the first one wins (matches `resolve_autoloop_preset_dir`).
+pub(crate) fn discover_autoloop_presets() -> Vec<DiscoveredPreset> {
+    let mut roots: Vec<(&'static str, PathBuf)> = Vec::new();
+
+    roots.push(("project", PathBuf::from("presets")));
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        roots.push(("xdg", PathBuf::from(xdg).join("ralph/autoloop-presets")));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        roots.push((
+            "home",
+            PathBuf::from(home).join(".config/autoloop/presets"),
+        ));
+    }
+    if let Ok(explicit) = std::env::var("AUTOLOOP_PRESETS_DIR") {
+        roots.push(("env", PathBuf::from(explicit)));
+    }
+
+    discover_in_roots(&roots)
+}
+
+/// Inner discovery that takes explicit roots so tests can exercise the logic
+/// without mutating process-wide environment variables (crate forbids unsafe,
+/// which `std::env::set_var` requires).
+fn discover_in_roots(roots: &[(&'static str, PathBuf)]) -> Vec<DiscoveredPreset> {
+    // Preserve first-wins semantics by keying on name and skipping duplicates.
+    let mut by_name: BTreeMap<String, DiscoveredPreset> = BTreeMap::new();
+    for (source, root) in roots {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !is_autoloop_preset_dir(&path) {
+                continue;
+            }
+            let Some(name) = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_string())
+            else {
+                continue;
+            };
+            // Skip if already discovered in an earlier root (first-wins).
+            if by_name.contains_key(&name) {
+                continue;
+            }
+            let description = read_preset_description(&path);
+            by_name.insert(
+                name.clone(),
+                DiscoveredPreset {
+                    name,
+                    path,
+                    source,
+                    description,
+                },
+            );
+        }
+    }
+    by_name.into_values().collect()
+}
+
+/// Read a one-line description from `README.md` (first non-empty, non-heading
+/// line) or fall back to the first `# ` comment line in `autoloops.toml`.
+fn read_preset_description(preset_dir: &Path) -> Option<String> {
+    let readme = preset_dir.join("README.md");
+    if let Ok(contents) = std::fs::read_to_string(&readme) {
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            // Skip markdown headings, keep first prose line.
+            if trimmed.starts_with('#') {
+                continue;
+            }
+            return Some(truncate_with_ellipsis(trimmed, 80).to_string());
+        }
+        // Fall through to title if no prose line.
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("# ") {
+                return Some(truncate_with_ellipsis(rest.trim(), 80).to_string());
+            }
+        }
+    }
+
+    let autoloops = preset_dir.join("autoloops.toml");
+    if let Ok(contents) = std::fs::read_to_string(&autoloops) {
+        for line in contents.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("# ") {
+                let rest = rest.trim();
+                if !rest.is_empty() {
+                    return Some(truncate_with_ellipsis(rest, 80).to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn list_presets_table<W: Write>(
+    writer: &mut W,
+    presets: &[DiscoveredPreset],
+    _use_colors: bool,
+) -> Result<()> {
+    if presets.is_empty() {
+        writeln!(
+            writer,
+            "No autoloop presets found. Searched:\n  - ./presets/\n  - $XDG_CONFIG_HOME/ralph/autoloop-presets/\n  - $HOME/.config/autoloop/presets/\n  - $AUTOLOOP_PRESETS_DIR/\n\nTo make autoloop presets discoverable, symlink them into one of the above. Example:\n  mkdir -p ~/.config/autoloop/presets\n  ln -s /path/to/autoloop/packages/presets/presets/autocode ~/.config/autoloop/presets/"
+        )?;
+        return Ok(());
+    }
+
+    writeln!(writer, "{:<22} {:<8} DESCRIPTION", "PRESET", "SOURCE")?;
+    writeln!(writer, "{}", "-".repeat(80))?;
+
+    for p in presets {
+        let desc = p.description.as_deref().unwrap_or("-");
+        let desc = truncate_with_ellipsis(desc, 48);
+        writeln!(writer, "{:<22} {:<8} {}", p.name, p.source, desc)?;
+    }
+    writeln!(writer)?;
+    writeln!(
+        writer,
+        "Run a preset with:  ralph run -H autoloop:<PRESET> -P PROMPT.md"
+    )?;
+    Ok(())
+}
+
+fn list_presets_json<W: Write>(writer: &mut W, presets: &[DiscoveredPreset]) -> Result<()> {
+    serde_json::to_writer_pretty(&mut *writer, presets)?;
+    writeln!(writer)?;
+    Ok(())
 }
 
 fn list_hats_json<W: Write>(writer: &mut W, registry: &HatRegistry) -> Result<()> {
@@ -1011,5 +1194,123 @@ mod tests {
         let result = resolve_backend(None, &config);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "gemini");
+    }
+
+    /// Write a minimal autoloop preset skeleton under `parent/<name>/`.
+    fn write_preset_skeleton(parent: &std::path::Path, name: &str, readme: Option<&str>) {
+        let dir = parent.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("autoloops.toml"), "# test preset\n").unwrap();
+        std::fs::write(dir.join("topology.toml"), "name = \"test\"\n").unwrap();
+        if let Some(body) = readme {
+            std::fs::write(dir.join("README.md"), body).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_discover_in_roots_finds_presets_and_skips_nonpresets() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_preset_skeleton(tmp.path(), "autotest-fixture", Some("Fixture preset for tests.\n"));
+        write_preset_skeleton(tmp.path(), "another-fixture", None);
+        // Non-preset dir should be skipped.
+        std::fs::create_dir_all(tmp.path().join("not-a-preset")).unwrap();
+
+        let roots: Vec<(&'static str, PathBuf)> = vec![("env", tmp.path().to_path_buf())];
+        let presets = discover_in_roots(&roots);
+        let names: Vec<_> = presets.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"autotest-fixture"), "got {:?}", names);
+        assert!(names.contains(&"another-fixture"), "got {:?}", names);
+        assert!(!names.contains(&"not-a-preset"), "got {:?}", names);
+
+        let with_readme = presets
+            .iter()
+            .find(|p| p.name == "autotest-fixture")
+            .unwrap();
+        assert_eq!(with_readme.source, "env");
+        assert_eq!(
+            with_readme.description.as_deref(),
+            Some("Fixture preset for tests.")
+        );
+
+        let without_readme = presets
+            .iter()
+            .find(|p| p.name == "another-fixture")
+            .unwrap();
+        // Fixture's autoloops.toml starts with `# test preset` — description should
+        // fall back to that when there's no README.md.
+        assert_eq!(without_readme.description.as_deref(), Some("test preset"));
+    }
+
+    #[test]
+    fn test_discover_in_roots_respects_first_wins_across_roots() {
+        let root_a = tempfile::tempdir().unwrap();
+        let root_b = tempfile::tempdir().unwrap();
+        write_preset_skeleton(root_a.path(), "shared", Some("From root A.\n"));
+        write_preset_skeleton(root_b.path(), "shared", Some("From root B.\n"));
+        write_preset_skeleton(root_b.path(), "b-only", None);
+
+        let roots: Vec<(&'static str, PathBuf)> = vec![
+            ("project", root_a.path().to_path_buf()),
+            ("env", root_b.path().to_path_buf()),
+        ];
+        let presets = discover_in_roots(&roots);
+        let shared = presets.iter().find(|p| p.name == "shared").unwrap();
+        assert_eq!(shared.source, "project", "first-wins should pick root A");
+        assert_eq!(shared.description.as_deref(), Some("From root A."));
+        assert!(presets.iter().any(|p| p.name == "b-only"));
+    }
+
+    #[test]
+    fn test_discover_in_roots_missing_roots_are_ignored() {
+        let roots: Vec<(&'static str, PathBuf)> = vec![
+            ("project", PathBuf::from("/nonexistent/ralph/presets-a")),
+            ("env", PathBuf::from("/nonexistent/ralph/presets-b")),
+        ];
+        let presets = discover_in_roots(&roots);
+        assert!(presets.is_empty());
+    }
+
+    #[test]
+    fn test_list_presets_table_empty_prints_search_paths() {
+        let mut buf = Vec::new();
+        list_presets_table(&mut buf, &[], false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("No autoloop presets found"));
+        assert!(output.contains("./presets/"));
+        assert!(output.contains("XDG_CONFIG_HOME"));
+        assert!(output.contains("AUTOLOOP_PRESETS_DIR"));
+    }
+
+    #[test]
+    fn test_list_presets_json_is_valid_array() {
+        let sample = vec![DiscoveredPreset {
+            name: "demo".into(),
+            path: PathBuf::from("/tmp/demo"),
+            source: "env",
+            description: Some("demo preset".into()),
+        }];
+        let mut buf = Vec::new();
+        list_presets_json(&mut buf, &sample).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&buf).unwrap();
+        assert!(parsed.is_array());
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["name"], "demo");
+        assert_eq!(arr[0]["source"], "env");
+    }
+
+    #[test]
+    fn test_read_preset_description_falls_back_to_toml_comment() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("p");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("autoloops.toml"),
+            "# This preset does a thing.\nevent_loop.max_iterations = 10\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("topology.toml"), "name = \"p\"\n").unwrap();
+        let desc = read_preset_description(&dir);
+        assert_eq!(desc.as_deref(), Some("This preset does a thing."));
     }
 }

--- a/crates/ralph-cli/src/hats.rs
+++ b/crates/ralph-cli/src/hats.rs
@@ -9,7 +9,7 @@
 use crate::backend_support;
 use crate::display::colors;
 use crate::preflight;
-use crate::{ConfigSource, HatsSource, is_autoloop_preset_dir};
+use crate::{ConfigSource, HatsSource, is_toml_preset_dir};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -49,16 +49,18 @@ pub enum HatsCommands {
     },
     /// Show detailed configuration for a specific hat
     Show(ShowArgs),
-    /// List autoloop preset directories discoverable on this system.
+    /// List all presets discoverable on this system (both YAML and TOML formats).
     ///
-    /// Walks the same resolver paths used by `-H autoloop:<name>`:
+    /// Walks the same resolver paths used by `-H <name>`:
     ///   1. `./presets/<name>/`
-    ///   2. `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/`
-    ///   3. `$HOME/.config/autoloop/presets/<name>/`
-    ///   4. `$AUTOLOOP_PRESETS_DIR/<name>/`
+    ///   2. `$XDG_CONFIG_HOME/ralph/presets/<name>/`
+    ///   3. `$HOME/.config/ralph/presets/<name>/`
+    ///   4. `$HOME/.config/autoloop/presets/<name>/` (shared with autoloop CLI)
+    ///   5. `$RALPH_PRESETS_DIR/<name>/`
+    ///   6. `$AUTOLOOP_PRESETS_DIR/<name>/` (deprecated alias for #5)
     ///
-    /// A directory counts as a preset if it contains both `autoloops.toml`
-    /// and `topology.toml`.
+    /// A preset is either a `.yml`/`.yaml` file (ralph's native shape) or a
+    /// directory containing `autoloops.toml` + `topology.toml` (multi-file TOML shape).
     ListPresets {
         /// Output format (table, json)
         #[arg(long, default_value = "table")]
@@ -105,7 +107,7 @@ pub async fn execute(
     // Short-circuit before preflight so users can run it outside any ralph
     // workspace (matches `kubectl config get-contexts` style ergonomics).
     if let Some(HatsCommands::ListPresets { format }) = &args.command {
-        let presets = discover_autoloop_presets();
+        let presets = discover_presets();
         return match format {
             ListFormat::Table => list_presets_table(&mut stdout, &presets, use_colors),
             ListFormat::Json => list_presets_json(&mut stdout, &presets),
@@ -137,36 +139,69 @@ pub async fn execute(
     }
 }
 
-/// A single discovered autoloop preset.
+/// Preset file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PresetFormat {
+    /// Native ralph shape: a single `.yml` / `.yaml` file.
+    Yaml,
+    /// Multi-file TOML shape: a directory with `autoloops.toml` + `topology.toml`.
+    Toml,
+}
+
+impl PresetFormat {
+    fn label(self) -> &'static str {
+        match self {
+            PresetFormat::Yaml => "yaml",
+            PresetFormat::Toml => "toml",
+        }
+    }
+}
+
+/// A single discovered preset (any format).
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DiscoveredPreset {
-    /// Preset name (directory basename).
+    /// Preset name (file stem for YAML, directory basename for TOML).
     pub name: String,
-    /// Absolute path to the preset directory.
+    /// Absolute path to the preset file or directory.
     pub path: PathBuf,
-    /// Which resolver path class matched (`project`, `xdg`, `home`, `env`).
+    /// Which resolver path class matched (`project`, `xdg`, `home`, `autoloop`, `env`).
     pub source: &'static str,
-    /// One-line description if discoverable (README.md first non-empty line, or autoloops.toml comment).
+    /// Format on disk.
+    pub format: PresetFormat,
+    /// One-line description if discoverable.
     pub description: Option<String>,
 }
 
-/// Walk the autoloop preset resolver paths and return every preset found.
+/// Walk the preset resolver paths and return every preset found.
 ///
-/// Ordering: project-local first, then XDG, then HOME/.config, then
-/// `$AUTOLOOP_PRESETS_DIR`. If the same preset name appears in multiple
-/// paths, the first one wins (matches `resolve_autoloop_preset_dir`).
-pub(crate) fn discover_autoloop_presets() -> Vec<DiscoveredPreset> {
+/// Covers BOTH preset formats:
+/// - YAML single-file presets (`<root>/*.yml`)
+/// - TOML multi-file preset directories (`<root>/<name>/autoloops.toml + topology.toml`)
+///
+/// Roots, in order:
+/// 1. `./presets/` (project-local)
+/// 2. `$XDG_CONFIG_HOME/ralph/presets/` (user, canonical)
+/// 3. `$HOME/.config/ralph/presets/` (user, fallback for #2)
+/// 4. `$HOME/.config/autoloop/presets/` (shared with autoloop CLI; back-compat)
+/// 5. `$RALPH_PRESETS_DIR/` (explicit override)
+/// 6. `$AUTOLOOP_PRESETS_DIR/` (deprecated alias for #5)
+///
+/// First-wins on name collisions.
+pub(crate) fn discover_presets() -> Vec<DiscoveredPreset> {
     let mut roots: Vec<(&'static str, PathBuf)> = Vec::new();
 
     roots.push(("project", PathBuf::from("presets")));
     if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-        roots.push(("xdg", PathBuf::from(xdg).join("ralph/autoloop-presets")));
+        roots.push(("xdg", PathBuf::from(xdg).join("ralph/presets")));
     }
     if let Ok(home) = std::env::var("HOME") {
-        roots.push((
-            "home",
-            PathBuf::from(home).join(".config/autoloop/presets"),
-        ));
+        let home = PathBuf::from(home);
+        roots.push(("home", home.join(".config/ralph/presets")));
+        roots.push(("autoloop", home.join(".config/autoloop/presets")));
+    }
+    if let Ok(explicit) = std::env::var("RALPH_PRESETS_DIR") {
+        roots.push(("env", PathBuf::from(explicit)));
     }
     if let Ok(explicit) = std::env::var("AUTOLOOP_PRESETS_DIR") {
         roots.push(("env", PathBuf::from(explicit)));
@@ -187,60 +222,61 @@ fn discover_in_roots(roots: &[(&'static str, PathBuf)]) -> Vec<DiscoveredPreset>
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if !is_autoloop_preset_dir(&path) {
-                continue;
-            }
-            let Some(name) = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .map(|s| s.to_string())
-            else {
+            let Some(discovered) = classify_entry(&path, source) else {
                 continue;
             };
             // Skip if already discovered in an earlier root (first-wins).
-            if by_name.contains_key(&name) {
+            if by_name.contains_key(&discovered.name) {
                 continue;
             }
-            let description = read_preset_description(&path);
-            by_name.insert(
-                name.clone(),
-                DiscoveredPreset {
-                    name,
-                    path,
-                    source,
-                    description,
-                },
-            );
+            by_name.insert(discovered.name.clone(), discovered);
         }
     }
     by_name.into_values().collect()
 }
 
-/// Read a one-line description from `README.md` (first non-empty, non-heading
-/// line) or fall back to the first `# ` comment line in `autoloops.toml`.
-fn read_preset_description(preset_dir: &Path) -> Option<String> {
-    let readme = preset_dir.join("README.md");
-    if let Ok(contents) = std::fs::read_to_string(&readme) {
-        for line in contents.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            // Skip markdown headings, keep first prose line.
-            if trimmed.starts_with('#') {
-                continue;
-            }
-            return Some(truncate_with_ellipsis(trimmed, 80).to_string());
-        }
-        // Fall through to title if no prose line.
-        for line in contents.lines() {
-            let trimmed = line.trim();
-            if let Some(rest) = trimmed.strip_prefix("# ") {
-                return Some(truncate_with_ellipsis(rest.trim(), 80).to_string());
-            }
-        }
+/// Classify a filesystem entry as a YAML preset, TOML preset dir, or neither.
+fn classify_entry(path: &Path, source: &'static str) -> Option<DiscoveredPreset> {
+    if is_toml_preset_dir(path) {
+        let name = path.file_name()?.to_str()?.to_string();
+        return Some(DiscoveredPreset {
+            name,
+            path: path.to_path_buf(),
+            source,
+            format: PresetFormat::Toml,
+            description: read_toml_preset_description(path),
+        });
     }
+    if is_yaml_preset_file(path) {
+        let name = path.file_stem()?.to_str()?.to_string();
+        return Some(DiscoveredPreset {
+            name,
+            path: path.to_path_buf(),
+            source,
+            format: PresetFormat::Yaml,
+            description: read_yaml_preset_description(path),
+        });
+    }
+    None
+}
 
+/// True if `path` is a readable `.yml` / `.yaml` file.
+fn is_yaml_preset_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("yml" | "yaml")
+    )
+}
+
+/// Read a one-line description from a TOML preset directory: `README.md`
+/// first prose line, falling back to the first `#` comment in `autoloops.toml`.
+fn read_toml_preset_description(preset_dir: &Path) -> Option<String> {
+    if let Some(desc) = first_readme_prose_line(&preset_dir.join("README.md")) {
+        return Some(desc);
+    }
     let autoloops = preset_dir.join("autoloops.toml");
     if let Ok(contents) = std::fs::read_to_string(&autoloops) {
         for line in contents.lines() {
@@ -248,9 +284,51 @@ fn read_preset_description(preset_dir: &Path) -> Option<String> {
             if let Some(rest) = trimmed.strip_prefix("# ") {
                 let rest = rest.trim();
                 if !rest.is_empty() {
-                    return Some(truncate_with_ellipsis(rest, 80).to_string());
+                    return Some(truncate_with_ellipsis(rest, 80));
                 }
             }
+        }
+    }
+    None
+}
+
+/// Read a one-line description from a YAML preset: first `#` comment line
+/// in the file (skipping shebang / blank / ABOUTME preamble).
+fn read_yaml_preset_description(path: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(path).ok()?;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            let rest = rest.trim();
+            if rest.is_empty() || rest.eq_ignore_ascii_case("ralph.yml") {
+                continue;
+            }
+            return Some(truncate_with_ellipsis(rest, 80));
+        }
+        // First non-comment line means no header block — give up.
+        return None;
+    }
+    None
+}
+
+/// Return the first non-empty, non-heading line of `README.md`, or the first
+/// heading's text if no prose line exists.
+fn first_readme_prose_line(readme: &Path) -> Option<String> {
+    let contents = std::fs::read_to_string(readme).ok()?;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        return Some(truncate_with_ellipsis(trimmed, 80));
+    }
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("# ") {
+            return Some(truncate_with_ellipsis(rest.trim(), 80));
         }
     }
     None
@@ -264,23 +342,34 @@ fn list_presets_table<W: Write>(
     if presets.is_empty() {
         writeln!(
             writer,
-            "No autoloop presets found. Searched:\n  - ./presets/\n  - $XDG_CONFIG_HOME/ralph/autoloop-presets/\n  - $HOME/.config/autoloop/presets/\n  - $AUTOLOOP_PRESETS_DIR/\n\nTo make autoloop presets discoverable, symlink them into one of the above. Example:\n  mkdir -p ~/.config/autoloop/presets\n  ln -s /path/to/autoloop/packages/presets/presets/autocode ~/.config/autoloop/presets/"
+            "No presets found. Searched:\n  - ./presets/\n  - $XDG_CONFIG_HOME/ralph/presets/\n  - $HOME/.config/ralph/presets/\n  - $HOME/.config/autoloop/presets/\n  - $RALPH_PRESETS_DIR/\n  - $AUTOLOOP_PRESETS_DIR/ (deprecated)\n\nDrop a YAML preset or TOML-dir preset in any of the above. Example:\n  mkdir -p ~/.config/ralph/presets\n  ln -s /path/to/autoloop/packages/presets/presets/autocode ~/.config/ralph/presets/\n\nOr set:  export RALPH_PRESETS_DIR=/path/to/your/presets"
         )?;
         return Ok(());
     }
 
-    writeln!(writer, "{:<22} {:<8} DESCRIPTION", "PRESET", "SOURCE")?;
+    writeln!(
+        writer,
+        "{:<22} {:<6} {:<9} DESCRIPTION",
+        "PRESET", "FORMAT", "SOURCE"
+    )?;
     writeln!(writer, "{}", "-".repeat(80))?;
 
     for p in presets {
         let desc = p.description.as_deref().unwrap_or("-");
-        let desc = truncate_with_ellipsis(desc, 48);
-        writeln!(writer, "{:<22} {:<8} {}", p.name, p.source, desc)?;
+        let desc = truncate_with_ellipsis(desc, 40);
+        writeln!(
+            writer,
+            "{:<22} {:<6} {:<9} {}",
+            p.name,
+            p.format.label(),
+            p.source,
+            desc
+        )?;
     }
     writeln!(writer)?;
     writeln!(
         writer,
-        "Run a preset with:  ralph run -H autoloop:<PRESET> -P PROMPT.md"
+        "Run a preset with:  ralph run -H <PRESET> -P PROMPT.md"
     )?;
     Ok(())
 }
@@ -1210,7 +1299,11 @@ mod tests {
     #[test]
     fn test_discover_in_roots_finds_presets_and_skips_nonpresets() {
         let tmp = tempfile::tempdir().unwrap();
-        write_preset_skeleton(tmp.path(), "autotest-fixture", Some("Fixture preset for tests.\n"));
+        write_preset_skeleton(
+            tmp.path(),
+            "autotest-fixture",
+            Some("Fixture preset for tests.\n"),
+        );
         write_preset_skeleton(tmp.path(), "another-fixture", None);
         // Non-preset dir should be skipped.
         std::fs::create_dir_all(tmp.path().join("not-a-preset")).unwrap();
@@ -1275,9 +1368,10 @@ mod tests {
         let mut buf = Vec::new();
         list_presets_table(&mut buf, &[], false).unwrap();
         let output = String::from_utf8(buf).unwrap();
-        assert!(output.contains("No autoloop presets found"));
+        assert!(output.contains("No presets found"));
         assert!(output.contains("./presets/"));
         assert!(output.contains("XDG_CONFIG_HOME"));
+        assert!(output.contains("RALPH_PRESETS_DIR"));
         assert!(output.contains("AUTOLOOP_PRESETS_DIR"));
     }
 
@@ -1287,6 +1381,7 @@ mod tests {
             name: "demo".into(),
             path: PathBuf::from("/tmp/demo"),
             source: "env",
+            format: PresetFormat::Toml,
             description: Some("demo preset".into()),
         }];
         let mut buf = Vec::new();
@@ -1297,10 +1392,11 @@ mod tests {
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["name"], "demo");
         assert_eq!(arr[0]["source"], "env");
+        assert_eq!(arr[0]["format"], "toml");
     }
 
     #[test]
-    fn test_read_preset_description_falls_back_to_toml_comment() {
+    fn test_read_toml_preset_description_falls_back_to_toml_comment() {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("p");
         std::fs::create_dir_all(&dir).unwrap();
@@ -1310,7 +1406,38 @@ mod tests {
         )
         .unwrap();
         std::fs::write(dir.join("topology.toml"), "name = \"p\"\n").unwrap();
-        let desc = read_preset_description(&dir);
+        let desc = read_toml_preset_description(&dir);
         assert_eq!(desc.as_deref(), Some("This preset does a thing."));
+    }
+
+    #[test]
+    fn test_discover_in_roots_finds_yaml_presets_alongside_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        // TOML preset dir
+        write_preset_skeleton(tmp.path(), "toml-preset", Some("A TOML preset.\n"));
+        // YAML file preset
+        std::fs::write(
+            tmp.path().join("yaml-preset.yml"),
+            "# A YAML preset for tests.\nhats: {}\n",
+        )
+        .unwrap();
+        // Random file that isn't a preset
+        std::fs::write(tmp.path().join("random.txt"), "ignore me").unwrap();
+
+        let roots: Vec<(&'static str, PathBuf)> = vec![("env", tmp.path().to_path_buf())];
+        let presets = discover_in_roots(&roots);
+
+        let toml_p = presets.iter().find(|p| p.name == "toml-preset").unwrap();
+        assert_eq!(toml_p.format, PresetFormat::Toml);
+        assert_eq!(toml_p.description.as_deref(), Some("A TOML preset."));
+
+        let yaml_p = presets.iter().find(|p| p.name == "yaml-preset").unwrap();
+        assert_eq!(yaml_p.format, PresetFormat::Yaml);
+        assert_eq!(
+            yaml_p.description.as_deref(),
+            Some("A YAML preset for tests.")
+        );
+
+        assert!(!presets.iter().any(|p| p.name == "random"));
     }
 }

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -357,12 +357,20 @@ impl ConfigSource {
 /// Source for hat collection configuration.
 #[derive(Debug, Clone)]
 pub enum HatsSource {
-    /// Local file path
+    /// Local file path (YAML Ralph preset)
     File(PathBuf),
     /// Builtin hat collection name (e.g., "builtin:code-assist")
     Builtin(String),
     /// Remote URL (e.g., "http://example.com/hats.yml")
     Remote(String),
+    /// Autoloop multi-file preset directory.
+    ///
+    /// Source shape matches [@mobrienv/autoloop](https://github.com/mobrienv/autoloop)
+    /// presets: a directory containing `autoloops.toml`, `topology.toml`,
+    /// optional `harness.md`, and `roles/*.md`. Triggered by `-H autoloop:<name>`
+    /// (resolves via `resolve_autoloop_preset_dir`) or by `-H <path>` where
+    /// `<path>` is a directory with those TOML files.
+    AutoloopDir(PathBuf),
 }
 
 impl HatsSource {
@@ -370,10 +378,22 @@ impl HatsSource {
     fn parse(s: &str) -> Self {
         if let Some(name) = s.strip_prefix("builtin:") {
             HatsSource::Builtin(name.to_string())
+        } else if let Some(name) = s.strip_prefix("autoloop:") {
+            match resolve_autoloop_preset_dir(name) {
+                Some(path) => HatsSource::AutoloopDir(path),
+                // Unresolved names surface as File so downstream IO errors name
+                // the unresolved string cleanly instead of a cryptic parse crash.
+                None => HatsSource::File(PathBuf::from(format!("autoloop:{name}"))),
+            }
         } else if s.starts_with("http://") || s.starts_with("https://") {
             HatsSource::Remote(s.to_string())
         } else {
-            HatsSource::File(PathBuf::from(s))
+            let path = PathBuf::from(s);
+            if is_autoloop_preset_dir(&path) {
+                HatsSource::AutoloopDir(path)
+            } else {
+                HatsSource::File(path)
+            }
         }
     }
 
@@ -383,8 +403,48 @@ impl HatsSource {
             HatsSource::File(path) => path.display().to_string(),
             HatsSource::Builtin(name) => format!("builtin:{}", name),
             HatsSource::Remote(url) => url.clone(),
+            HatsSource::AutoloopDir(path) => format!("autoloop:{}", path.display()),
         }
     }
+}
+
+/// Returns true if `path` is a directory matching the autoloop preset shape.
+pub(crate) fn is_autoloop_preset_dir(path: &Path) -> bool {
+    path.is_dir()
+        && path.join("autoloops.toml").is_file()
+        && path.join("topology.toml").is_file()
+}
+
+/// Search for an autoloop preset dir named `name`.
+///
+/// Resolution order, first hit wins:
+/// 1. `./presets/<name>/` (project-local)
+/// 2. `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/` (user)
+/// 3. `$HOME/.config/autoloop/presets/<name>/` (shared with autoloop itself)
+/// 4. `$AUTOLOOP_PRESETS_DIR/<name>/` (explicit override)
+///
+/// Returns `None` if no candidate directory exists and matches the preset
+/// shape.
+pub(crate) fn resolve_autoloop_preset_dir(name: &str) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    candidates.push(PathBuf::from("presets").join(name));
+
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        candidates.push(PathBuf::from(xdg).join("ralph/autoloop-presets").join(name));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        candidates.push(
+            PathBuf::from(home)
+                .join(".config/autoloop/presets")
+                .join(name),
+        );
+    }
+    if let Ok(explicit) = std::env::var("AUTOLOOP_PRESETS_DIR") {
+        candidates.push(PathBuf::from(explicit).join(name));
+    }
+
+    candidates.into_iter().find(|p| is_autoloop_preset_dir(p))
 }
 
 /// Known core fields that can be overridden via CLI.

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -367,84 +367,101 @@ pub enum HatsSource {
     ///
     /// Source shape matches [@mobrienv/autoloop](https://github.com/mobrienv/autoloop)
     /// presets: a directory containing `autoloops.toml`, `topology.toml`,
-    /// optional `harness.md`, and `roles/*.md`. Triggered by `-H autoloop:<name>`
-    /// (resolves via `resolve_autoloop_preset_dir`) or by `-H <path>` where
-    /// `<path>` is a directory with those TOML files.
-    AutoloopDir(PathBuf),
+    /// Multi-file TOML preset directory.
+    ///
+    /// Source shape: a directory containing `autoloops.toml`, `topology.toml`,
+    /// optional `harness.md`, and `roles/*.md`. Originally the native shape of
+    /// [@mobrienv/autoloop](https://github.com/mobrienv/autoloop); ralph now
+    /// treats it as a first-class preset format. Triggered by `-H <name>`
+    /// (via [`resolve_preset_dir`]) or by `-H <path>` when the path is a
+    /// directory with those TOML files.
+    PresetDir(PathBuf),
 }
 
 impl HatsSource {
     /// Parse a hats source string into its variant.
+    ///
+    /// Resolution order for a bare `-H <value>`:
+    /// 1. `builtin:<name>` — shipped ralph preset (back-compat, kept).
+    /// 2. `http(s)://...` — remote YAML URL.
+    /// 3. Any path that exists on disk — YAML file or TOML preset dir (auto-detect).
+    /// 4. Bare `<name>` — looked up via [`resolve_preset_dir`]; on miss,
+    ///    surfaced as a `File` so the downstream IO error names it cleanly.
     fn parse(s: &str) -> Self {
         if let Some(name) = s.strip_prefix("builtin:") {
-            HatsSource::Builtin(name.to_string())
-        } else if let Some(name) = s.strip_prefix("autoloop:") {
-            match resolve_autoloop_preset_dir(name) {
-                Some(path) => HatsSource::AutoloopDir(path),
-                // Unresolved names surface as File so downstream IO errors name
-                // the unresolved string cleanly instead of a cryptic parse crash.
-                None => HatsSource::File(PathBuf::from(format!("autoloop:{name}"))),
-            }
-        } else if s.starts_with("http://") || s.starts_with("https://") {
-            HatsSource::Remote(s.to_string())
-        } else {
-            let path = PathBuf::from(s);
-            if is_autoloop_preset_dir(&path) {
-                HatsSource::AutoloopDir(path)
-            } else {
-                HatsSource::File(path)
-            }
+            return HatsSource::Builtin(name.to_string());
         }
+        if s.starts_with("http://") || s.starts_with("https://") {
+            return HatsSource::Remote(s.to_string());
+        }
+        let path = PathBuf::from(s);
+        if path.exists() {
+            if is_toml_preset_dir(&path) {
+                return HatsSource::PresetDir(path);
+            }
+            return HatsSource::File(path);
+        }
+        // Bare name — try preset lookup.
+        if let Some(resolved) = resolve_preset_dir(s) {
+            return HatsSource::PresetDir(resolved);
+        }
+        HatsSource::File(path)
     }
 
     /// Human-readable source label.
+    ///
+    /// The label must be round-trippable through [`HatsSource::parse`] — ralph
+    /// re-spawns subprocesses (e.g. TUI mode) by passing this label back as
+    /// `-H <label>`, which then runs through `parse()` again. Using a bare
+    /// path matches the `File` variant so the auto-detect branch picks up the
+    /// preset shape on reparse.
     pub fn label(&self) -> String {
         match self {
             HatsSource::File(path) => path.display().to_string(),
             HatsSource::Builtin(name) => format!("builtin:{}", name),
             HatsSource::Remote(url) => url.clone(),
-            HatsSource::AutoloopDir(path) => format!("autoloop:{}", path.display()),
+            HatsSource::PresetDir(path) => path.display().to_string(),
         }
     }
 }
 
-/// Returns true if `path` is a directory matching the autoloop preset shape.
-pub(crate) fn is_autoloop_preset_dir(path: &Path) -> bool {
-    path.is_dir()
-        && path.join("autoloops.toml").is_file()
-        && path.join("topology.toml").is_file()
+/// Returns true if `path` is a directory matching the TOML multi-file preset shape.
+pub(crate) fn is_toml_preset_dir(path: &Path) -> bool {
+    path.is_dir() && path.join("autoloops.toml").is_file() && path.join("topology.toml").is_file()
 }
 
-/// Search for an autoloop preset dir named `name`.
+/// Search for a TOML preset dir named `name`.
 ///
 /// Resolution order, first hit wins:
 /// 1. `./presets/<name>/` (project-local)
-/// 2. `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/` (user)
-/// 3. `$HOME/.config/autoloop/presets/<name>/` (shared with autoloop itself)
-/// 4. `$AUTOLOOP_PRESETS_DIR/<name>/` (explicit override)
+/// 2. `$XDG_CONFIG_HOME/ralph/presets/<name>/` (user, canonical)
+/// 3. `$HOME/.config/ralph/presets/<name>/` (user, fallback for #2)
+/// 4. `$HOME/.config/autoloop/presets/<name>/` (shared with autoloop CLI)
+/// 5. `$RALPH_PRESETS_DIR/<name>/` (explicit override)
+/// 6. `$AUTOLOOP_PRESETS_DIR/<name>/` (deprecated alias for #5)
 ///
-/// Returns `None` if no candidate directory exists and matches the preset
-/// shape.
-pub(crate) fn resolve_autoloop_preset_dir(name: &str) -> Option<PathBuf> {
+/// Returns `None` if no candidate directory exists and matches the preset shape.
+pub(crate) fn resolve_preset_dir(name: &str) -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
     candidates.push(PathBuf::from("presets").join(name));
 
     if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
-        candidates.push(PathBuf::from(xdg).join("ralph/autoloop-presets").join(name));
+        candidates.push(PathBuf::from(xdg).join("ralph/presets").join(name));
     }
     if let Ok(home) = std::env::var("HOME") {
-        candidates.push(
-            PathBuf::from(home)
-                .join(".config/autoloop/presets")
-                .join(name),
-        );
+        let home = PathBuf::from(home);
+        candidates.push(home.join(".config/ralph/presets").join(name));
+        candidates.push(home.join(".config/autoloop/presets").join(name));
+    }
+    if let Ok(explicit) = std::env::var("RALPH_PRESETS_DIR") {
+        candidates.push(PathBuf::from(explicit).join(name));
     }
     if let Ok(explicit) = std::env::var("AUTOLOOP_PRESETS_DIR") {
         candidates.push(PathBuf::from(explicit).join(name));
     }
 
-    candidates.into_iter().find(|p| is_autoloop_preset_dir(p))
+    candidates.into_iter().find(|p| is_toml_preset_dir(p))
 }
 
 /// Known core fields that can be overridden via CLI.
@@ -2967,6 +2984,58 @@ mod tests {
                 assert_eq!(path, std::path::PathBuf::from("hats/feature.yml"))
             }
             _ => panic!("Expected File variant"),
+        }
+    }
+
+    /// TUI mode re-spawns ralph via `ralph -H <label>` where `label` is the
+    /// output of [`HatsSource::label`]. That label MUST parse back into an
+    /// equivalent variant — otherwise the subprocess crashes with "Hats file
+    /// not found" on the second parse. Guard every variant here.
+    #[test]
+    fn test_hats_source_label_round_trips_through_parse() {
+        use std::path::PathBuf;
+
+        // Builtin
+        let original = HatsSource::Builtin("code-assist".to_string());
+        let label = original.label();
+        assert_eq!(label, "builtin:code-assist");
+        match HatsSource::parse(&label) {
+            HatsSource::Builtin(name) => assert_eq!(name, "code-assist"),
+            other => panic!("Builtin label didn't round-trip: got {:?}", other),
+        }
+
+        // File
+        let original = HatsSource::File(PathBuf::from("/some/file.yml"));
+        let label = original.label();
+        match HatsSource::parse(&label) {
+            HatsSource::File(path) => assert_eq!(path, PathBuf::from("/some/file.yml")),
+            other => panic!("File label didn't round-trip: got {:?}", other),
+        }
+
+        // Remote
+        let original = HatsSource::Remote("https://example.com/x.yml".to_string());
+        let label = original.label();
+        match HatsSource::parse(&label) {
+            HatsSource::Remote(url) => assert_eq!(url, "https://example.com/x.yml"),
+            other => panic!("Remote label didn't round-trip: got {:?}", other),
+        }
+
+        // PresetDir — label must NOT include a `preset:` prefix (parse only
+        // recognizes `builtin:`). A bare path goes through the existence
+        // check + is_toml_preset_dir auto-detect on reparse.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("autoloops.toml"), "# t\n").unwrap();
+        std::fs::write(tmp.path().join("topology.toml"), "name = \"t\"\n").unwrap();
+        let original = HatsSource::PresetDir(tmp.path().to_path_buf());
+        let label = original.label();
+        assert!(
+            !label.starts_with("preset:"),
+            "PresetDir label must be a bare path for round-trip; got {:?}",
+            label
+        );
+        match HatsSource::parse(&label) {
+            HatsSource::PresetDir(path) => assert_eq!(path, tmp.path().to_path_buf()),
+            other => panic!("PresetDir label didn't round-trip: got {:?}", other),
         }
     }
 

--- a/crates/ralph-cli/src/preflight.rs
+++ b/crates/ralph-cli/src/preflight.rs
@@ -213,14 +213,14 @@ pub(crate) async fn load_config_for_preflight(
             );
         }
 
-        // Autoloop presets carry loop-level policy (max_iterations,
+        // TOML multi-file presets carry loop-level policy (max_iterations,
         // required_events) that the generic hats-overlay allowlist rightly
-        // rejects from user-authored YAML hats files. For `autoloop:` /
-        // autoloop-dir sources we inject those knobs directly into core
-        // BEFORE the generic overlay merge, which still filters
-        // user-editable event_loop keys defensively.
-        if let HatsSource::AutoloopDir(path) = source {
-            apply_autoloop_core_patch(&mut core_value, path)?;
+        // rejects from user-authored YAML hats files. For TOML preset
+        // sources we inject those knobs directly into core BEFORE the
+        // generic overlay merge, which still filters user-editable
+        // event_loop keys defensively.
+        if let HatsSource::PresetDir(path) = source {
+            apply_toml_preset_core_patch(&mut core_value, path)?;
         }
 
         let hats_value = load_hats_value(source).await?;
@@ -370,7 +370,7 @@ async fn load_core_value(
 /// These knobs intentionally bypass [`merge_hats_overlay`]'s allowlist because
 /// they're loop-wide policy sourced from an imported preset, not from a
 /// user-authored hats YAML file.
-fn apply_autoloop_core_patch(core_value: &mut Value, preset_dir: &Path) -> Result<()> {
+fn apply_toml_preset_core_patch(core_value: &mut Value, preset_dir: &Path) -> Result<()> {
     let registry = ralph_core::PresetRegistry::default();
     let overlay = registry.load(preset_dir).with_context(|| {
         format!(
@@ -455,19 +455,20 @@ async fn load_hats_value(source: &HatsSource) -> Result<Value> {
                 config_resolution::parse_yaml_value(preset.content, &format!("builtin:{}", name))?;
             extract_hat_overlay_from_preset(preset_value)
         }
-        HatsSource::AutoloopDir(path) => {
+        HatsSource::PresetDir(path) => {
             if !path.exists() {
                 anyhow::bail!(
-                    "Autoloop preset dir not found: {}. If this was an `autoloop:<name>` \
-                     lookup, check that `./presets/<name>/`, `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/`, \
-                     or `$AUTOLOOP_PRESETS_DIR/<name>/` exists and contains `autoloops.toml` and `topology.toml`.",
+                    "Preset directory not found: {}. For `-H <name>` lookups, ensure the name resolves under \
+                     `./presets/<name>/`, `$XDG_CONFIG_HOME/ralph/presets/<name>/`, `$HOME/.config/ralph/presets/<name>/`, \
+                     `$HOME/.config/autoloop/presets/<name>/`, or `$RALPH_PRESETS_DIR/<name>/` \
+                     and contains `autoloops.toml` and `topology.toml`. Run `ralph hats list-presets` to see what is discoverable.",
                     path.display()
                 );
             }
             let registry = ralph_core::PresetRegistry::default();
             let value = registry
                 .load(path)
-                .with_context(|| format!("Failed to import autoloop preset from {}", path.display()))?;
+                .with_context(|| format!("Failed to import preset from {}", path.display()))?;
             extract_hat_overlay_from_preset(value)
         }
     }

--- a/crates/ralph-cli/src/preflight.rs
+++ b/crates/ralph-cli/src/preflight.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::{ArgAction, Parser, ValueEnum};
 use ralph_core::{CheckResult, CheckStatus, PreflightReport, PreflightRunner, RalphConfig};
 use serde_yaml::{Mapping, Value};
+use std::path::Path;
 use tracing::{info, warn};
 
 use crate::{ConfigSource, HatsSource, config_resolution, presets};
@@ -212,6 +213,16 @@ pub(crate) async fn load_config_for_preflight(
             );
         }
 
+        // Autoloop presets carry loop-level policy (max_iterations,
+        // required_events) that the generic hats-overlay allowlist rightly
+        // rejects from user-authored YAML hats files. For `autoloop:` /
+        // autoloop-dir sources we inject those knobs directly into core
+        // BEFORE the generic overlay merge, which still filters
+        // user-editable event_loop keys defensively.
+        if let HatsSource::AutoloopDir(path) = source {
+            apply_autoloop_core_patch(&mut core_value, path)?;
+        }
+
         let hats_value = load_hats_value(source).await?;
         validate_hats_config_shape(&hats_value, &source.label())?;
         core_value = merge_hats_overlay(core_value, hats_value)?;
@@ -352,6 +363,51 @@ async fn load_core_value(
     Ok((merged, overrides, merged_label))
 }
 
+/// Merge loop-level fields an autoloop preset carries (`event_loop.max_iterations`,
+/// `event_loop.required_events`) directly into `core_value` before the generic
+/// hats overlay merge runs.
+///
+/// These knobs intentionally bypass [`merge_hats_overlay`]'s allowlist because
+/// they're loop-wide policy sourced from an imported preset, not from a
+/// user-authored hats YAML file.
+fn apply_autoloop_core_patch(core_value: &mut Value, preset_dir: &Path) -> Result<()> {
+    let registry = ralph_core::PresetRegistry::default();
+    let overlay = registry.load(preset_dir).with_context(|| {
+        format!(
+            "Failed to import autoloop preset from {}",
+            preset_dir.display()
+        )
+    })?;
+
+    let Some(overlay_map) = overlay.as_mapping() else {
+        return Ok(());
+    };
+    let Some(overlay_el) = mapping_get(overlay_map, "event_loop").and_then(Value::as_mapping)
+    else {
+        return Ok(());
+    };
+
+    let core_map = core_value
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow::anyhow!("Core config must be a YAML mapping"))?;
+
+    let mut core_el_value = mapping_get(core_map, "event_loop")
+        .cloned()
+        .unwrap_or_else(|| Value::Mapping(Mapping::new()));
+    let core_el_map = core_el_value
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow::anyhow!("core.event_loop must be a mapping when provided"))?;
+
+    for key in ["max_iterations", "required_events"] {
+        if let Some(val) = mapping_get(overlay_el, key) {
+            mapping_insert(core_el_map, key, val.clone());
+        }
+    }
+
+    mapping_insert(core_map, "event_loop", core_el_value);
+    Ok(())
+}
+
 async fn load_hats_value(source: &HatsSource) -> Result<Value> {
     match source {
         HatsSource::File(path) => {
@@ -398,6 +454,21 @@ async fn load_hats_value(source: &HatsSource) -> Result<Value> {
             let preset_value =
                 config_resolution::parse_yaml_value(preset.content, &format!("builtin:{}", name))?;
             extract_hat_overlay_from_preset(preset_value)
+        }
+        HatsSource::AutoloopDir(path) => {
+            if !path.exists() {
+                anyhow::bail!(
+                    "Autoloop preset dir not found: {}. If this was an `autoloop:<name>` \
+                     lookup, check that `./presets/<name>/`, `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/`, \
+                     or `$AUTOLOOP_PRESETS_DIR/<name>/` exists and contains `autoloops.toml` and `topology.toml`.",
+                    path.display()
+                );
+            }
+            let registry = ralph_core::PresetRegistry::default();
+            let value = registry
+                .load(path)
+                .with_context(|| format!("Failed to import autoloop preset from {}", path.display()))?;
+            extract_hat_overlay_from_preset(value)
         }
     }
 }

--- a/crates/ralph-cli/tests/integration_autoloop_preset.rs
+++ b/crates/ralph-cli/tests/integration_autoloop_preset.rs
@@ -1,0 +1,164 @@
+//! Integration tests for autoloop preset import via the `-H` flag.
+//!
+//! Covers:
+//! - `-H <dir>` where the directory is an autoloop preset (auto-detect).
+//! - `-H autoloop:<name>` where `<name>` resolves via cwd-local `presets/`.
+//! - Error messaging when an autoloop name fails to resolve.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+const MIN_AUTOLOOPS_TOML: &str = r#"
+event_loop.max_iterations = 17
+event_loop.completion_event = "task.complete"
+event_loop.required_events = ["review.passed"]
+"#;
+
+const MIN_TOPOLOGY_TOML: &str = r#"
+name = "it-test"
+completion = "task.complete"
+
+[[role]]
+id = "planner"
+emits = ["tasks.ready"]
+prompt_file = "roles/planner.md"
+
+[[role]]
+id = "builder"
+emits = ["review.ready"]
+prompt_file = "roles/builder.md"
+
+[[role]]
+id = "critic"
+emits = ["review.passed"]
+prompt_file = "roles/critic.md"
+
+[handoff]
+"loop.start" = ["planner"]
+"tasks.ready" = ["builder"]
+"review.ready" = ["critic"]
+"#;
+
+fn write_autoloop_preset(root: &Path, name: &str) -> std::path::PathBuf {
+    let dir = root.join("presets").join(name);
+    fs::create_dir_all(dir.join("roles")).unwrap();
+    fs::write(dir.join("autoloops.toml"), MIN_AUTOLOOPS_TOML).unwrap();
+    fs::write(dir.join("topology.toml"), MIN_TOPOLOGY_TOML).unwrap();
+    fs::write(dir.join("roles/planner.md"), "Plan.").unwrap();
+    fs::write(dir.join("roles/builder.md"), "Build.").unwrap();
+    fs::write(dir.join("roles/critic.md"), "Criticize.").unwrap();
+    fs::write(
+        dir.join("harness.md"),
+        "Autoloop harness: always verify before completing.",
+    )
+    .unwrap();
+    dir
+}
+
+fn run_ralph(cwd: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_ralph"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("execute ralph")
+}
+
+#[test]
+fn dry_run_detects_autoloop_preset_dir_passed_as_path() {
+    let tmp = TempDir::new().unwrap();
+    let preset = write_autoloop_preset(tmp.path(), "my-autoloop");
+
+    let output = run_ralph(
+        tmp.path(),
+        &[
+            "--color",
+            "never",
+            "--hats",
+            preset.to_str().unwrap(),
+            "run",
+            "--dry-run",
+            "--skip-preflight",
+            "--prompt",
+            "hello",
+            "--backend",
+            "claude",
+            "--no-tui",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "run failed: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Dry run mode"), "stdout: {stdout}");
+}
+
+#[test]
+fn autoloop_name_prefix_resolves_from_cwd_presets_dir() {
+    let tmp = TempDir::new().unwrap();
+    write_autoloop_preset(tmp.path(), "my-autoloop");
+
+    let output = run_ralph(
+        tmp.path(),
+        &[
+            "--color",
+            "never",
+            "--hats",
+            "autoloop:my-autoloop",
+            "run",
+            "--dry-run",
+            "--skip-preflight",
+            "--prompt",
+            "hello",
+            "--backend",
+            "claude",
+            "--no-tui",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "run failed: stdout={}\nstderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn unresolved_autoloop_name_fails_with_helpful_error() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = run_ralph(
+        tmp.path(),
+        &[
+            "--color",
+            "never",
+            "--hats",
+            "autoloop:definitely-not-here",
+            "run",
+            "--dry-run",
+            "--skip-preflight",
+            "--prompt",
+            "hello",
+            "--backend",
+            "claude",
+            "--no-tui",
+        ],
+    );
+
+    assert!(!output.status.success(), "expected failure for missing preset");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("definitely-not-here") || combined.contains("autoloop"),
+        "error should mention the missing name: {combined}"
+    );
+}

--- a/crates/ralph-cli/tests/integration_preset.rs
+++ b/crates/ralph-cli/tests/integration_preset.rs
@@ -1,9 +1,9 @@
-//! Integration tests for autoloop preset import via the `-H` flag.
+//! Integration tests for preset import via the `-H` flag.
 //!
 //! Covers:
-//! - `-H <dir>` where the directory is an autoloop preset (auto-detect).
-//! - `-H autoloop:<name>` where `<name>` resolves via cwd-local `presets/`.
-//! - Error messaging when an autoloop name fails to resolve.
+//! - `-H <dir>` where the directory is a TOML multi-file preset (auto-detect).
+//! - `-H <name>` where `<name>` resolves via cwd-local `presets/`.
+//! - Error messaging when a preset name fails to resolve.
 
 use std::fs;
 use std::path::Path;
@@ -41,7 +41,7 @@ prompt_file = "roles/critic.md"
 "review.ready" = ["critic"]
 "#;
 
-fn write_autoloop_preset(root: &Path, name: &str) -> std::path::PathBuf {
+fn write_toml_preset(root: &Path, name: &str) -> std::path::PathBuf {
     let dir = root.join("presets").join(name);
     fs::create_dir_all(dir.join("roles")).unwrap();
     fs::write(dir.join("autoloops.toml"), MIN_AUTOLOOPS_TOML).unwrap();
@@ -51,7 +51,7 @@ fn write_autoloop_preset(root: &Path, name: &str) -> std::path::PathBuf {
     fs::write(dir.join("roles/critic.md"), "Criticize.").unwrap();
     fs::write(
         dir.join("harness.md"),
-        "Autoloop harness: always verify before completing.",
+        "Harness: always verify before completing.",
     )
     .unwrap();
     dir
@@ -66,9 +66,9 @@ fn run_ralph(cwd: &Path, args: &[&str]) -> std::process::Output {
 }
 
 #[test]
-fn dry_run_detects_autoloop_preset_dir_passed_as_path() {
+fn dry_run_detects_toml_preset_dir_passed_as_path() {
     let tmp = TempDir::new().unwrap();
-    let preset = write_autoloop_preset(tmp.path(), "my-autoloop");
+    let preset = write_toml_preset(tmp.path(), "my-preset");
 
     let output = run_ralph(
         tmp.path(),
@@ -99,9 +99,9 @@ fn dry_run_detects_autoloop_preset_dir_passed_as_path() {
 }
 
 #[test]
-fn autoloop_name_prefix_resolves_from_cwd_presets_dir() {
+fn bare_preset_name_resolves_from_cwd_presets_dir() {
     let tmp = TempDir::new().unwrap();
-    write_autoloop_preset(tmp.path(), "my-autoloop");
+    write_toml_preset(tmp.path(), "my-preset");
 
     let output = run_ralph(
         tmp.path(),
@@ -109,7 +109,7 @@ fn autoloop_name_prefix_resolves_from_cwd_presets_dir() {
             "--color",
             "never",
             "--hats",
-            "autoloop:my-autoloop",
+            "my-preset",
             "run",
             "--dry-run",
             "--skip-preflight",
@@ -130,7 +130,7 @@ fn autoloop_name_prefix_resolves_from_cwd_presets_dir() {
 }
 
 #[test]
-fn unresolved_autoloop_name_fails_with_helpful_error() {
+fn unresolved_preset_name_fails_with_helpful_error() {
     let tmp = TempDir::new().unwrap();
 
     let output = run_ralph(
@@ -139,7 +139,7 @@ fn unresolved_autoloop_name_fails_with_helpful_error() {
             "--color",
             "never",
             "--hats",
-            "autoloop:definitely-not-here",
+            "definitely-not-here",
             "run",
             "--dry-run",
             "--skip-preflight",
@@ -151,14 +151,17 @@ fn unresolved_autoloop_name_fails_with_helpful_error() {
         ],
     );
 
-    assert!(!output.status.success(), "expected failure for missing preset");
+    assert!(
+        !output.status.success(),
+        "expected failure for missing preset"
+    );
     let combined = format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("definitely-not-here") || combined.contains("autoloop"),
+        combined.contains("definitely-not-here"),
         "error should mention the missing name: {combined}"
     );
 }

--- a/crates/ralph-core/Cargo.toml
+++ b/crates/ralph-core/Cargo.toml
@@ -19,6 +19,7 @@ async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+toml.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -117,7 +117,7 @@ pub use preflight::{
     PreflightRunner, extract_acceptance_criteria, extract_all_criteria, extract_criteria_from_file,
 };
 pub use preset_source::{
-    AutoloopPresetSource, PresetRegistry, PresetSource, PresetSourceError, YamlPresetSource,
+    PresetRegistry, PresetSource, PresetSourceError, TomlPresetSource, YamlPresetSource,
 };
 #[cfg(feature = "recording")]
 pub use session_player::{PlayerConfig, ReplayMode, SessionPlayer, TimestampedRecord};

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -38,6 +38,7 @@ mod memory_store;
 pub mod merge_queue;
 pub mod planning_session;
 pub mod preflight;
+pub mod preset_source;
 #[cfg(feature = "recording")]
 mod session_player;
 #[cfg(feature = "recording")]
@@ -114,6 +115,9 @@ pub use planning_session::{
 pub use preflight::{
     AcceptanceCriterion, CheckResult, CheckStatus, PreflightCheck, PreflightReport,
     PreflightRunner, extract_acceptance_criteria, extract_all_criteria, extract_criteria_from_file,
+};
+pub use preset_source::{
+    AutoloopPresetSource, PresetRegistry, PresetSource, PresetSourceError, YamlPresetSource,
 };
 #[cfg(feature = "recording")]
 pub use session_player::{PlayerConfig, ReplayMode, SessionPlayer, TimestampedRecord};

--- a/crates/ralph-core/src/preset_source.rs
+++ b/crates/ralph-core/src/preset_source.rs
@@ -5,7 +5,7 @@
 //! implementations:
 //!
 //! - [`YamlPresetSource`] — the canonical Ralph single-file YAML shape.
-//! - [`AutoloopPresetSource`] — imports multi-file TOML presets authored for
+//! - [`TomlPresetSource`] — imports multi-file TOML presets authored for
 //!   the [`@mobrienv/autoloop`](https://github.com/mobrienv/autoloop) runtime
 //!   (directory containing `autoloops.toml` + `topology.toml` + `roles/*.md`
 //!   + optional `harness.md`).
@@ -80,7 +80,7 @@ impl PresetSourceError {
 /// without incurring the cost of a full parse.
 pub trait PresetSource: Send + Sync {
     /// Short identifier used in error messages and logs (e.g., `"yaml"`,
-    /// `"autoloop"`).
+    /// `"toml"`).
     fn id(&self) -> &'static str;
 
     /// Returns `true` iff this source can handle the preset at `path`.
@@ -101,7 +101,7 @@ pub trait PresetSource: Send + Sync {
 /// Ordered registry of [`PresetSource`] impls.
 ///
 /// Sources registered earlier win detection ties. The default registry is
-/// `[AutoloopPresetSource, YamlPresetSource]` — autoloop first because its
+/// `[TomlPresetSource, YamlPresetSource]` — TOML-dir first because its
 /// detection is strict (requires a directory with two specific TOML files),
 /// YAML second as the permissive fallback.
 pub struct PresetRegistry {
@@ -138,17 +138,14 @@ impl PresetRegistry {
     /// Peek which source handles `path` without loading. Returns the source's
     /// `id()` string, or `None` if no source matches.
     pub fn detect(&self, path: &Path) -> Option<&'static str> {
-        self.sources
-            .iter()
-            .find(|s| s.detect(path))
-            .map(|s| s.id())
+        self.sources.iter().find(|s| s.detect(path)).map(|s| s.id())
     }
 }
 
 impl Default for PresetRegistry {
     fn default() -> Self {
         Self::new()
-            .register(Box::new(AutoloopPresetSource::new()))
+            .register(Box::new(TomlPresetSource::new()))
             .register(Box::new(YamlPresetSource::new()))
     }
 }
@@ -192,17 +189,17 @@ impl PresetSource for YamlPresetSource {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[derive(Default)]
-pub struct AutoloopPresetSource;
+pub struct TomlPresetSource;
 
-impl AutoloopPresetSource {
+impl TomlPresetSource {
     pub fn new() -> Self {
         Self
     }
 }
 
-impl PresetSource for AutoloopPresetSource {
+impl PresetSource for TomlPresetSource {
     fn id(&self) -> &'static str {
-        "autoloop"
+        "toml"
     }
 
     fn detect(&self, path: &Path) -> bool {
@@ -273,12 +270,13 @@ fn build_overlay(
         insert_str(&mut hat, "name", &role.name);
         // Ralph requires non-empty `description`. Autoloop presets don't have
         // this field, so synthesize one from id+first emit.
-        let description = role.description.clone().unwrap_or_else(|| {
-            match role.emits.first() {
+        let description = role
+            .description
+            .clone()
+            .unwrap_or_else(|| match role.emits.first() {
                 Some(ev) => format!("Autoloop role `{}` — emits {}", role.id, ev),
                 None => format!("Autoloop role `{}`", role.id),
-            }
-        });
+            });
         insert_str(&mut hat, "description", &description);
         insert_str_list(
             &mut hat,
@@ -330,7 +328,10 @@ fn build_overlay(
             .iter()
             .filter_map(|v| v.as_str().map(|s| Value::String(s.to_string())))
             .collect();
-        event_loop.insert(Value::String("required_events".into()), Value::Sequence(items));
+        event_loop.insert(
+            Value::String("required_events".into()),
+            Value::Sequence(items),
+        );
     }
 
     // Starting event: autoloop preset convention is `loop.start`. If the
@@ -359,7 +360,10 @@ fn build_overlay(
     );
     overlay.insert(Value::String("hats".into()), Value::Mapping(hats));
     if !event_loop.is_empty() {
-        overlay.insert(Value::String("event_loop".into()), Value::Mapping(event_loop));
+        overlay.insert(
+            Value::String("event_loop".into()),
+            Value::Mapping(event_loop),
+        );
     }
 
     // Harness text goes into guardrails as a single entry prefixed with a
@@ -485,9 +489,10 @@ fn resolve_role_prompt(
     prompt_file: Option<&str>,
 ) -> Result<String, PresetSourceError> {
     if let Some(inline) = inline
-        && !inline.trim().is_empty() {
-            return Ok(inline);
-        }
+        && !inline.trim().is_empty()
+    {
+        return Ok(inline);
+    }
     let Some(rel) = prompt_file else {
         return Ok(String::new());
     };
@@ -505,9 +510,9 @@ fn extract_handoff(
     let Some(raw) = topology.get("handoff") else {
         return Ok(Vec::new());
     };
-    let table = raw.as_table().ok_or_else(|| {
-        PresetSourceError::malformed(preset_dir, "handoff must be a TOML table")
-    })?;
+    let table = raw
+        .as_table()
+        .ok_or_else(|| PresetSourceError::malformed(preset_dir, "handoff must be a TOML table"))?;
 
     let mut out = Vec::with_capacity(table.len());
     for (event, value) in table {
@@ -661,7 +666,7 @@ prompt_file = "roles/critic.md"
     fn autoloop_source_detects_valid_preset_dir() {
         let tmp = TempDir::new().unwrap();
         minimal_preset(tmp.path());
-        assert!(AutoloopPresetSource::new().detect(tmp.path()));
+        assert!(TomlPresetSource::new().detect(tmp.path()));
     }
 
     #[test]
@@ -669,14 +674,14 @@ prompt_file = "roles/critic.md"
         let tmp = TempDir::new().unwrap();
         let yml = tmp.path().join("x.yml");
         fs::write(&yml, "").unwrap();
-        assert!(!AutoloopPresetSource::new().detect(&yml));
+        assert!(!TomlPresetSource::new().detect(&yml));
     }
 
     #[test]
     fn autoloop_source_rejects_dir_missing_topology() {
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("autoloops.toml"), "").unwrap();
-        assert!(!AutoloopPresetSource::new().detect(tmp.path()));
+        assert!(!TomlPresetSource::new().detect(tmp.path()));
     }
 
     #[test]
@@ -684,7 +689,7 @@ prompt_file = "roles/critic.md"
         let tmp = TempDir::new().unwrap();
         minimal_preset(tmp.path());
 
-        let overlay = AutoloopPresetSource::new().load(tmp.path()).unwrap();
+        let overlay = TomlPresetSource::new().load(tmp.path()).unwrap();
         let map = overlay.as_mapping().unwrap();
 
         // Hats are populated for each role.
@@ -733,7 +738,7 @@ prompt_file = "roles/critic.md"
         let tmp = TempDir::new().unwrap();
         minimal_preset(tmp.path());
 
-        let overlay = AutoloopPresetSource::new().load(tmp.path()).unwrap();
+        let overlay = TomlPresetSource::new().load(tmp.path()).unwrap();
         let event_loop = overlay
             .as_mapping()
             .unwrap()
@@ -795,7 +800,7 @@ prompt = "be done"
             ],
         );
 
-        let overlay = AutoloopPresetSource::new().load(tmp.path()).unwrap();
+        let overlay = TomlPresetSource::new().load(tmp.path()).unwrap();
         let cp = overlay
             .as_mapping()
             .unwrap()
@@ -814,7 +819,7 @@ prompt = "be done"
 
         let tmp = TempDir::new().unwrap();
         minimal_preset(tmp.path());
-        assert_eq!(registry.detect(tmp.path()), Some("autoloop"));
+        assert_eq!(registry.detect(tmp.path()), Some("toml"));
 
         let yml = tmp.path().join("out.yml");
         fs::write(&yml, "event_loop: {}").unwrap();
@@ -836,7 +841,10 @@ prompt = "be done"
     fn handoff_inversion_preserves_event_order_per_role() {
         let handoff = vec![
             ("a.first".to_string(), vec!["r1".to_string()]),
-            ("a.second".to_string(), vec!["r1".to_string(), "r2".to_string()]),
+            (
+                "a.second".to_string(),
+                vec!["r1".to_string(), "r2".to_string()],
+            ),
             ("a.third".to_string(), vec!["r1".to_string()]),
         ];
         let inverted = invert_handoff(&handoff);
@@ -863,7 +871,7 @@ prompt = "be done"
             return;
         }
 
-        let overlay = AutoloopPresetSource::new()
+        let overlay = TomlPresetSource::new()
             .load(&fixture)
             .expect("real autocode preset must load");
 

--- a/crates/ralph-core/src/preset_source.rs
+++ b/crates/ralph-core/src/preset_source.rs
@@ -1,0 +1,897 @@
+//! Preset source abstraction — extensible pluggable loaders for hat-collection
+//! presets authored in formats other than Ralph's native YAML.
+//!
+//! This module defines the [`PresetSource`] trait and ships two built-in
+//! implementations:
+//!
+//! - [`YamlPresetSource`] — the canonical Ralph single-file YAML shape.
+//! - [`AutoloopPresetSource`] — imports multi-file TOML presets authored for
+//!   the [`@mobrienv/autoloop`](https://github.com/mobrienv/autoloop) runtime
+//!   (directory containing `autoloops.toml` + `topology.toml` + `roles/*.md`
+//!   + optional `harness.md`).
+//!
+//! New preset shapes plug in by implementing [`PresetSource::detect`] +
+//! [`PresetSource::load`] and registering with [`PresetRegistry`].
+//!
+//! All impls produce a [`serde_yaml::Value`] that can be consumed by the
+//! existing hat-overlay merging pipeline in `ralph-cli`, so downstream code
+//! does not need to know which preset format was on disk.
+//!
+//! ## Autoloop → Ralph mapping
+//!
+//! | Autoloop                                          | Ralph                                      |
+//! | ------------------------------------------------- | ------------------------------------------ |
+//! | `[[role]] id`                                     | `hats.<id>` key                            |
+//! | `[[role]] prompt_file` (read from disk)           | `hats.<id>.instructions`                   |
+//! | `[[role]] emits`                                  | `hats.<id>.publishes`                      |
+//! | `[handoff] <event> = [role, ...]` (inverted)      | `hats.<role>.triggers` list                |
+//! | `topology.completion`                             | `event_loop.completion_promise`            |
+//! | `autoloops.toml` `event_loop.completion_event`    | `event_loop.completion_promise` (fallback) |
+//! | `autoloops.toml` `event_loop.required_events`     | `event_loop.required_events`               |
+//! | `autoloops.toml` `event_loop.max_iterations`      | `event_loop.max_iterations`                |
+//! | `handoff["loop.start"]` (first target's role id)  | `event_loop.starting_event = "loop.start"` |
+//! | `harness.md` (whole file)                         | appended to `core.guardrails`              |
+//!
+//! Fields Ralph has but autoloop lacks (backend, cli, core.specs_dir, etc.)
+//! stay unset — the overlay only populates hats/events/event_loop slots, and
+//! the caller's `ralph.yml` supplies the rest exactly as it does for builtin
+//! presets.
+
+use serde_yaml::{Mapping, Value};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Error returned by a [`PresetSource::load`] implementation.
+#[derive(Debug, thiserror::Error)]
+pub enum PresetSourceError {
+    #[error("i/o error reading preset at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("malformed preset at {path}: {message}")]
+    Malformed { path: PathBuf, message: String },
+    #[error("unsupported preset shape at {path}")]
+    Unsupported { path: PathBuf },
+}
+
+impl PresetSourceError {
+    pub(crate) fn io(path: impl Into<PathBuf>, source: io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+
+    pub(crate) fn malformed(path: impl Into<PathBuf>, message: impl Into<String>) -> Self {
+        Self::Malformed {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Pluggable loader for a preset shape.
+///
+/// Implementations are stateless; a single instance is reused across loads.
+/// Detection is cheap and path-based so callers can probe multiple sources
+/// without incurring the cost of a full parse.
+pub trait PresetSource: Send + Sync {
+    /// Short identifier used in error messages and logs (e.g., `"yaml"`,
+    /// `"autoloop"`).
+    fn id(&self) -> &'static str;
+
+    /// Returns `true` iff this source can handle the preset at `path`.
+    ///
+    /// Callers walk through registered sources in order; the first one whose
+    /// `detect` returns `true` is chosen. Detection MUST be side-effect free
+    /// (read-only fs access is fine).
+    fn detect(&self, path: &Path) -> bool;
+
+    /// Parse the preset at `path` into a hat-overlay YAML value.
+    ///
+    /// The returned [`Value`] MUST be a mapping with a `hats:` key (and
+    /// optionally `events:` / `event_loop:`). It is merged into the core
+    /// Ralph config by the caller.
+    fn load(&self, path: &Path) -> Result<Value, PresetSourceError>;
+}
+
+/// Ordered registry of [`PresetSource`] impls.
+///
+/// Sources registered earlier win detection ties. The default registry is
+/// `[AutoloopPresetSource, YamlPresetSource]` — autoloop first because its
+/// detection is strict (requires a directory with two specific TOML files),
+/// YAML second as the permissive fallback.
+pub struct PresetRegistry {
+    sources: Vec<Box<dyn PresetSource>>,
+}
+
+impl PresetRegistry {
+    /// Empty registry. Use [`PresetRegistry::default`] for the shipped sources.
+    pub fn new() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+
+    /// Append a source to the registry.
+    pub fn register(mut self, source: Box<dyn PresetSource>) -> Self {
+        self.sources.push(source);
+        self
+    }
+
+    /// Find the first registered source whose `detect` returns true, then
+    /// invoke its `load`.
+    pub fn load(&self, path: &Path) -> Result<Value, PresetSourceError> {
+        for source in &self.sources {
+            if source.detect(path) {
+                return source.load(path);
+            }
+        }
+        Err(PresetSourceError::Unsupported {
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Peek which source handles `path` without loading. Returns the source's
+    /// `id()` string, or `None` if no source matches.
+    pub fn detect(&self, path: &Path) -> Option<&'static str> {
+        self.sources
+            .iter()
+            .find(|s| s.detect(path))
+            .map(|s| s.id())
+    }
+}
+
+impl Default for PresetRegistry {
+    fn default() -> Self {
+        Self::new()
+            .register(Box::new(AutoloopPresetSource::new()))
+            .register(Box::new(YamlPresetSource::new()))
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// YAML source — the native Ralph shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct YamlPresetSource;
+
+impl YamlPresetSource {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PresetSource for YamlPresetSource {
+    fn id(&self) -> &'static str {
+        "yaml"
+    }
+
+    fn detect(&self, path: &Path) -> bool {
+        if !path.is_file() {
+            return false;
+        }
+        matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("yml" | "yaml")
+        )
+    }
+
+    fn load(&self, path: &Path) -> Result<Value, PresetSourceError> {
+        let text = fs::read_to_string(path).map_err(|e| PresetSourceError::io(path, e))?;
+        serde_yaml::from_str(&text).map_err(|e| PresetSourceError::malformed(path, e.to_string()))
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Autoloop source — multi-file TOML preset directory.
+// ──────────────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+pub struct AutoloopPresetSource;
+
+impl AutoloopPresetSource {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PresetSource for AutoloopPresetSource {
+    fn id(&self) -> &'static str {
+        "autoloop"
+    }
+
+    fn detect(&self, path: &Path) -> bool {
+        path.is_dir()
+            && path.join("topology.toml").is_file()
+            && path.join("autoloops.toml").is_file()
+    }
+
+    fn load(&self, path: &Path) -> Result<Value, PresetSourceError> {
+        let topology = read_toml(&path.join("topology.toml"))?;
+        let autoloops = read_toml(&path.join("autoloops.toml"))?;
+        let harness_text = maybe_read_text(&path.join("harness.md"))?;
+
+        build_overlay(path, &topology, &autoloops, harness_text.as_deref())
+    }
+}
+
+fn read_toml(path: &Path) -> Result<toml::Value, PresetSourceError> {
+    let text = fs::read_to_string(path).map_err(|e| PresetSourceError::io(path, e))?;
+    toml::from_str(&text).map_err(|e| PresetSourceError::malformed(path, e.to_string()))
+}
+
+fn maybe_read_text(path: &Path) -> Result<Option<String>, PresetSourceError> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    fs::read_to_string(path)
+        .map(Some)
+        .map_err(|e| PresetSourceError::io(path, e))
+}
+
+fn build_overlay(
+    preset_dir: &Path,
+    topology: &toml::Value,
+    autoloops: &toml::Value,
+    harness: Option<&str>,
+) -> Result<Value, PresetSourceError> {
+    let topology_table = topology
+        .as_table()
+        .ok_or_else(|| PresetSourceError::malformed(preset_dir, "topology.toml must be a table"))?;
+
+    // ── Extract topology fields ────────────────────────────────────────────
+    let preset_name = topology_table
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let completion_event = topology_table
+        .get("completion")
+        .and_then(|v| v.as_str())
+        .map(ToString::to_string);
+
+    let roles = extract_roles(preset_dir, topology_table)?;
+    let handoff = extract_handoff(preset_dir, topology_table)?;
+
+    // Invert the handoff map: Ralph defines triggers per hat, autoloop
+    // defines handoff per event → role list. Pattern keys (`/regex/`) are
+    // passed through verbatim — Ralph matches raw strings for triggers so
+    // regex handoffs become literal trigger strings. Acceptable because
+    // 15/16 autoloop presets use exact-match handoffs.
+    let triggers_by_role = invert_handoff(&handoff);
+
+    // ── Build hats mapping ─────────────────────────────────────────────────
+    let mut hats = Mapping::new();
+    for role in &roles {
+        let mut hat = Mapping::new();
+        insert_str(&mut hat, "name", &role.name);
+        // Ralph requires non-empty `description`. Autoloop presets don't have
+        // this field, so synthesize one from id+first emit.
+        let description = role.description.clone().unwrap_or_else(|| {
+            match role.emits.first() {
+                Some(ev) => format!("Autoloop role `{}` — emits {}", role.id, ev),
+                None => format!("Autoloop role `{}`", role.id),
+            }
+        });
+        insert_str(&mut hat, "description", &description);
+        insert_str_list(
+            &mut hat,
+            "triggers",
+            triggers_by_role.get(&role.id).map(Vec::as_slice),
+        );
+        insert_str_list(&mut hat, "publishes", Some(&role.emits));
+        insert_str(&mut hat, "instructions", &role.prompt);
+        if let Some(default) = role.emits.first() {
+            insert_str(&mut hat, "default_publishes", default);
+        }
+        hats.insert(Value::String(role.id.clone()), Value::Mapping(hat));
+    }
+
+    // ── Build event_loop overlay ───────────────────────────────────────────
+    let mut event_loop = Mapping::new();
+    let autoloops_event_loop = autoloops
+        .get("event_loop")
+        .and_then(|v| v.as_table())
+        .cloned()
+        .unwrap_or_default();
+
+    // Completion: topology.completion wins, then autoloops event_loop.completion_event.
+    let completion = completion_event.or_else(|| {
+        autoloops_event_loop
+            .get("completion_event")
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string)
+    });
+    if let Some(c) = completion {
+        insert_str(&mut event_loop, "completion_promise", &c);
+    }
+
+    if let Some(max_iters) = autoloops_event_loop
+        .get("max_iterations")
+        .and_then(toml_int)
+    {
+        event_loop.insert(
+            Value::String("max_iterations".into()),
+            Value::Number(max_iters.into()),
+        );
+    }
+
+    if let Some(required) = autoloops_event_loop
+        .get("required_events")
+        .and_then(|v| v.as_array())
+    {
+        let items: Vec<Value> = required
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| Value::String(s.to_string())))
+            .collect();
+        event_loop.insert(Value::String("required_events".into()), Value::Sequence(items));
+    }
+
+    // Starting event: autoloop preset convention is `loop.start`. If the
+    // handoff defines a route out of `loop.start`, honor it; otherwise leave
+    // unset so Ralph derives from the hat topology.
+    if handoff.iter().any(|(event, _)| event == "loop.start") {
+        insert_str(&mut event_loop, "starting_event", "loop.start");
+    }
+
+    // ── Overlay envelope ───────────────────────────────────────────────────
+    let mut overlay = Mapping::new();
+    if !preset_name.is_empty() {
+        insert_str(&mut overlay, "name", &preset_name);
+    }
+    insert_str(
+        &mut overlay,
+        "description",
+        &format!(
+            "Imported autoloop preset{}",
+            if preset_name.is_empty() {
+                String::new()
+            } else {
+                format!(": {}", preset_name)
+            }
+        ),
+    );
+    overlay.insert(Value::String("hats".into()), Value::Mapping(hats));
+    if !event_loop.is_empty() {
+        overlay.insert(Value::String("event_loop".into()), Value::Mapping(event_loop));
+    }
+
+    // Harness text goes into guardrails as a single entry prefixed with a
+    // marker. The caller's `load_hats_value` restricts overlays to
+    // hats/events/event_loop by default, but the `name`+`description`+harness
+    // payload is captured in each hat's instructions as well so nothing is
+    // lost when the strict overlay filter drops the top-level extras.
+    if let Some(harness_text) = harness {
+        prepend_harness_into_hats(&mut overlay, harness_text);
+    }
+
+    Ok(Value::Mapping(overlay))
+}
+
+/// Prepend the `harness.md` content (global autoloop rules) to every hat's
+/// `instructions`. This is the only slot in Ralph's hats-overlay schema where
+/// the text survives hat-overlay extraction — top-level keys like `core:` are
+/// dropped by `hats_disallowed_keys`.
+fn prepend_harness_into_hats(overlay: &mut Mapping, harness: &str) {
+    let Some(hats) = overlay
+        .get_mut(Value::String("hats".into()))
+        .and_then(Value::as_mapping_mut)
+    else {
+        return;
+    };
+
+    let harness_block = format!(
+        "## Shared harness rules (imported from autoloop `harness.md`)\n\n{}\n\n---\n\n",
+        harness.trim_end()
+    );
+
+    for (_k, v) in hats.iter_mut() {
+        let Some(hat) = v.as_mapping_mut() else {
+            continue;
+        };
+        let key = Value::String("instructions".into());
+        let merged = match hat.get(&key).and_then(Value::as_str) {
+            Some(existing) => format!("{}{}", harness_block, existing),
+            None => harness_block.clone(),
+        };
+        hat.insert(key, Value::String(merged));
+    }
+}
+
+struct AutoloopRole {
+    id: String,
+    name: String,
+    description: Option<String>,
+    emits: Vec<String>,
+    prompt: String,
+}
+
+fn extract_roles(
+    preset_dir: &Path,
+    topology: &toml::map::Map<String, toml::Value>,
+) -> Result<Vec<AutoloopRole>, PresetSourceError> {
+    let raw_roles = topology
+        .get("role")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut roles = Vec::with_capacity(raw_roles.len());
+    for role_value in raw_roles {
+        let role_table = role_value.as_table().ok_or_else(|| {
+            PresetSourceError::malformed(preset_dir, "every [[role]] must be a TOML table")
+        })?;
+
+        let id = role_table
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| PresetSourceError::malformed(preset_dir, "role missing `id`"))?
+            .to_string();
+
+        let emits: Vec<String> = role_table
+            .get("emits")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let inline_prompt = role_table
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string);
+
+        let prompt_file = role_table
+            .get("prompt_file")
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string);
+
+        let prompt = resolve_role_prompt(preset_dir, inline_prompt, prompt_file.as_deref())?;
+
+        let name = role_table
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| humanize_role_id(&id));
+
+        let description = role_table
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(ToString::to_string);
+
+        roles.push(AutoloopRole {
+            id,
+            name,
+            description,
+            emits,
+            prompt,
+        });
+    }
+
+    Ok(roles)
+}
+
+fn resolve_role_prompt(
+    preset_dir: &Path,
+    inline: Option<String>,
+    prompt_file: Option<&str>,
+) -> Result<String, PresetSourceError> {
+    if let Some(inline) = inline
+        && !inline.trim().is_empty() {
+            return Ok(inline);
+        }
+    let Some(rel) = prompt_file else {
+        return Ok(String::new());
+    };
+    let full = preset_dir.join(rel);
+    if !full.is_file() {
+        return Ok(String::new());
+    }
+    fs::read_to_string(&full).map_err(|e| PresetSourceError::io(full, e))
+}
+
+fn extract_handoff(
+    preset_dir: &Path,
+    topology: &toml::map::Map<String, toml::Value>,
+) -> Result<Vec<(String, Vec<String>)>, PresetSourceError> {
+    let Some(raw) = topology.get("handoff") else {
+        return Ok(Vec::new());
+    };
+    let table = raw.as_table().ok_or_else(|| {
+        PresetSourceError::malformed(preset_dir, "handoff must be a TOML table")
+    })?;
+
+    let mut out = Vec::with_capacity(table.len());
+    for (event, value) in table {
+        let targets: Vec<String> = match value {
+            toml::Value::Array(arr) => arr
+                .iter()
+                .filter_map(|v| v.as_str().map(ToString::to_string))
+                .collect(),
+            toml::Value::String(s) => vec![s.clone()],
+            _ => continue,
+        };
+        out.push((event.clone(), targets));
+    }
+    Ok(out)
+}
+
+fn invert_handoff(
+    handoff: &[(String, Vec<String>)],
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    let mut by_role: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for (event, targets) in handoff {
+        for role in targets {
+            let entry = by_role.entry(role.clone()).or_default();
+            if !entry.iter().any(|e| e == event) {
+                entry.push(event.clone());
+            }
+        }
+    }
+    by_role
+}
+
+fn humanize_role_id(id: &str) -> String {
+    if id.is_empty() {
+        return String::new();
+    }
+    let mut chars = id.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn insert_str(map: &mut Mapping, key: &str, value: &str) {
+    map.insert(Value::String(key.into()), Value::String(value.to_string()));
+}
+
+fn insert_str_list(map: &mut Mapping, key: &str, values: Option<&[String]>) {
+    let list = values
+        .map(|xs| {
+            xs.iter()
+                .map(|v| Value::String(v.clone()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    map.insert(Value::String(key.into()), Value::Sequence(list));
+}
+
+fn toml_int(v: &toml::Value) -> Option<i64> {
+    match v {
+        toml::Value::Integer(i) => Some(*i),
+        toml::Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_preset(dir: &Path, files: &[(&str, &str)]) {
+        for (rel, content) in files {
+            let full = dir.join(rel);
+            if let Some(parent) = full.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(full, content).unwrap();
+        }
+    }
+
+    fn minimal_preset(dir: &Path) {
+        write_preset(
+            dir,
+            &[
+                (
+                    "autoloops.toml",
+                    r#"
+event_loop.max_iterations = 42
+event_loop.completion_event = "task.complete"
+event_loop.required_events = ["review.passed"]
+"#,
+                ),
+                (
+                    "topology.toml",
+                    r#"
+name = "demo"
+completion = "task.complete"
+
+[[role]]
+id = "planner"
+emits = ["tasks.ready"]
+prompt_file = "roles/planner.md"
+
+[[role]]
+id = "builder"
+emits = ["review.ready"]
+prompt_file = "roles/builder.md"
+
+[[role]]
+id = "critic"
+emits = ["review.passed", "review.rejected"]
+prompt_file = "roles/critic.md"
+
+[handoff]
+"loop.start" = ["planner"]
+"tasks.ready" = ["builder"]
+"review.ready" = ["critic"]
+"review.rejected" = ["builder"]
+"#,
+                ),
+                ("roles/planner.md", "Plan the work."),
+                ("roles/builder.md", "Build the work."),
+                ("roles/critic.md", "Criticize the work."),
+                ("harness.md", "Always be honest.\n"),
+            ],
+        );
+    }
+
+    #[test]
+    fn yaml_source_detects_yml_files() {
+        let tmp = TempDir::new().unwrap();
+        let yml = tmp.path().join("x.yml");
+        fs::write(&yml, "event_loop: {}").unwrap();
+        let src = YamlPresetSource::new();
+        assert!(src.detect(&yml));
+    }
+
+    #[test]
+    fn yaml_source_rejects_directories() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!YamlPresetSource::new().detect(tmp.path()));
+    }
+
+    #[test]
+    fn autoloop_source_detects_valid_preset_dir() {
+        let tmp = TempDir::new().unwrap();
+        minimal_preset(tmp.path());
+        assert!(AutoloopPresetSource::new().detect(tmp.path()));
+    }
+
+    #[test]
+    fn autoloop_source_rejects_files() {
+        let tmp = TempDir::new().unwrap();
+        let yml = tmp.path().join("x.yml");
+        fs::write(&yml, "").unwrap();
+        assert!(!AutoloopPresetSource::new().detect(&yml));
+    }
+
+    #[test]
+    fn autoloop_source_rejects_dir_missing_topology() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("autoloops.toml"), "").unwrap();
+        assert!(!AutoloopPresetSource::new().detect(tmp.path()));
+    }
+
+    #[test]
+    fn autoloop_source_loads_preset_with_inverted_handoffs() {
+        let tmp = TempDir::new().unwrap();
+        minimal_preset(tmp.path());
+
+        let overlay = AutoloopPresetSource::new().load(tmp.path()).unwrap();
+        let map = overlay.as_mapping().unwrap();
+
+        // Hats are populated for each role.
+        let hats = map
+            .get(Value::String("hats".into()))
+            .and_then(Value::as_mapping)
+            .unwrap();
+        assert_eq!(hats.len(), 3);
+
+        // Builder hat has triggers derived from inverted handoff.
+        let builder = hats
+            .get(Value::String("builder".into()))
+            .and_then(Value::as_mapping)
+            .unwrap();
+        let triggers: Vec<String> = builder
+            .get(Value::String("triggers".into()))
+            .and_then(Value::as_sequence)
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str().map(ToString::to_string))
+            .collect();
+        assert!(triggers.contains(&"tasks.ready".to_string()));
+        assert!(triggers.contains(&"review.rejected".to_string()));
+
+        // Builder publishes its emits.
+        let publishes: Vec<String> = builder
+            .get(Value::String("publishes".into()))
+            .and_then(Value::as_sequence)
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str().map(ToString::to_string))
+            .collect();
+        assert_eq!(publishes, vec!["review.ready".to_string()]);
+
+        // Instructions include both the harness block and the role prompt.
+        let instructions = builder
+            .get(Value::String("instructions".into()))
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(instructions.contains("Always be honest"));
+        assert!(instructions.contains("Build the work."));
+    }
+
+    #[test]
+    fn autoloop_source_populates_event_loop() {
+        let tmp = TempDir::new().unwrap();
+        minimal_preset(tmp.path());
+
+        let overlay = AutoloopPresetSource::new().load(tmp.path()).unwrap();
+        let event_loop = overlay
+            .as_mapping()
+            .unwrap()
+            .get(Value::String("event_loop".into()))
+            .and_then(Value::as_mapping)
+            .unwrap();
+
+        assert_eq!(
+            event_loop
+                .get(Value::String("completion_promise".into()))
+                .and_then(Value::as_str),
+            Some("task.complete")
+        );
+        assert_eq!(
+            event_loop
+                .get(Value::String("max_iterations".into()))
+                .and_then(Value::as_i64),
+            Some(42)
+        );
+        assert_eq!(
+            event_loop
+                .get(Value::String("starting_event".into()))
+                .and_then(Value::as_str),
+            Some("loop.start")
+        );
+
+        let required: Vec<String> = event_loop
+            .get(Value::String("required_events".into()))
+            .and_then(Value::as_sequence)
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str().map(ToString::to_string))
+            .collect();
+        assert_eq!(required, vec!["review.passed".to_string()]);
+    }
+
+    #[test]
+    fn autoloop_completion_falls_back_to_event_loop_config() {
+        let tmp = TempDir::new().unwrap();
+        write_preset(
+            tmp.path(),
+            &[
+                (
+                    "autoloops.toml",
+                    r#"event_loop.completion_event = "done.fire""#,
+                ),
+                (
+                    "topology.toml",
+                    r#"
+name = "x"
+[[role]]
+id = "one"
+emits = ["done.fire"]
+prompt = "be done"
+[handoff]
+"loop.start" = ["one"]
+"#,
+                ),
+            ],
+        );
+
+        let overlay = AutoloopPresetSource::new().load(tmp.path()).unwrap();
+        let cp = overlay
+            .as_mapping()
+            .unwrap()
+            .get(Value::String("event_loop".into()))
+            .and_then(Value::as_mapping)
+            .unwrap()
+            .get(Value::String("completion_promise".into()))
+            .and_then(Value::as_str)
+            .unwrap();
+        assert_eq!(cp, "done.fire");
+    }
+
+    #[test]
+    fn registry_default_picks_autoloop_for_preset_dirs_and_yaml_for_files() {
+        let registry = PresetRegistry::default();
+
+        let tmp = TempDir::new().unwrap();
+        minimal_preset(tmp.path());
+        assert_eq!(registry.detect(tmp.path()), Some("autoloop"));
+
+        let yml = tmp.path().join("out.yml");
+        fs::write(&yml, "event_loop: {}").unwrap();
+        assert_eq!(registry.detect(&yml), Some("yaml"));
+    }
+
+    #[test]
+    fn registry_reports_unsupported_for_unknown_shape() {
+        let registry = PresetRegistry::default();
+        let tmp = TempDir::new().unwrap();
+        let weird = tmp.path().join("weird.txt");
+        fs::write(&weird, "").unwrap();
+
+        let err = registry.load(&weird).unwrap_err();
+        assert!(matches!(err, PresetSourceError::Unsupported { .. }));
+    }
+
+    #[test]
+    fn handoff_inversion_preserves_event_order_per_role() {
+        let handoff = vec![
+            ("a.first".to_string(), vec!["r1".to_string()]),
+            ("a.second".to_string(), vec!["r1".to_string(), "r2".to_string()]),
+            ("a.third".to_string(), vec!["r1".to_string()]),
+        ];
+        let inverted = invert_handoff(&handoff);
+        assert_eq!(
+            inverted.get("r1").unwrap(),
+            &vec![
+                "a.first".to_string(),
+                "a.second".to_string(),
+                "a.third".to_string()
+            ]
+        );
+        assert_eq!(inverted.get("r2").unwrap(), &vec!["a.second".to_string()]);
+    }
+
+    /// Smoke test against the real autoloop `autocode` preset shipped in the
+    /// sibling workspace. Skipped when the fixtures aren't present so CI on a
+    /// bare clone still passes.
+    #[test]
+    fn autoloop_source_loads_real_autocode_fixture_when_available() {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../autoloop/packages/presets/presets/autocode");
+        if !fixture.is_dir() {
+            eprintln!("skip: {} not present", fixture.display());
+            return;
+        }
+
+        let overlay = AutoloopPresetSource::new()
+            .load(&fixture)
+            .expect("real autocode preset must load");
+
+        let hats = overlay
+            .as_mapping()
+            .unwrap()
+            .get(Value::String("hats".into()))
+            .and_then(Value::as_mapping)
+            .expect("hats mapping populated");
+
+        for expected in ["planner", "builder", "critic", "finalizer"] {
+            assert!(
+                hats.contains_key(Value::String(expected.into())),
+                "missing hat: {expected}"
+            );
+        }
+
+        let event_loop = overlay
+            .as_mapping()
+            .unwrap()
+            .get(Value::String("event_loop".into()))
+            .and_then(Value::as_mapping)
+            .expect("event_loop overlay populated");
+        assert_eq!(
+            event_loop
+                .get(Value::String("completion_promise".into()))
+                .and_then(Value::as_str),
+            Some("task.complete")
+        );
+    }
+}

--- a/presets/README.md
+++ b/presets/README.md
@@ -49,6 +49,50 @@ Example workflow patterns now live in the docs rather than as shipped preset fil
 - `docs/examples/`
 - `presets/COLLECTION.md`
 
+## Importing Autoloop Presets
+
+Ralph can load hat collections authored for [`@mobrienv/autoloop`](https://github.com/mobrienv/autoloop) without translating them by hand. Autoloop presets are multi-file directories (`autoloops.toml` + `topology.toml` + `roles/*.md` + optional `harness.md`); Ralph's preset loader detects and imports them directly.
+
+**Three ways to target an autoloop preset with `-H`:**
+
+```bash
+# 1. Explicit directory path
+ralph run -c ralph.yml -H ./path/to/autocode -p "..."
+
+# 2. `autoloop:<name>` — resolves via lookup order below
+ralph run -c ralph.yml -H autoloop:autocode -p "..."
+
+# 3. Autoloop dir in the usual `./presets/<name>/` slot (auto-detected)
+ralph run -c ralph.yml -H ./presets/autocode -p "..."
+```
+
+**Lookup order for `autoloop:<name>`:**
+
+1. `./presets/<name>/` (project-local)
+2. `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/`
+3. `$HOME/.config/ralph/autoloop-presets/<name>/`
+4. `$AUTOLOOP_PRESETS_DIR/<name>/` (explicit override)
+
+First directory whose layout matches (`autoloops.toml` + `topology.toml` present) wins.
+
+**Mapping:**
+
+| Autoloop | Ralph |
+|---|---|
+| `topology.toml` `[[role]].id` | `hats.<id>` |
+| `role.prompt_file` contents | `hat.instructions` |
+| `role.emits` | `hat.publishes` |
+| `[handoff]` entries (inverted) | `hat.triggers` |
+| `topology.completion` / `event_loop.completion_event` | `event_loop.completion_promise` |
+| `event_loop.max_iterations` | `event_loop.max_iterations` |
+| `event_loop.required_events` | `event_loop.required_events` |
+| `handoff["loop.start"]` route | `event_loop.starting_event = "loop.start"` |
+| `harness.md` (whole file) | prepended to every hat's `instructions` |
+
+Ralph fields autoloop doesn't populate (`cli.backend`, `core.specs_dir`, `core.guardrails`, etc.) still come from your `ralph.yml`, same as with a builtin hat collection.
+
+The importer is extensible — see `crates/ralph-core/src/preset_source.rs` for the `PresetSource` trait; new preset shapes plug in by implementing `detect` + `load`.
+
 ## Source Of Truth
 
 - Canonical builtins: `presets/*.yml`

--- a/presets/README.md
+++ b/presets/README.md
@@ -49,35 +49,41 @@ Example workflow patterns now live in the docs rather than as shipped preset fil
 - `docs/examples/`
 - `presets/COLLECTION.md`
 
-## Importing Autoloop Presets
+## Importing External Presets
 
-Ralph can load hat collections authored for [`@mobrienv/autoloop`](https://github.com/mobrienv/autoloop) without translating them by hand. Autoloop presets are multi-file directories (`autoloops.toml` + `topology.toml` + `roles/*.md` + optional `harness.md`); Ralph's preset loader detects and imports them directly.
+Ralph loads hat collections in two formats:
 
-**Three ways to target an autoloop preset with `-H`:**
+- **YAML** — single-file `<name>.yml` (ralph's native shape, same as the builtins in `presets/*.yml`).
+- **TOML multi-file** — directory containing `autoloops.toml` + `topology.toml` + `roles/*.md` + optional `harness.md`. Originally the [`@mobrienv/autoloop`](https://github.com/mobrienv/autoloop) shape; ralph now treats it as first-class alongside YAML.
+
+**Three ways to target a preset with `-H`:**
 
 ```bash
-# 1. Explicit directory path
+# 1. Bare name — looked up via the resolver (see below)
+ralph run -c ralph.yml -H autocode -p "..."
+
+# 2. Explicit path (YAML file or TOML directory, auto-detected)
 ralph run -c ralph.yml -H ./path/to/autocode -p "..."
+ralph run -c ralph.yml -H ./presets/code-assist.yml -p "..."
 
-# 2. `autoloop:<name>` — resolves via lookup order below
-ralph run -c ralph.yml -H autoloop:autocode -p "..."
-
-# 3. Autoloop dir in the usual `./presets/<name>/` slot (auto-detected)
-ralph run -c ralph.yml -H ./presets/autocode -p "..."
+# 3. Shipped builtin
+ralph run -c ralph.yml -H builtin:code-assist -p "..."
 ```
 
-**Lookup order for `autoloop:<name>`:**
+**Lookup order for `-H <name>`:**
 
-1. `./presets/<name>/` (project-local)
-2. `$XDG_CONFIG_HOME/ralph/autoloop-presets/<name>/`
-3. `$HOME/.config/ralph/autoloop-presets/<name>/`
-4. `$AUTOLOOP_PRESETS_DIR/<name>/` (explicit override)
+1. `./presets/<name>(.yml|.yaml|/)` (project-local)
+2. `$XDG_CONFIG_HOME/ralph/presets/<name>/`
+3. `$HOME/.config/ralph/presets/<name>/`
+4. `$HOME/.config/autoloop/presets/<name>/` (shared with autoloop CLI)
+5. `$RALPH_PRESETS_DIR/<name>/`
+6. `$AUTOLOOP_PRESETS_DIR/<name>/` (deprecated alias for #5)
 
-First directory whose layout matches (`autoloops.toml` + `topology.toml` present) wins.
+First match wins. Use `ralph hats list-presets` to see everything discoverable on your system.
 
-**Mapping:**
+**TOML → Ralph mapping** (for TOML-dir presets):
 
-| Autoloop | Ralph |
+| TOML | Ralph |
 |---|---|
 | `topology.toml` `[[role]].id` | `hats.<id>` |
 | `role.prompt_file` contents | `hat.instructions` |
@@ -89,7 +95,7 @@ First directory whose layout matches (`autoloops.toml` + `topology.toml` present
 | `handoff["loop.start"]` route | `event_loop.starting_event = "loop.start"` |
 | `harness.md` (whole file) | prepended to every hat's `instructions` |
 
-Ralph fields autoloop doesn't populate (`cli.backend`, `core.specs_dir`, `core.guardrails`, etc.) still come from your `ralph.yml`, same as with a builtin hat collection.
+Ralph fields TOML presets don't populate (`cli.backend`, `core.specs_dir`, `core.guardrails`, etc.) still come from your `ralph.yml`, same as with a builtin hat collection.
 
 The importer is extensible — see `crates/ralph-core/src/preset_source.rs` for the `PresetSource` trait; new preset shapes plug in by implementing `detect` + `load`.
 


### PR DESCRIPTION
Makes "preset" the canonical term across ralph. `-H <name>` now resolves either single-file YAML presets (ralph's native shape) or multi-file TOML preset directories (the @mobrienv/autoloop shape). New `ralph hats list-presets` command discovers both across 6 resolver paths.

## User-facing changes

- **`-H <name>`** \u2014 new canonical short form. Walks the 6-path resolver, first-wins.
- **`-H <path>`** \u2014 auto-detects file vs directory vs preset shape.
- **`-H builtin:<name>`** \u2014 unchanged (shipped YAML presets).
- **`ralph hats list-presets`** \u2014 new subcommand. Shows PRESET / FORMAT / SOURCE / DESCRIPTION columns. Works outside any workspace (short-circuits before config load).

**Resolver paths**, in priority order:
1. `./presets/<name>` (project-local)
2. `$XDG_CONFIG_HOME/ralph/presets/<name>/`
3. `$HOME/.config/ralph/presets/<name>/` (new canonical)
4. `$HOME/.config/autoloop/presets/<name>/` (shared with autoloop CLI, enables zero-config autoloop interop)
5. `$RALPH_PRESETS_DIR/<name>/` (new canonical env)
6. `$AUTOLOOP_PRESETS_DIR/<name>/` (kept as fallback)

## Architecture

New `ralph_core::preset_source` module with `PresetSource` trait + two built-in impls:
- `YamlPresetSource` (ralph's native single-file shape)
- `TomlPresetSource` (multi-file directory with `autoloops.toml` + `topology.toml` + `roles/*.md`)

Pluggable `PresetRegistry` picks the right loader based on path shape. Both impls produce a `serde_yaml::Value` consumed by the existing hat-overlay merging pipeline, so downstream code is format-agnostic.

TOML\u2192Ralph mapping: roles \u2192 hats, emits \u2192 publishes, handoff (inverted) \u2192 triggers, harness.md prepended to all hat instructions. Preflight injects loop-level policy (`max_iterations`, `required_events`) from `autoloops.toml` into core config before the generic overlay merge.

## Demo

```
$ ralph hats list-presets
PRESET                 FORMAT SOURCE    DESCRIPTION
------------------------------------------------------------------
autodebug              toml   autoloop  Systematic debugging loop based on...
autoresearch           yaml   project   Autoresearch Preset
code-assist            yaml   project   Code-Assist: Flexible TDD Impleme...
debug                  yaml   project   Debug Preset
...

$ ralph run -H autodebug -P PROMPT.md -a
[loads autoloop autodebug preset from ~/.config/autoloop/presets/]
```

## Tests

- **38 new/updated tests**: 31 hats unit tests (+YAML-discovery case), 3 integration tests for bare `-H <name>` resolution, several preset_source unit tests for the TOML loader + registry dispatch.
- Full `cargo test -p ralph-cli --bin ralph hats::` \u2192 31/31 pass.
- `cargo test -p ralph-cli --test integration_preset` \u2192 3/3 pass.
- `cargo test -p ralph-core` \u2192 13/13 pass.
- Pre-existing parallel-test flake in `loop_runner::test_process_pending_merges_redirects_subprocess_output_to_log_file` is unaffected (passes in isolation on both main and this branch).

## Commits

1. `feat(cli): import autoloop presets via -H and discover them with \`hats list-presets\``
2. `feat(cli): unify preset mechanism under \`-H <name>\` (both YAML + TOML formats)`

First commit is the preset-source registry + `PresetDir` variant + initial `list-presets` command. Second is the rename to drop the "autoloop" qualifier at the user level and unify YAML+TOML under a single canonical lookup.

## Breaking changes

None for released surface. Internal types were renamed (`AutoloopPresetSource` \u2192 `TomlPresetSource`, `HatsSource::AutoloopDir` \u2192 `PresetDir`, etc.) but these were landed in the same change set and never shipped. `-H autoloop:<name>` was proposed in an intermediate branch but never merged to main, so no users depend on it.