### PR TITLE
docs(presets): link to autoloop authoring guide for TOML presets

### DIFF
--- a/docs/guide/presets.md
+++ b/docs/guide/presets.md
@@ -166,6 +166,38 @@ Run it:
 ralph run -c ralph.yml -H .ralph/hats/my-workflow.yml
 ```
 
+## TOML-Shape Presets (multi-file directory)
+
+Ralph also loads the multi-file TOML preset format originally defined by [`@mobrienv/autoloop`](https://github.com/mikeyobrien/autoloop) — a directory containing `autoloops.toml`, `topology.toml`, `harness.md`, and per-role prompt files under `roles/`. This is treated as a first-class preset format alongside YAML; use `-H <name>` or `-H <path>` identically.
+
+```bash
+# Discoverable via the resolver (see "Preset Resolution" below)
+ralph run -H autocode -p "Add OAuth login"
+
+# Or point at the directory directly
+ralph run -H /path/to/autocode -p "Add OAuth login"
+```
+
+**Authoring a TOML preset** — follow the autoloop authoring guide:
+
+- **[Creating presets](https://mikeyobrien.github.io/autoloop/guides/creating-presets)** — directory layout, `autoloops.toml` + `topology.toml` fields, role prompt conventions, harness rules, fail-closed patterns.
+- **[Bundled preset examples](https://github.com/mikeyobrien/autoloop/tree/main/packages/presets/presets)** — 15+ reference implementations (autocode, autofix, autoreview, autodebug, autospec, etc.) you can copy as a starting point.
+
+The TOML shape is useful when each role needs its own prompt file, a separate harness, or more structure than a single YAML permits. Both shapes compile to the same internal representation, so nothing about the rest of ralph changes — the backend, CLI, event flow, and completion semantics work identically.
+
+## Preset Resolution
+
+`-H <name>` resolves a bare preset name against these paths in order (first hit wins):
+
+1. `./presets/<name>(.yml|.yaml|/)` — project-local
+2. `$XDG_CONFIG_HOME/ralph/presets/<name>/`
+3. `$HOME/.config/ralph/presets/<name>/` — user, canonical
+4. `$HOME/.config/autoloop/presets/<name>/` — shared with the autoloop CLI
+5. `$RALPH_PRESETS_DIR/<name>/` — explicit override
+6. `$AUTOLOOP_PRESETS_DIR/<name>/` — back-compat fallback
+
+Run `ralph hats list-presets` to see everything discoverable on your system (both YAML and TOML shapes in one table).
+
 ## Source of Truth and Sync
 
 - Canonical preset files: `presets/*.yml`

--- a/presets/COLLECTION.md
+++ b/presets/COLLECTION.md
@@ -855,3 +855,10 @@ hats:
 - `<phase>.ready` / `<phase>.done` — Phase transitions
 - `<thing>.approved` / `<thing>.rejected` — Review gates
 - `<noun>.found` / `<noun>.missing` — Discovery events
+
+### Authoring a TOML multi-file preset
+
+For bigger presets where each role wants its own prompt file and a separate harness, use the multi-file TOML shape instead. See the autoloop authoring guide — ralph consumes that format directly via `-H <name>` or `-H <path>`:
+
+- **[Creating presets (autoloop docs)](https://mikeyobrien.github.io/autoloop/guides/creating-presets)** — directory layout, `autoloops.toml` + `topology.toml` fields, role prompts, fail-closed patterns.
+- **[Bundled examples](https://github.com/mikeyobrien/autoloop/tree/main/packages/presets/presets)** — working reference presets (autocode, autofix, autodebug, autospec, …).

--- a/presets/README.md
+++ b/presets/README.md
@@ -54,7 +54,12 @@ Example workflow patterns now live in the docs rather than as shipped preset fil
 Ralph loads hat collections in two formats:
 
 - **YAML** — single-file `<name>.yml` (ralph's native shape, same as the builtins in `presets/*.yml`).
-- **TOML multi-file** — directory containing `autoloops.toml` + `topology.toml` + `roles/*.md` + optional `harness.md`. Originally the [`@mobrienv/autoloop`](https://github.com/mobrienv/autoloop) shape; ralph now treats it as first-class alongside YAML.
+- **TOML multi-file** — directory containing `autoloops.toml` + `topology.toml` + `roles/*.md` + optional `harness.md`. Originally the [`@mobrienv/autoloop`](https://github.com/mikeyobrien/autoloop) shape; ralph now treats it as first-class alongside YAML.
+
+For the TOML shape, see the autoloop authoring guide:
+
+- **[Creating presets](https://mikeyobrien.github.io/autoloop/guides/creating-presets)** — directory layout, `autoloops.toml` + `topology.toml` fields, role prompts, harness rules, fail-closed patterns.
+- **[Bundled examples](https://github.com/mikeyobrien/autoloop/tree/main/packages/presets/presets)** — 15+ reference presets (autocode, autofix, autodebug, autospec, …) that work unchanged in ralph via `-H <name>`.
 
 **Three ways to target a preset with `-H`:**
 


### PR DESCRIPTION
Follow-up to #316 (canonical preset mechanism). Now that `-H <name>` resolves TOML multi-file presets (autoloop shape) alongside YAML, users need docs on how to *author* the TOML format. Instead of duplicating the full authoring spec here, link to the canonical autoloop docs.

## Changes

- **`docs/guide/presets.md`** \u2014 new "TOML-Shape Presets" section with authoring links + new "Preset Resolution" block enumerating the 6 lookup paths and `ralph hats list-presets`.
- **`presets/README.md`** \u2014 authoring links in "Importing External Presets"; fixed a stale `github.com/mobrienv/` URL (wrong org).
- **`presets/COLLECTION.md`** \u2014 new "Authoring a TOML multi-file preset" subsection.

All three point to:
- https://mikeyobrien.github.io/autoloop/guides/creating-presets
- https://github.com/mikeyobrien/autoloop/tree/main/packages/presets/presets

Docs-only; no code or test changes.