### PR TITLE
feat(cli): add --approve flag for human-in-the-loop iteration approval

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -104,6 +104,7 @@ fn resolve_loop_id(
 ///   (equivalent to `--no-auto-merge`). If `None`, uses `config.features.auto_merge`.
 /// * `resume_loop_id` - Explicit loop ID to use when resuming (`--loop-id`).
 ///   If `None` and `resume` is true, reuses the existing `current-loop-id` marker.
+#[allow(clippy::fn_params_excessive_bools)]
 pub async fn run_loop_impl(
     config: RalphConfig,
     color_mode: ColorMode,
@@ -116,6 +117,7 @@ pub async fn run_loop_impl(
     custom_args: Vec<String>,
     auto_merge_override: Option<bool>,
     resume_loop_id: Option<String>,
+    approve: bool,
 ) -> Result<TerminationReason> {
     // Set up process group leadership per spec
     // "The orchestrator must run as a process group leader"
@@ -1920,7 +1922,7 @@ pub async fn run_loop_impl(
             return Ok(reason);
         }
 
-        let output = outcome.output;
+        let mut output = outcome.output;
         let success = outcome.success;
 
         // Note: TUI lines are now written directly to IterationBuffer during streaming,
@@ -1979,6 +1981,41 @@ pub async fn run_loop_impl(
 
         // Process output
         if let Some(reason) = event_loop.process_output(&hat_id, &output, success) {
+            // ─────────────────────────────────────────────────────────────────
+            // Human approval checkpoint on completion (--approve flag)
+            // When the agent says LOOP_COMPLETE, give the human a chance to
+            // provide feedback and force another iteration instead.
+            // ─────────────────────────────────────────────────────────────────
+            if approve
+                && !enable_tui
+                && !enable_rpc
+                && reason == TerminationReason::CompletionPromise
+            {
+                match prompt_human_approval(event_loop.state().iteration, &hat_id) {
+                    ApprovalDecision::Feedback(msg) => {
+                        // Inject as human.guidance so it gets prepended to next prompt
+                        event_loop.inject_human_guidance(std::iter::once(msg));
+                        info!("Feedback injected. Overriding completion — continuing loop.");
+                        // Clear output so the text-fallback completion check doesn't re-trigger
+                        output.clear();
+                        continue;
+                    }
+                    ApprovalDecision::Quit => {
+                        handle_termination(
+                            &TerminationReason::Stopped,
+                            event_loop.state(),
+                            &config.core.scratchpad.path,
+                            &loop_history,
+                            &loop_context,
+                            auto_merge,
+                            &prompt_content,
+                        );
+                        return Ok(TerminationReason::Stopped);
+                    }
+                    ApprovalDecision::Continue => {} // fall through to normal termination
+                }
+            }
+
             // Per spec: Log "All done! {promise} detected." when completion promise found
             if reason == TerminationReason::CompletionPromise {
                 info!(
@@ -2575,6 +2612,36 @@ pub async fn run_loop_impl(
         if EventParser::contains_promise(&output, &config.event_loop.completion_promise) {
             event_loop.request_completion_from_text_fallback();
             if let Some(reason) = event_loop.check_completion_event() {
+                // ─────────────────────────────────────────────────────────────
+                // Human approval checkpoint on text-fallback completion (--approve)
+                // ─────────────────────────────────────────────────────────────
+                if approve
+                    && !enable_tui
+                    && !enable_rpc
+                    && reason == TerminationReason::CompletionPromise
+                {
+                    match prompt_human_approval(event_loop.state().iteration, &hat_id) {
+                        ApprovalDecision::Feedback(msg) => {
+                            event_loop.inject_human_guidance(std::iter::once(msg));
+                            info!("Feedback injected. Overriding completion — continuing loop.");
+                            continue;
+                        }
+                        ApprovalDecision::Quit => {
+                            handle_termination(
+                                &TerminationReason::Stopped,
+                                event_loop.state(),
+                                &config.core.scratchpad.path,
+                                &loop_history,
+                                &loop_context,
+                                auto_merge,
+                                &prompt_content,
+                            );
+                            return Ok(TerminationReason::Stopped);
+                        }
+                        ApprovalDecision::Continue => {} // fall through to normal termination
+                    }
+                }
+
                 info!(
                     "Completion promise {} detected in output text.",
                     config.event_loop.completion_promise
@@ -4938,6 +5005,7 @@ pub async fn start_loop(
         Vec::new(),         // no custom args
         None,               // default auto-merge
         None,               // no explicit loop ID
+        false,              // no approval in worktree loops
     )
     .await
 }
@@ -6187,6 +6255,62 @@ fn merge_wave_results_to_events_file(
     file.write_all(buf.as_bytes())?;
 
     Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Human approval checkpoint (--approve flag)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Decision from the human approval prompt.
+enum ApprovalDecision {
+    /// Continue to next iteration.
+    Continue,
+    /// Inject feedback and continue.
+    Feedback(String),
+    /// Stop the loop.
+    Quit,
+}
+
+/// Prompts the user for approval after an iteration completes.
+fn prompt_human_approval(iteration: u32, hat_id: &ralph_proto::HatId) -> ApprovalDecision {
+    use std::io::{BufRead, Write};
+
+    eprintln!();
+    eprintln!("─────────────────────────────────────────────────────────");
+    eprintln!(
+        "  ✅ Iteration {} complete (hat: {})",
+        iteration,
+        hat_id.as_str()
+    );
+    eprintln!("  [a]pprove   [f]eedback   [q]uit");
+    eprintln!("─────────────────────────────────────────────────────────");
+    eprint!("> ");
+    let _ = std::io::stderr().flush();
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if stdin.lock().read_line(&mut line).unwrap_or(0) == 0 {
+        return ApprovalDecision::Continue;
+    }
+
+    match line.trim().to_lowercase().as_str() {
+        "q" | "quit" => ApprovalDecision::Quit,
+        "f" | "feedback" => {
+            eprint!("Your feedback: ");
+            let _ = std::io::stderr().flush();
+            let mut feedback = String::new();
+            if stdin.lock().read_line(&mut feedback).unwrap_or(0) == 0 {
+                return ApprovalDecision::Continue;
+            }
+            let feedback = feedback.trim().to_string();
+            if feedback.is_empty() {
+                ApprovalDecision::Continue
+            } else {
+                ApprovalDecision::Feedback(feedback)
+            }
+        }
+        _ => ApprovalDecision::Continue,
+    }
 }
 
 #[cfg(test)]

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -835,6 +835,14 @@ struct RunArgs {
     #[arg(long, value_name = "FILE")]
     record_session: Option<PathBuf>,
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // Human-in-the-Loop Options
+    // ─────────────────────────────────────────────────────────────────────────
+    /// Pause after each iteration for human approval/feedback.
+    /// Shows iteration summary and prompts: [a]pprove, [f]eedback, [q]uit.
+    #[arg(long)]
+    approve: bool,
+
     /// Custom backend command and arguments (use after --)
     #[arg(last = true)]
     custom_args: Vec<String>,
@@ -1295,6 +1303,7 @@ async fn main() -> Result<()> {
                 verbose: false,
                 quiet: false,
                 record_session: None,
+                approve: false,
                 custom_args: Vec::new(),
             };
             run_command(
@@ -1812,7 +1821,11 @@ async fn run_command(
 
     // Run the orchestration loop and exit with proper exit code
     // TUI is enabled by default (unless --no-tui, --autonomous, or --rpc is specified)
-    let wants_tui = !args.no_tui && !args.autonomous && !args.rpc;
+    // --approve forces no-TUI mode since the approval prompt needs stdin/stdout
+    let wants_tui = !args.no_tui && !args.autonomous && !args.rpc && !args.approve;
+    if args.approve && !args.no_tui && !args.autonomous && !args.rpc {
+        info!("--approve enabled: TUI disabled (approval prompt needs stdin/stdout)");
+    }
     let use_legacy_tui = args.legacy_tui;
     let enable_rpc = args.rpc;
     let verbosity = Verbosity::resolve(verbose || args.verbose, args.quiet);
@@ -1849,6 +1862,7 @@ async fn run_command(
             custom_args,
             auto_merge_override,
             args.loop_id,
+            args.approve,
         )
         .await?
     };
@@ -2252,6 +2266,7 @@ async fn resume_command(
         Vec::new(), // Resume command doesn't support custom args
         None,       // Use config.features.auto_merge (deprecated command)
         None,       // Deprecated resume command doesn't support --loop-id
+        false,      // Deprecated resume command doesn't support --approve
     )
     .await?;
     let exit_code = reason.exit_code();
@@ -3845,6 +3860,7 @@ core:
             verbose: false,
             quiet: false,
             record_session: None,
+            approve: false,
             custom_args: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

Adds an opt-in `--approve` flag to `ralph run` that pauses after each iteration and prompts the user to approve, give feedback, or quit.

Closes #217.

## Motivation

`human.guidance` events (via TUI `g` key or `ralph tools steer`) are **non-blocking** — the agent can rush to `LOOP_COMPLETE` before the human reviews the work, and existing mechanisms can't override completion once declared.

This PR adds a hard checkpoint: when `--approve` is set, the loop pauses at every completion boundary and waits for explicit user input before terminating or continuing.

## Demo

<img width="1084" height="850" alt="Screenshot 2026-05-29 at 8 27 21 PM" src="https://github.com/user-attachments/assets/7906067b-bdac-4f48-a3ee-7ac96d0f6997" />

## Behavior

| Input | Action |
| :---- | :----- |
| `a` (or any other key) | Approve completion → terminate as `CompletionPromise` |
| `f` | Prompt for feedback → inject as `human.guidance` → override completion → continue next iteration |
| `q` | Terminate as `Stopped` |

When `--approve` is set, TUI mode is auto-disabled (the prompt needs raw stdin/stdout). A log line announces this at startup.

## How it works

1. After each iteration, when a `CompletionPromise` is detected (either via `process_output` or the text-fallback path), the prompt is shown.
2. If the user gives feedback, it's injected via the existing `EventLoop::inject_human_guidance` mechanism, which:
   - Persists the guidance to the scratchpad
   - Prepends it to the next iteration's prompt as `## ROBOT GUIDANCE`
   - The `continue` statement skips termination, forcing another iteration

No new infrastructure — reuses Ralph's existing guidance system.

## Files changed

| File | Change |
| :--- | :----- |
| `crates/ralph-cli/src/main.rs` | Add `--approve` to `RunArgs`, thread through 3 `run_loop_impl` call sites, auto-disable TUI when set |
| `crates/ralph-cli/src/loop_runner.rs` | Add `approve: bool` param, approval checkpoint at both completion-detection paths, `ApprovalDecision` enum, `prompt_human_approval` async fn |

~130 lines of new code, no external dependencies.

## Testing

Manual end-to-end with `claude` backend:

- [x] Iteration runs and outputs `LOOP_COMPLETE`
- [x] Approval prompt appears
- [x] `[a]pprove` terminates loop normally
- [x] `[f]eedback` accepts text and overrides completion
- [x] Feedback persists to scratchpad
- [x] Next iteration sees guidance and acts on it
- [x] File contents change as instructed
- [x] `[q]uit` terminates with `Stopped` reason

Build & tests:

- [x] `cargo build -p ralph-cli` passes
- [x] `cargo test -p ralph-cli --lib` passes (3/3)

## Future work (out of scope)

Native TUI integration would require new RPC events (e.g. `awaiting_approval`) and commands (`approve`, `feedback`). Current implementation auto-disables TUI as a pragmatic trade-off for shipping a working feature in a focused PR.