### PR TITLE
fix(event-loop): persist continue state

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -231,6 +231,14 @@ pub async fn run_loop_impl(
 
     // Initialize event loop with context for proper path resolution
     let mut event_loop = EventLoop::with_context(config.clone(), ctx.clone());
+    let loop_state_path = event_loop.loop_state_path();
+    if resume {
+        if let Err(e) = event_loop.restore_loop_state(&loop_state_path) {
+            warn!("Failed to restore persisted loop state: {}", e);
+        }
+    } else if let Err(e) = EventLoop::clear_loop_state(&loop_state_path) {
+        warn!("Failed to clear stale persisted loop state: {}", e);
+    }
 
     // Inject robot service (Telegram) for human-in-the-loop communication
     if config.robot.enabled
@@ -338,6 +346,14 @@ pub async fn run_loop_impl(
     // Initialize event logger for debugging (uses context for path resolution)
     let mut event_logger = EventLogger::from_context(&ctx);
 
+    // On --continue, hydrate runtime state from the existing events file before
+    // appending this process's task.resume record. This preserves historical
+    // seen_topics and republishes watchdog/human resume events appended after
+    // the last loop.terminate without double-delivering the fresh task.resume.
+    if resume && let Err(e) = event_loop.replay_resume_events_from_jsonl() {
+        warn!("Failed to replay resume events from JSONL: {}", e);
+    }
+
     // Log initial event (use configured starting_event or default to task.start/task.resume)
     let default_start_topic = if resume { "task.resume" } else { "task.start" };
     let start_topic = config
@@ -435,7 +451,8 @@ pub async fn run_loop_impl(
             std::sync::Mutex::new(("unknown".to_string(), "Unknown".to_string())),
         );
         let rpc_state_completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let rpc_state_total_cost: Arc<std::sync::Mutex<f64>> = Arc::new(std::sync::Mutex::new(0.0));
+        let rpc_state_total_cost: Arc<std::sync::Mutex<f64>> =
+            Arc::new(std::sync::Mutex::new(event_loop.state().cumulative_cost));
 
         let rpc_state_iteration_clone = rpc_state_iteration.clone();
         let rpc_state_hat_clone = rpc_state_hat.clone();
@@ -1977,8 +1994,14 @@ pub async fn run_loop_impl(
             event_loop.registry(),
         );
 
-        // Process output
-        if let Some(reason) = event_loop.process_output(&hat_id, &output, success) {
+        // Process output; cost must be added before termination checks so
+        // max_cost applies across iterations and across --continue resumes.
+        event_loop.add_cost(outcome.total_cost_usd);
+        let termination = event_loop.process_output(&hat_id, &output, success);
+        if let Err(e) = event_loop.save_loop_state(&loop_state_path) {
+            warn!("Failed to persist loop state: {}", e);
+        }
+        if let Some(reason) = termination {
             // Per spec: Log "All done! {promise} detected." when completion promise found
             if reason == TerminationReason::CompletionPromise {
                 info!(

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -921,10 +921,10 @@ impl EventLoop {
             if line.trim().is_empty() {
                 continue;
             }
-            if let Ok(event) = serde_json::from_str::<crate::event_reader::Event>(&line) {
-                if event.topic == "loop.terminate" {
-                    last_terminate = Some(index as u64 + 1);
-                }
+            if let Ok(event) = serde_json::from_str::<crate::event_reader::Event>(&line)
+                && event.topic == "loop.terminate"
+            {
+                last_terminate = Some(index as u64 + 1);
             }
         }
 

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -19,6 +19,7 @@ use crate::memory_store::{MarkdownMemoryStore, format_memories_as_markdown, trun
 use crate::skill_registry::SkillRegistry;
 use crate::text::floor_char_boundary;
 use ralph_proto::{CheckinContext, Event, EventBus, Hat, HatId, RobotService};
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -47,6 +48,14 @@ pub struct ProcessedEventsWithWaves {
     pub processed: ProcessedEvents,
     /// Wave events extracted before normal processing (have wave_id set).
     pub wave_events: Vec<crate::event_reader::Event>,
+}
+
+/// Durable subset of loop runtime state restored by `ralph run --continue`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PersistedLoopState {
+    pub iteration: u32,
+    pub total_cost_usd: f64,
+    pub last_hat: Option<String>,
 }
 
 /// Reason the event loop terminated.
@@ -465,6 +474,61 @@ impl EventLoop {
         &self.state
     }
 
+    /// Returns the path used for durable `--continue` loop state.
+    pub fn loop_state_path(&self) -> PathBuf {
+        self.loop_context
+            .as_ref()
+            .map(|ctx| ctx.ralph_dir().join("api/loop-state.json"))
+            .unwrap_or_else(|| PathBuf::from(".ralph/api/loop-state.json"))
+    }
+
+    /// Serializes the durable subset of runtime state.
+    pub fn persisted_loop_state(&self) -> PersistedLoopState {
+        PersistedLoopState {
+            iteration: self.state.iteration,
+            total_cost_usd: self.state.cumulative_cost,
+            last_hat: self
+                .state
+                .last_hat
+                .as_ref()
+                .map(|hat| hat.as_str().to_string()),
+        }
+    }
+
+    /// Restores persisted `--continue` state from disk if present.
+    pub fn restore_loop_state(&mut self, path: &std::path::Path) -> std::io::Result<()> {
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let raw = std::fs::read_to_string(path)?;
+        let persisted: PersistedLoopState = serde_json::from_str(&raw).map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+        })?;
+        self.state.iteration = persisted.iteration;
+        self.state.cumulative_cost = persisted.total_cost_usd;
+        self.state.last_hat = persisted.last_hat.map(HatId::new);
+        Ok(())
+    }
+
+    /// Saves persisted `--continue` state to disk.
+    pub fn save_loop_state(&self, path: &std::path::Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let payload = serde_json::to_string_pretty(&self.persisted_loop_state())?;
+        std::fs::write(path, payload)
+    }
+
+    /// Removes stale persisted loop state for a fresh run.
+    pub fn clear_loop_state(path: &std::path::Path) -> std::io::Result<()> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
     /// Resets the stale-loop topic counter.
     ///
     /// Call after processing wave results — multiple events with the same topic
@@ -787,6 +851,46 @@ impl EventLoop {
             // Find ralph in the bus's registered hats
             self.bus.hat_ids().find(|id| id.as_str() == "ralph")
         }
+    }
+
+    /// Replays persisted events needed to resume an interrupted/parked loop.
+    ///
+    /// Resume has two separate needs:
+    /// - all historical topics hydrate `seen_topics` so event-chain validation
+    ///   knows what happened before the process restarted;
+    /// - events appended after the last `loop.terminate` are republished to the
+    ///   in-memory bus so watchdog/human resume events trigger hats naturally.
+    ///
+    /// Events at or before the last `loop.terminate` are state history only and
+    /// must not be republished, otherwise `--continue` would rerun old work.
+    pub fn replay_resume_events_from_jsonl(&mut self) -> std::io::Result<ProcessedEvents> {
+        let path = self.event_reader.path().to_path_buf();
+        let mut historical_reader = EventReader::new(&path);
+        let result = historical_reader.read_new_events()?;
+
+        for event in &result.events {
+            self.state.seen_topics.insert(event.topic.clone());
+        }
+
+        let last_terminate_index = result
+            .events
+            .iter()
+            .rposition(|event| event.topic == "loop.terminate");
+        let replay_events = match last_terminate_index {
+            Some(index) => result.events.into_iter().skip(index + 1).collect(),
+            None => Vec::new(),
+        };
+
+        let processed = self.process_parse_result(crate::event_reader::ParseResult {
+            events: replay_events,
+            malformed: result.malformed,
+        })?;
+
+        if let Ok(metadata) = std::fs::metadata(&path) {
+            self.event_reader.set_position(metadata.len());
+        }
+
+        Ok(processed)
     }
 
     /// Advances the event reader to the current end of the events file.

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -21,7 +21,8 @@ use crate::text::floor_char_boundary;
 use ralph_proto::{CheckinContext, Event, EventBus, Hat, HatId, RobotService};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::path::PathBuf;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
@@ -876,14 +877,27 @@ impl EventLoop {
             .events
             .iter()
             .rposition(|event| event.topic == "loop.terminate");
+        let last_terminate_line = if result.malformed.is_empty() {
+            None
+        } else {
+            Self::last_terminate_line_number(&path)?
+        };
         let replay_events = match last_terminate_index {
             Some(index) => result.events.into_iter().skip(index + 1).collect(),
+            None => Vec::new(),
+        };
+        let replay_malformed = match last_terminate_line {
+            Some(line_number) => result
+                .malformed
+                .into_iter()
+                .filter(|malformed| malformed.line_number > line_number)
+                .collect(),
             None => Vec::new(),
         };
 
         let processed = self.process_parse_result(crate::event_reader::ParseResult {
             events: replay_events,
-            malformed: result.malformed,
+            malformed: replay_malformed,
         })?;
 
         if let Ok(metadata) = std::fs::metadata(&path) {
@@ -891,6 +905,30 @@ impl EventLoop {
         }
 
         Ok(processed)
+    }
+
+    fn last_terminate_line_number(path: &Path) -> std::io::Result<Option<u64>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let file = std::fs::File::open(path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut last_terminate = None;
+
+        for (index, line) in reader.lines().enumerate() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(event) = serde_json::from_str::<crate::event_reader::Event>(&line) {
+                if event.topic == "loop.terminate" {
+                    last_terminate = Some(index as u64 + 1);
+                }
+            }
+        }
+
+        Ok(last_terminate)
     }
 
     /// Advances the event reader to the current end of the events file.

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -423,6 +423,47 @@ hats:
 }
 
 #[test]
+fn test_resume_replay_ignores_malformed_events_before_last_terminate() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let yaml = r#"
+hats:
+  monitor:
+    name: "Monitor"
+    triggers: ["build.monitoring.resume"]
+    publishes: ["build.monitoring.done"]
+"#;
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+
+    write_raw_line_to_jsonl(&events_path, "{not json");
+    write_raw_line_to_jsonl(&events_path, "{\"topic\":");
+    write_raw_line_to_jsonl(&events_path, "still not json");
+    write_event_to_jsonl(&events_path, "task.start", "original objective");
+    write_event_to_jsonl(&events_path, "loop.terminate", "parked");
+    write_event_to_jsonl(
+        &events_path,
+        "build.monitoring.resume",
+        "watchdog says continue",
+    );
+
+    event_loop.replay_resume_events_from_jsonl().unwrap();
+
+    assert_eq!(
+        event_loop.state.consecutive_malformed_events, 0,
+        "malformed history before the last loop.terminate must not trip resume validation"
+    );
+
+    let prompt = event_loop.build_prompt(&HatId::new("ralph")).unwrap();
+    assert!(prompt.contains("build.monitoring.resume"));
+    assert!(!prompt.contains("event.malformed"));
+}
+
+#[test]
 fn test_completion_promise_detection() {
     use std::fs;
     use tempfile::TempDir;
@@ -719,6 +760,16 @@ fn write_event_to_jsonl(path: &std::path::Path, topic: &str, payload: &str) {
         .open(path)
         .unwrap();
     writeln!(file, "{}", event_json).unwrap();
+}
+
+fn write_raw_line_to_jsonl(path: &std::path::Path, line: &str) {
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap();
+    writeln!(file, "{line}").unwrap();
 }
 
 #[test]

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -298,6 +298,131 @@ event_loop:
 }
 
 #[test]
+fn test_persisted_loop_state_round_trips_iteration_cost_and_last_hat() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let state_path = temp_dir.path().join(".ralph/api/loop-state.json");
+
+    let mut event_loop = EventLoop::new(RalphConfig::default());
+    event_loop.state.iteration = 7;
+    event_loop.state.cumulative_cost = 1.23;
+    event_loop.state.last_hat = Some(HatId::new("builder"));
+    event_loop.save_loop_state(&state_path).unwrap();
+
+    let mut resumed = EventLoop::new(RalphConfig::default());
+    resumed.restore_loop_state(&state_path).unwrap();
+
+    assert_eq!(resumed.state.iteration, 7);
+    assert!((resumed.state.cumulative_cost - 1.23).abs() < f64::EPSILON);
+    assert_eq!(resumed.state.last_hat.as_ref().unwrap().as_str(), "builder");
+}
+
+#[test]
+fn test_fresh_run_clears_stale_persisted_loop_state() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let state_path = temp_dir.path().join(".ralph/api/loop-state.json");
+
+    let mut event_loop = EventLoop::new(RalphConfig::default());
+    event_loop.state.iteration = 3;
+    event_loop.state.cumulative_cost = 0.42;
+    event_loop.save_loop_state(&state_path).unwrap();
+    assert!(state_path.exists());
+
+    EventLoop::clear_loop_state(&state_path).unwrap();
+    assert!(!state_path.exists());
+}
+
+#[test]
+fn test_resume_replay_hydrates_seen_topics_without_republishing_pre_terminate_events() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let yaml = r#"
+hats:
+  monitor:
+    name: "Monitor"
+    triggers: ["build.monitoring.resume"]
+    publishes: ["build.monitoring.done"]
+"#;
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+
+    write_event_to_jsonl(&events_path, "task.start", "original objective");
+    write_event_to_jsonl(
+        &events_path,
+        "build.monitoring.park",
+        "park before shutdown",
+    );
+    write_event_to_jsonl(&events_path, "loop.terminate", "parked");
+
+    event_loop.replay_resume_events_from_jsonl().unwrap();
+
+    assert!(event_loop.state.seen_topics.contains("task.start"));
+    assert!(
+        event_loop
+            .state
+            .seen_topics
+            .contains("build.monitoring.park")
+    );
+    assert!(event_loop.state.seen_topics.contains("loop.terminate"));
+    assert!(
+        !event_loop.has_pending_events(),
+        "events before the last loop.terminate should hydrate state but not re-trigger hats"
+    );
+}
+
+#[test]
+fn test_resume_replay_publishes_events_after_last_terminate_to_bus() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let yaml = r#"
+hats:
+  monitor:
+    name: "Monitor"
+    triggers: ["build.monitoring.resume"]
+    publishes: ["build.monitoring.done"]
+"#;
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+
+    write_event_to_jsonl(&events_path, "task.start", "original objective");
+    write_event_to_jsonl(&events_path, "loop.terminate", "parked");
+    write_event_to_jsonl(
+        &events_path,
+        "build.monitoring.resume",
+        "watchdog says continue",
+    );
+
+    event_loop.replay_resume_events_from_jsonl().unwrap();
+
+    assert!(event_loop.state.seen_topics.contains("task.start"));
+    assert!(event_loop.state.seen_topics.contains("loop.terminate"));
+    assert!(
+        event_loop
+            .state
+            .seen_topics
+            .contains("build.monitoring.resume")
+    );
+
+    let prompt = event_loop.build_prompt(&HatId::new("ralph")).unwrap();
+    assert!(
+        prompt.contains("build.monitoring.resume"),
+        "post-terminate resume event should be delivered to the in-memory bus"
+    );
+    assert!(prompt.contains("watchdog says continue"));
+}
+
+#[test]
 fn test_completion_promise_detection() {
     use std::fs;
     use tempfile::TempDir;

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -464,6 +464,32 @@ hats:
 }
 
 #[test]
+fn test_resume_replay_reports_malformed_events_after_last_terminate() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let config = RalphConfig::default();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+
+    write_event_to_jsonl(&events_path, "task.start", "original objective");
+    write_event_to_jsonl(&events_path, "loop.terminate", "parked");
+    write_raw_line_to_jsonl(&events_path, "{not json");
+
+    event_loop.replay_resume_events_from_jsonl().unwrap();
+
+    assert_eq!(
+        event_loop.state.consecutive_malformed_events, 1,
+        "malformed lines after the last loop.terminate should still use normal backpressure"
+    );
+
+    let prompt = event_loop.build_prompt(&HatId::new("ralph")).unwrap();
+    assert!(prompt.contains("event.malformed"));
+}
+
+#[test]
 fn test_completion_promise_detection() {
     use std::fs;
     use tempfile::TempDir;


### PR DESCRIPTION
## Summary
- persist `ralph run --continue` loop state to `.ralph/api/loop-state.json` after each iteration and restore it on continue
- clear stale persisted loop state for fresh runs
- replay existing JSONL history on continue: hydrate `seen_topics` from all history, and republish only events after the last `loop.terminate` so watchdog/human resume triggers fire naturally
- seed RPC total-cost state from restored loop cost so `--max-cost` remains continuous across restarts

## Root cause
`--continue` restored the scratchpad/events marker but not the in-memory runtime state. The JSONL reader was advanced past existing records, so historical topics were unavailable for chain validation and post-termination resume events never reached the bus. Iteration/cost tracking also lived only in memory, so restarts reset both counters.

## Test plan
- `cargo fmt --check`
- `git diff --check`
- targeted `cargo test -p ralph-core` filters for the new persisted loop state and resume replay tests
- `cargo test -p ralph-core`
- `cargo test -p ralph-cli --no-run`
- `cargo test -p ralph-cli`

Closes #244
Closes #295
