### PR TITLE
feat(skills): add ralph-docs skill for llms.txt-driven introspection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,18 +4,19 @@
     "name": "mikeyobrien"
   },
   "metadata": {
-    "description": "Public agent skills for operating Ralph hats and loops",
-    "version": "1.0.0"
+    "description": "Public agent skills for operating and introspecting Ralph",
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "ralph-orchestrator",
-      "description": "Skills for creating, improving, and operating Ralph hats and loops",
+      "description": "Skills for creating hats, operating loops, and introspecting Ralph via its published llms.txt",
       "source": "./",
       "strict": false,
       "skills": [
         "./skills/ralph-hats",
-        "./skills/ralph-loop"
+        "./skills/ralph-loop",
+        "./skills/ralph-docs"
       ]
     }
   ]

--- a/skills/README.md
+++ b/skills/README.md
@@ -3,12 +3,15 @@
 This directory is the canonical public skill package for external agent
 harnesses that operate Ralph.
 
-It ships two skills:
+It ships three skills:
 
 - `ralph-hats` for creating, inspecting, validating, and improving hat
   collections
 - `ralph-loop` for running, monitoring, resuming, merging, and debugging Ralph
   loops
+- `ralph-docs` for introspecting and improving Ralph itself via the
+  published `llms.txt` doc map — answering "how does Ralph do X?"
+  questions and scoping code changes to the ralph-orchestrator repo
 
 These are public agent skills. They are not part of Ralph's internal
 `ralph tools skill` registry.
@@ -31,12 +34,13 @@ List the skills in this repository:
 npx skills add mikeyobrien/ralph-orchestrator --list
 ```
 
-Install both skills for Claude Code:
+Install all skills for Claude Code:
 
 ```bash
 npx skills add mikeyobrien/ralph-orchestrator \
   --skill ralph-hats \
   --skill ralph-loop \
+  --skill ralph-docs \
   -a claude-code \
   -y
 ```

--- a/skills/ralph-docs/SKILL.md
+++ b/skills/ralph-docs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: ralph-docs
+description: Introspect, explain, and improve Ralph Orchestrator using its published llms.txt doc map. Use this skill whenever the user asks questions about Ralph's behavior, wants to understand how a Ralph internal works (event loop, hats, memories, tasks, backends, presets), debug an unfamiliar failure mode, or propose a code change to the ralph-orchestrator repo. The skill teaches the agent to discover authoritative answers from the live docs via llms.txt before guessing, and to scope improvements through the published architecture rather than the local checkout alone.
+---
+
+# Ralph Docs
+
+Introspect Ralph Orchestrator the same way the framework expects a smart agent to
+— consult the published documentation map at
+<https://mikeyobrien.github.io/ralph-orchestrator/llms.txt>, fetch only the
+sections relevant to the question, and answer from authoritative sources.
+
+Use this skill to behave like an internal Ralph contributor rather than a
+guess-first assistant.
+
+## Use This Skill For
+
+- Answering "how does Ralph do X?" questions about the event loop, hats,
+  memories, tasks, presets, backends, CLI, TUI, diagnostics, waves, or API.
+- Explaining an observed behavior ("why did my loop terminate with
+  max_iterations?", "why didn't my hat fire?") from first principles in the
+  docs, not pattern-matching.
+- Proposing and scoping an improvement to the `ralph-orchestrator` codebase —
+  locating the right crate, the relevant concept doc, and the existing test
+  surface before writing code.
+- Triaging a ralph bug report: map symptoms to likely subsystem, pull in the
+  concept + reference docs for that subsystem, identify the probable file path
+  in the repo.
+- Onboarding: answer a new user's setup/quick-start questions from the official
+  Getting Started pages instead of the agent's stale training data.
+
+## Core Principle: llms.txt Is The Router
+
+Ralph's llms.txt is a curated map, not a full-text dump. The workflow is:
+
+1. **Discover** — fetch `llms.txt` to see the top-level sections
+   (Getting Started / Concepts / User Guide / Advanced / API / Examples /
+   Contributing / Reference).
+2. **Narrow** — pick the 1–3 pages that actually answer the question. The map
+   links directly to `.md` versions — those are agent-optimized and should be
+   preferred over scraping HTML.
+3. **Fetch** — pull only those pages. Do not fetch more than three pages
+   speculatively; the budget should be spent on answering, not browsing.
+4. **Cross-check** — for code-level claims, confirm against the repo (crate
+   paths are listed in AGENTS.md / CLAUDE.md inside the ralph-orchestrator
+   checkout).
+5. **Answer** — cite the page you relied on. Include the URL so the user can
+   verify.
+
+## Workflow
+
+1. Identify the question's subsystem using the taxonomy in
+   `references/llms-txt-map.md` (hats, event loop, memories, tasks, backends,
+   presets, CLI, TUI, diagnostics, waves, API).
+2. If `~/.cache/ralph-docs/llms.txt` exists and is <7 days old, use it. Else
+   refetch it:
+
+   ```bash
+   mkdir -p ~/.cache/ralph-docs
+   curl -sSfL https://mikeyobrien.github.io/ralph-orchestrator/llms.txt \
+     -o ~/.cache/ralph-docs/llms.txt
+   ```
+
+3. Pick the 1–3 linked `.md` pages most relevant to the subsystem. The map
+   entries are documented in `references/llms-txt-map.md`; use it to shortcut
+   the grep.
+4. Fetch just those pages via `curl -sSfL <url> -o ~/.cache/ralph-docs/<stem>.md`
+   and read them. Agents with `web_fetch` or an equivalent tool should use that
+   instead.
+5. Answer the user's question grounded in what you just read. Quote the
+   relevant sentence when the user asks "does Ralph do X?" so they can audit.
+6. If the answer requires a code change, switch to the ralph-orchestrator
+   checkout and follow `references/contributing.md` for the propose-a-change
+   workflow.
+
+## Scope Boundaries
+
+- This skill answers and explains. For creating/modifying user hats, defer to
+  **ralph-hats**. For operating a live loop (running, resuming, merging,
+  debugging), defer to **ralph-loop**. For code changes to
+  ralph-orchestrator itself, this skill scopes the change; the actual editing
+  uses the agent's native code-editing tools.
+- Do not invent features not present in the published docs. If llms.txt does
+  not surface an answer, say so and suggest checking the source tree at
+  <https://github.com/mikeyobrien/ralph-orchestrator>.
+- Do not rely on the agent's pretraining for version-sensitive claims (e.g.
+  CLI flags, preset names). Ralph's CLI evolves; always verify against
+  `guide/cli-reference.md` or `reference/changelog.md`.
+
+## Guardrails
+
+- Prefer `.md` URLs from llms.txt over scraping the rendered HTML.
+- Cache fetched pages under `~/.cache/ralph-docs/` with a 7-day staleness
+  threshold. Refetch llms.txt before any other doc to detect renames/moves.
+- When cited docs contradict the local checkout (docs newer than the user's
+  installed ralph version), note the mismatch and suggest `ralph --version` so
+  the user can decide which to trust.
+- For "how to improve Ralph" requests, always read
+  `concepts/tenets/index.md` first. Ralph's six tenets are load-bearing;
+  changes that fight them usually belong somewhere else.
+
+## Output Expectations
+
+- Answer first, then link. Don't make the user wait for a verbose tour.
+- Include at least one source URL for non-trivial claims.
+- When proposing a code change, name the crate + file (see
+  `references/contributing.md` for the crate map), the concept doc that
+  justifies the change, and the test file that should cover it.
+
+## Read These References When Needed
+
+- For the llms.txt section map + which pages answer which question:
+  `references/llms-txt-map.md`
+- For FAQ recipes (common introspection patterns):
+  `references/common-questions.md`
+- For how to propose a code change, including crate layout and PR conventions:
+  `references/contributing.md`

--- a/skills/ralph-docs/agents/openai.yaml
+++ b/skills/ralph-docs/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Ralph Docs"
+  short_description: "Introspect and improve Ralph via its published llms.txt doc map"
+  default_prompt: "Use $ralph-docs to answer this question or scope this improvement using Ralph's published documentation."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/ralph-docs/references/common-questions.md
+++ b/skills/ralph-docs/references/common-questions.md
@@ -1,0 +1,119 @@
+# Common Ralph Introspection Recipes
+
+Use these patterns when the user's question matches. Each recipe is:
+1. Trigger — what the user said
+2. Fetch — which doc pages to pull
+3. Check — what to grep or grep-equivalent in them
+4. Answer shape — how to frame the reply
+
+## "Why did my loop terminate?"
+
+1. **Trigger**: User shares a `Loop terminated:` banner or exit code 2.
+2. **Fetch**:
+   - `reference/troubleshooting/index.md`
+   - `concepts/hats-and-events/index.md` (for the completion model)
+3. **Check**: look for the specific reason string (`max_iterations`,
+   `max_runtime_seconds`, `completion_promise`, `required_events`, `error`).
+   Each maps to a documented termination path.
+4. **Answer shape**: name the termination reason, quote the doc on what it
+   means, tell the user the exact config knob (in ralph.yml or preset) that
+   controls it. If it's `max_iterations` with work still pending, suggest
+   raising the cap or checking whether `required_events` was actually emitted.
+
+## "Why isn't my hat firing?"
+
+1. **Trigger**: user-authored hat doesn't activate after the expected event.
+2. **Fetch**:
+   - `concepts/hats-and-events/index.md`
+   - `reference/troubleshooting/index.md` (ambiguous-routing section)
+3. **Check**: confirm the hat's `triggers:` matches the emitted event
+   **exactly** (no wildcards), and that only one hat claims that trigger
+   (ralph rejects ambiguous routing at preflight).
+4. **Answer shape**: run `ralph hats validate` + `ralph hats graph`; show the
+   expected event chain; point at the specific trigger in the preset.
+
+## "Which preset should I use for X?"
+
+1. **Trigger**: "should I use code-assist or feature?"
+2. **Fetch**:
+   - `guide/presets/index.md` (preset decision matrix)
+3. **Check**: pattern column + entry event + completion event.
+4. **Answer shape**: one-line recommendation + why (cite the pattern it
+   matches). Offer `ralph hats list-presets` so the user sees everything
+   discoverable locally, including TOML presets from `~/.config/autoloop/presets/`.
+
+## "How does Ralph decide a backend?"
+
+1. **Trigger**: "why did it pick claude?", "how do I force kiro-acp?".
+2. **Fetch**:
+   - `guide/backends/index.md`
+   - `reference/faq/index.md` (auto-detect precedence)
+3. **Check**: resolution order is CLI flag (`-b`) > `cli.backend:` in config >
+   auto-detect walking the default priority list.
+4. **Answer shape**: print the precedence, show the user the exact override
+   for their case (flag or config).
+
+## "What is the .ralph/ directory for?"
+
+1. **Fetch**:
+   - `advanced/memory-system/index.md`
+   - `advanced/task-system/index.md`
+   - `concepts/memories-and-tasks/index.md`
+2. **Check**: scratchpad, memories.md, tasks.jsonl, loop.lock, loops.json,
+   merge-queue.jsonl purposes.
+3. **Answer shape**: one sentence per file + which ralph command touches it.
+
+## "How do I add a new backend?"
+
+1. **Trigger**: "I want Ralph to support X model CLI".
+2. **Fetch**:
+   - `guide/backends/index.md` (existing patterns)
+   - `api/ralph-adapters/index.md` (the adapter trait / executor types)
+3. **Check**: the backend enum, `CliBackend::<name>()` factory, executor
+   type (PTY/Stdio/Acp), priority-list insertion point.
+4. **Answer shape**: list the crates to edit (`ralph-adapters` for the
+   backend + executor, `ralph-cli/src/doctor.rs` for env-var diagnostics,
+   `guide/backends.md` for docs, tests). Refer the user to
+   `references/contributing.md` for the PR workflow.
+
+## "Why is Ralph slow / stuck?"
+
+1. **Fetch**:
+   - `reference/troubleshooting/index.md` (idle-timeout section)
+   - `advanced/diagnostics/index.md`
+2. **Check**: `idle_timeout_secs`, backend cold-start cost, TUI subprocess
+   mode, diagnostic log path (`.ralph/diagnostics/logs/`).
+3. **Answer shape**: direct them to the diagnostic log filename convention;
+   suggest raising `idle_timeout_secs` for slow backends (kiro-acp is ~20s
+   cold start).
+
+## "How do I reset Ralph state between runs?"
+
+1. **Fetch**:
+   - `guide/cli-reference/index.md` (`ralph clean`)
+2. **Answer shape**: `ralph clean` clears `.ralph/agent/`; manual removal of
+   `.ralph/loops.json` for loop registry; `.ralph/merge-queue.jsonl` for
+   merge queue.
+
+## "Does Ralph support X feature?"
+
+The generic pattern:
+
+1. `curl` llms.txt.
+2. `grep` for the feature keyword in section titles and link descriptions.
+3. If present → fetch that page, confirm, answer yes with source.
+4. If absent → search `reference/changelog/index.md` for recent additions.
+5. Still absent → search `specs/` in the repo (not on doc site).
+6. Finally → source tree at
+   <https://github.com/mikeyobrien/ralph-orchestrator/tree/main/crates>.
+
+Do not assume features exist because "they should" — Ralph is deliberately
+minimal. When unsure, say "not documented; here's where to confirm".
+
+## "What changed in the latest version?"
+
+1. **Fetch**:
+   - `reference/changelog/index.md`
+2. **Answer**: summarize the entries newer than the user's local
+   `ralph --version`. Include PR numbers when linked (e.g. #316) for
+   traceability.

--- a/skills/ralph-docs/references/contributing.md
+++ b/skills/ralph-docs/references/contributing.md
@@ -1,0 +1,117 @@
+# Proposing a Ralph Code Change
+
+Use this when the user wants to improve or fix something in the
+`ralph-orchestrator` repo itself (not their own hat collection).
+
+## Before Writing Code
+
+1. **Confirm it's not already a feature.** Fetch the relevant doc page from
+   llms.txt. Ralph is deliberately minimal; sometimes the answer is "use the
+   existing knob".
+2. **Confirm it doesn't violate a tenet.** Read
+   `concepts/tenets/index.md`. The six tenets are load-bearing:
+   fresh-context, backpressure, disposable plans, disk-is-state,
+   steer-with-signals, let-Ralph-Ralph. Changes that fight these usually
+   belong elsewhere.
+3. **Map it to the right crate.** See the crate map below.
+
+## Crate Map
+
+```
+ralph-cli      → CLI entry point; subcommands (run, plan, task, loops, web, hats)
+ralph-core     → Orchestration logic: event loop, hats, memories, tasks, preset_source
+ralph-adapters → Backend integrations (Claude, Kiro, Gemini, Codex, Roo, etc.)
+ralph-telegram → Telegram bot for human-in-the-loop
+ralph-tui      → Terminal UI (ratatui)
+ralph-e2e      → End-to-end test framework
+ralph-proto    → Protocol definitions
+ralph-bench    → Benchmarking
+ralph-api      → HTTP API server
+backend/       → Web dashboard server (Fastify + tRPC + SQLite)
+frontend/      → Web dashboard UI (React + Vite)
+```
+
+More precise file map (from the repo AGENTS.md):
+
+| Subsystem | File |
+|---|---|
+| Event loop | `crates/ralph-core/src/event_loop/mod.rs` |
+| Hat system | `crates/ralph-core/src/hatless_ralph.rs` |
+| Memory | `crates/ralph-core/src/memory.rs`, `memory_store.rs` |
+| Tasks | `crates/ralph-core/src/task.rs`, `task_store.rs` |
+| Preset source (YAML + TOML) | `crates/ralph-core/src/preset_source.rs` |
+| Lock coordination | `crates/ralph-core/src/worktree.rs` |
+| Loop registry | `crates/ralph-core/src/loop_registry.rs` |
+| Merge queue | `crates/ralph-core/src/merge_queue.rs` |
+| CLI commands | `crates/ralph-cli/src/loops.rs`, `hats.rs`, `task_cli.rs`, `main.rs` |
+| Backend selection | `crates/ralph-adapters/src/cli_backend.rs`, `auto_detect.rs` |
+| ACP executor | `crates/ralph-adapters/src/acp_executor.rs` |
+| Preflight | `crates/ralph-cli/src/preflight.rs` |
+| Doctor | `crates/ralph-cli/src/doctor.rs` |
+
+## Required Build/Test Sequence
+
+Run these in order before opening a PR:
+
+```bash
+cargo fmt                                            # no warnings accepted
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test -p ralph-core                             # loader + core tests
+cargo test -p ralph-cli --bin ralph <your_module>::  # module-scoped
+cargo test -p ralph-cli --test <integration_file>    # integration tests
+./scripts/ci-rust-gate.sh                            # what CI actually runs
+```
+
+If the change is user-visible, also update:
+
+- `docs/guide/<relevant>.md` (user-facing behavior change)
+- `docs/reference/changelog/index.md` (add a line under Unreleased)
+- Any preset YAML/TOML under `presets/` if the change affects them
+
+## PR Conventions
+
+- **Branch naming**: `feat/<topic>`, `fix/<topic>`, `docs/<topic>`.
+- **Commit style**: conventional commits — `feat(cli):`, `fix(core):`,
+  `docs(presets):`, etc. Keep the subject ≤72 chars.
+- **Body**: explain *why*, not just *what*. Link to the issue / doc if there
+  is one.
+- **Merge mode**: squash. The repo squash-merges by default via
+  `gh pr merge <N> --squash --delete-branch`.
+- **Do not push directly to main**; open a PR even for trivial changes.
+
+## Testing a Change Against a Real Ralph Loop
+
+For behavioral changes (not cosmetics), run at least one end-to-end
+iteration with a minimal preset against a real backend before merging:
+
+```bash
+cd /tmp/ralph-smoketest && mkdir -p x && cd x
+echo "trivial task" > PROMPT.md
+ralph run -H builtin:hatless-baseline -b claude -P PROMPT.md --max-iterations 2 -a -q
+cat .ralph/events-*.jsonl
+```
+
+Confirm events fire and the termination reason is what you expect.
+
+## When To Defer
+
+- Pure surface polish (typos, stale doc links, formatting) → open a docs PR.
+- Feature requests touching multiple crates → write a spec under `specs/` first
+  and get alignment before coding.
+- Anything changing the hat contract, event loop semantics, or disk layout
+  (`.ralph/` structure) → read all six tenet docs, draft a spec, and expect
+  discussion.
+
+## After Merge
+
+Sync local main, then reinstall:
+
+```bash
+git checkout main && git pull --rebase
+cargo build --release --bin ralph
+install -m 755 target/release/ralph ~/.cargo/bin/ralph
+ralph --version
+```
+
+Use `install` instead of `cp` — macOS Gatekeeper caches the original
+signature and can silently SIGKILL a cp'd binary whose contents changed.

--- a/skills/ralph-docs/references/llms-txt-map.md
+++ b/skills/ralph-docs/references/llms-txt-map.md
@@ -1,0 +1,101 @@
+# Ralph llms.txt Section Map
+
+The authoritative doc index is at
+<https://mikeyobrien.github.io/ralph-orchestrator/llms.txt>.
+
+This file is a **routing shortcut** — given a user question or bug report, it
+tells you which 1–3 pages to fetch. Always refetch llms.txt itself before any
+other page; URLs do get renamed.
+
+## Top-Level Sections
+
+1. **Getting Started** — setup, install, first task. Use for onboarding.
+2. **Concepts** — mental model. Use for "why does Ralph work this way?"
+3. **User Guide** — practical CLI usage. Use for "how do I…?"
+4. **Advanced** — architecture, subsystems. Use for deep questions.
+5. **API Reference** — crate-level rustdoc. Use for code changes.
+6. **Examples** — working config patterns. Use as templates.
+7. **Contributing** — dev setup, PR conventions. Use before shipping changes.
+8. **Reference** — changelog, FAQ, glossary, troubleshooting. Use for
+   version-specific claims and error triage.
+
+## Question → Page Map
+
+Use this before speculatively fetching. The canonical URL pattern is
+`https://mikeyobrien.github.io/ralph-orchestrator/<path>/index.md`.
+
+### Event loop behavior
+
+- "Why did my loop terminate?" → `reference/troubleshooting/index.md`
+- "What is the starting event?" → `concepts/hats-and-events/index.md`
+- "How does fresh-context-each-iteration work?" →
+  `concepts/tenets/index.md`, `concepts/ralph-wiggum-technique/index.md`
+- "How do completion events work?" → `advanced/event-system/index.md`
+
+### Hats (user-authored workflows)
+
+- "How do I write a hat?" → `advanced/custom-hats/index.md`
+- "What's a trigger vs a publish?" → `concepts/hats-and-events/index.md`
+- "Which builtin preset should I use?" → `guide/presets/index.md`
+- "Why is my hat not firing?" → `reference/troubleshooting/index.md` +
+  `concepts/hats-and-events/index.md`
+
+### Memories + Tasks
+
+- "How do memories persist?" → `advanced/memory-system/index.md`
+- "Where are tasks stored?" → `advanced/task-system/index.md`,
+  `concepts/memories-and-tasks/index.md`
+- "How do I reset them?" — check CLI: `guide/cli-reference/index.md` (`ralph clean`)
+
+### Backends
+
+- "What backends are supported?" → `guide/backends/index.md`
+- "How does backend selection work?" → `guide/backends/index.md` +
+  `reference/faq/index.md` (auto-detect order)
+- "Why does my backend time out?" → `reference/troubleshooting/index.md`
+- kiro-acp, claude, gemini, codex, pi, roo, copilot, opencode, amp —
+  all covered in `guide/backends/index.md`
+
+### Presets
+
+- "List the presets" → `guide/presets/index.md` (+ `ralph hats list-presets`
+  for discoverable ones on the user's system)
+- "Authoring YAML presets" → `guide/presets/index.md`
+- "Authoring TOML presets" → link out to
+  <https://mikeyobrien.github.io/autoloop/guides/creating-presets>
+- Preset resolver paths → `guide/presets/index.md` (since PR #316)
+
+### CLI + TUI
+
+- Flag meanings → `guide/cli-reference/index.md`
+- Autonomous vs interactive → `guide/cli-reference/index.md`
+- RPC mode / subprocess TUI → `api/ralph-cli/index.md`
+- Web dashboard → `advanced/diagnostics/index.md`
+
+### Parallel loops + waves
+
+- Worktrees, merge queue → `advanced/parallel-loops/index.md`
+- Wave dispatch → `advanced/agent-waves/index.md`
+
+### Code contribution
+
+- Crate layout → AGENTS.md in the repo root (not on the doc site)
+- Dev setup → `contributing/setup/index.md`
+- Style → `contributing/style/index.md`
+- Tests → `contributing/testing/index.md`
+- PRs → `contributing/pull-requests/index.md`
+
+## Freshness
+
+llms.txt is regenerated on doc deploys. Cache for at most 7 days. Any doc
+page linked from it is the canonical source for its topic — prefer it over
+README snippets in the repo, which may lag.
+
+## When llms.txt Doesn't Cover It
+
+- **Crate-internal details** not surfaced in API docs: read the source at
+  <https://github.com/mikeyobrien/ralph-orchestrator/tree/main/crates>.
+- **Recent changes**: consult `reference/changelog/index.md` and the GitHub
+  releases/commit log.
+- **Experimental features**: may live in `specs/` in the repo, not on the
+  doc site.


### PR DESCRIPTION
Third public skill in the ralph-orchestrator plugin, alongside `ralph-hats` and `ralph-loop`. Teaches external agents (Claude Code, Codex, etc.) to introspect and improve Ralph via the published [llms.txt](https://mikeyobrien.github.io/ralph-orchestrator/llms.txt) doc map instead of guessing from pretraining.

## Motivation

Ralph already publishes a curated llms.txt (documented at llmsdotxt.com as the emerging standard for AI-readable docs). Agents that know to consult it answer questions authoritatively; agents that don't tend to pattern-match stale knowledge. This skill makes the former the default.

Pattern is the same one Claude Code uses for its own docs: SKILL.md declares triggers + workflow, references/ holds the routing map + FAQ recipes + contribution scope, agents/ holds the per-runtime manifest.

## What it enables

- **Q&A**: "how does Ralph do X?" \u2192 fetch the relevant concept/guide page, quote the authoritative answer, cite the URL.
- **Bug triage**: "why did my loop terminate?" \u2192 map symptom to subsystem doc (troubleshooting + tenets + hats-and-events), not guess.
- **Code changes**: "add backend X" \u2192 locate the right crate (ralph-adapters + doctor + docs + tests), cite the architecture doc that justifies the approach, name the PR conventions.
- **Onboarding**: new users get answers from Getting Started pages rather than the agent's stale training data.

## Contents

- `skills/ralph-docs/SKILL.md` \u2014 frontmatter trigger + 6-step workflow + scope boundaries + guardrails.
- `skills/ralph-docs/references/llms-txt-map.md` \u2014 subsystem \u2192 page routing shortcut.
- `skills/ralph-docs/references/common-questions.md` \u2014 8 FAQ recipes (loop termination, hat not firing, backend selection, .ralph/ layout, adding a backend, slow loops, state reset, feature-support check).
- `skills/ralph-docs/references/contributing.md` \u2014 crate map, required build/test sequence, PR conventions, macOS `install` vs `cp` gotcha.
- `skills/ralph-docs/agents/openai.yaml` \u2014 Codex agent manifest.

## Plugin registration

- `skills/README.md` lists ralph-docs as the third skill.
- `.claude-plugin/marketplace.json` registers it + bumps plugin version `1.0.0 \u2192 1.1.0`.

## No code changes

Pure docs / skill content. No CI impact beyond format checks.