### PR TITLE
feat(slack): add thread-bound Ralph surface

### DIFF
--- a/.hermes/plans/2026-06-07_kanban-t_3691ff70-slack-streaming.md
+++ b/.hermes/plans/2026-06-07_kanban-t_3691ff70-slack-streaming.md
@@ -1,0 +1,11 @@
+# Kanban t_3691ff70 — Slack AI streaming capability gate
+
+## Goal
+Add Slack `chat.startStream` / `chat.appendStream` / `chat.stopStream` support to `ralph-slack` without requiring streaming for every Slack deployment.
+
+## Plan
+1. Add failing fake-HTTP tests for stream start/append/stop request shape, Slack error surfacing, and unsupported/missing-scope fallback classification.
+2. Implement small Slack API wrappers and a stream support classifier/capability type; keep tokens redacted and use JSON payloads matching current Slack docs (`markdown_text`, optional chunks, `task_update`).
+3. Expose a config flag in `SlackBotConfig` for opt-in streaming while preserving default `chat.update`/message fallback behavior.
+4. Run narrow tests, then `cargo +stable fmt --all --check` and `cargo +stable test -p ralph-slack`.
+5. Commit coherent changes if verification passes.

--- a/.hermes/plans/2026-06-07_slack-file-upload-support.md
+++ b/.hermes/plans/2026-06-07_slack-file-upload-support.md
@@ -1,0 +1,21 @@
+# Slack file upload support plan
+
+Goal: update Ralph Slack surface so loop-local Slack output can send file attachments/artifacts into the bound thread, and update the Slack app manifest/scopes/runbooks accordingly.
+
+Plan:
+1. Inspect `crates/ralph-slack` API/service traits and `RobotService` shape to find the clean file-send seam.
+2. Add Slack file upload support with the current Slack external upload flow (`files.getUploadURLExternal` -> upload bytes -> `files.completeUploadExternal`) rather than deprecated `files.upload`.
+3. Keep uploads scoped to the already-authorized/bound thread: channel + root `thread_ts` from persisted binding; validate local file path before reading; do not upload secrets accidentally by logging paths/tokens only sanitized.
+4. Add tests with fake Slack API/server covering upload request shape, thread association, and token redaction.
+5. Update manifest/runbooks/docs/setup helper to include `files:write` and file smoke steps. (Manifest/helper already include `files:write`; docs/runbooks/signoff now call out upload smoke.)
+6. Run focused tests and commit.
+
+Implementation notes:
+- Use structured `human.interact` attachment payloads only (`attachments`/`files` array with `path` and optional `caption`). Do not parse arbitrary Slack inbound text as file upload commands.
+- `SlackService` validates uploads against the configured workspace root before reading the file and always completes uploads into its bound `channel_id` + root `thread_ts`.
+
+Quality bar:
+- No token printing.
+- No arbitrary Slack-chosen repo/path selection.
+- File upload uses the same authorized bound thread model as messages.
+- Concrete verification evidence before closeout.

--- a/.hermes/plans/2026-06-07_slack-production-readiness.md
+++ b/.hermes/plans/2026-06-07_slack-production-readiness.md
@@ -1,0 +1,56 @@
+# Ralph Slack Thread Surface Production Readiness Plan
+
+## Goal
+Make Ralph's Slack surface production-ready for: one Slack root thread starts one loop, Ralph posts progress/results in-thread, Mikey can steer via replies, and stop/status/help controls are safe and reliable.
+
+## Current live state
+- Dedicated Slack app tokens and channel/user mapping exist locally under `/tmp/ralph-slack-setup/`.
+- Live Slack daemon can connect and receive events.
+- Live root thread successfully bound to loop `slack-C0B8SHYCBBP-1780860470-298719`.
+- First live loop exposed runner/contract issues: spawned process exited/stalled, then manual codex smoke produced `debug.step` repeatedly and terminated stale instead of `LOOP_COMPLETE`.
+
+## Production readiness gates
+
+### Gate 1: Deterministic local E2E
+- Socket Mode hello frames ignored; ackable envelopes acked before spawn.
+- Root app mention creates exactly one thread binding and spawns one loop.
+- Bound reply routes to `human.response` if pending question exists.
+- Bound reply routes to `human.guidance` otherwise.
+- Duplicate event ids are ignored.
+- Unauthorized users/channels/bot messages are ignored before side effects.
+- Stop/status/help/tail commands work in known threads and do not become guidance.
+- Stopped loops block future guidance.
+- Loop spawner uses autonomous/headless mode and writes inspectable per-loop logs.
+- Slack live-smoke runbook covers state + log verification.
+
+### Gate 2: Runner contract
+- Slack-spawned loop gets the correct Slack binding (`RALPH_LOOP_ID`, channel, thread_ts, workspace root).
+- Loop uses a known-good backend available on this machine.
+- Config/hat contract yields valid Ralph events and either `LOOP_COMPLETE` or actionable failure, not repeated dummy/debug topics.
+- Per-loop stdout/stderr are captured.
+- State process_id points to the actual child Ralph process.
+- Slack thread receives terminal/failure update if the loop terminates non-zero/stale.
+
+### Gate 3: Live Slack smoke
+Run live tests in the dedicated channel:
+1. Preflight post succeeds.
+2. Top-level app mention starts a new loop and posts loop id.
+3. Reply while no pending question writes guidance to the loop event stream.
+4. `/status` or `status` in thread returns current status.
+5. `tail` in thread returns useful recent events/log lines without secrets.
+6. `stop`/`cancel` by creator stops loop and marks state stopped.
+7. Unauthorized simulated user/channel tests are covered by local tests; live test should not require unsafe real users.
+
+### Gate 4: Hygiene/security
+- No real Slack tokens in tracked files, docs, logs, or final output.
+- Runtime artifacts are ignored or local-only.
+- Git diff only includes coherent source/docs/tests.
+- Relevant test slices and at least one broad crate test pass.
+
+## Immediate execution steps
+1. Triage live daemon and stale loop state; stop stale loops and keep one daemon running.
+2. Fix the runner contract root causes with regression tests.
+3. Add a narrow production-smoke config/fixture that yields `LOOP_COMPLETE` deterministically, or make the live smoke use a proven builtin hat collection instead of an ad-hoc dummy config.
+4. Re-run local tests.
+5. Run live Slack smoke cycle and capture state/log evidence.
+6. Commit coherent changes and report remaining gaps.

--- a/.hermes/plans/2026-06-07_t845fbdc0-slack-progress-update.md
+++ b/.hermes/plans/2026-06-07_t845fbdc0-slack-progress-update.md
@@ -1,0 +1,11 @@
+# t_845fbdc0 — Slack live progress update surface
+
+## Goal
+Replace per-event Slack progress spam with one thread message that is created once and updated as loop progress changes, while preserving raw `!tail` and final completion messages.
+
+## Steps
+1. Inspect current ralph-slack API, state, monitor, and fake tests to identify progress posting path.
+2. Add test-first coverage for `chat.update` and for two progress events reusing the same Slack timestamp.
+3. Implement minimal Slack API/state/monitor changes with update coalescing.
+4. Run targeted tests, then required fmt/test gates.
+5. Commit coherent changes and block for review with evidence.

--- a/.hermes/plans/2026-06-07_t_4dc805ed_slack_interactive_controls.md
+++ b/.hermes/plans/2026-06-07_t_4dc805ed_slack_interactive_controls.md
@@ -1,0 +1,11 @@
+# t_4dc805ed Slack interactive controls plan
+
+## Objective
+Add Slack-native Block Kit control handling for status, tail, stop/cancel, approve, and request changes while preserving typed commands and existing Telegram/RObot behavior.
+
+## Steps
+1. RED: add focused ralph-slack tests for interactive Socket Mode `block_actions` parsing and button auth/command routing.
+2. GREEN: map Slack action payloads into the existing thread routing path, preserving allow-list checks and creator-only stop.
+3. Polish Block Kit renderers so cards expose Status, Tail 10, Stop/Cancel, Approve, and Request changes where appropriate.
+4. Verify with `cargo +stable fmt --all --check` and `cargo +stable test -p ralph-slack`.
+5. Commit only coherent source/test/plan changes.

--- a/.hermes/plans/2026-06-07_t_8e8070d1-slack-closeout.md
+++ b/.hermes/plans/2026-06-07_t_8e8070d1-slack-closeout.md
@@ -1,0 +1,11 @@
+# t_8e8070d1 — Slack UX final polish closeout
+
+## Objective
+Prove the Slack thread surface is shippable: docs reflect the current polished UX, tests pass, live-smoke availability is checked without exposing secrets, and the branch is left reviewable.
+
+## Steps
+1. Inspect current Slack implementation and docs against the source UX plan.
+2. Update `docs/guide/slack.md` and `docs/runbooks/slack-live-smoke-test.md` for Block Kit cards/buttons, streaming APIs, thread commands, scopes/events, smoke checklist, and reinstall requirements.
+3. Run required gates: `cargo +stable fmt --all --check`, `cargo +stable check -p ralph-slack -p ralph-cli`, `cargo +stable test -p ralph-slack`, `cargo +stable test -p ralph-cli bot::tests`, and `git diff --check`.
+4. Check whether Slack tokens/app config are available without printing secrets; run live smoke only if fully configured.
+5. Clean/inspect git status, commit coherent closeout docs, and post Kanban review-required handoff with exact evidence.

--- a/.hermes/plans/2026-06-07_t_c7ca7f7a-slack-block-kit-renderer.md
+++ b/.hermes/plans/2026-06-07_t_c7ca7f7a-slack-block-kit-renderer.md
@@ -1,0 +1,15 @@
+# t_c7ca7f7a — Slack Block Kit renderer
+
+## Contract
+Add a Slack renderer seam for polished start/progress/final/status/help messages, preserve plain text fallback and existing post-thread behavior, and extend state with optional message timestamps while keeping old JSON readable.
+
+## Steps
+1. Inspect current ralph-slack API/state/service/daemon tests and choose the narrowest test seam.
+2. Add failing tests first for renderer Block Kit shape, API block payload posting, and old/new state serialization behavior.
+3. Implement minimal renderer structs/helpers, API optional blocks payload support, and optional timestamp fields.
+4. Run `cargo +stable fmt --all --check`, `cargo +stable test -p ralph-slack`, `git diff --check`, then commit coherent changes.
+
+## Guardrails
+- No secrets in logs or fixtures.
+- Preserve Telegram behavior by only touching `crates/ralph-slack` unless compilation requires exports.
+- Do not modify pre-existing untracked plan/setup artifacts unrelated to this card.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,8 +261,10 @@ RObot:
     app_token: null           # Prefer RALPH_SLACK_APP_TOKEN for daemon --slack
     channel_ids: [C0123456789]
     allowed_users: [U0123456789]
+    repo_aliases:
+      ralph: /absolute/path/to/repo
     channel_repos:
-      C0123456789: /absolute/path/to/repo
+      C0123456789: ralph
     start_mode: app_mention
 ```
 
@@ -279,9 +281,9 @@ RObot:
 
 - Telegram uses the existing loop-local bot service and routes by reply/default loop semantics.
 - Slack uses one `ralph bot daemon --slack` Socket Mode process for inbound events; do not make every loop open its own Socket Mode connection.
-- Slack routing is locked: channel -> repo/workspace root, then thread -> loop binding. Slack text cannot choose arbitrary repos.
+- Slack routing is locked: channel -> default repo alias, then thread -> loop binding. Slack text can choose only configured aliases and safe relative subdirectories.
 - Slack daemon must gate allowed channel/user and dedupe event IDs before spawning loops or writing event files.
-- Slack in-thread commands are plain text/app-mention style (`help`, `status`, `tail [n]`, `stop`/`cancel`); slash commands generally do not work as native thread replies.
+- Slack in-thread commands are plain text/app-mention style (`help`, `repo`, `status`, `tail [n]`, `stop`/`cancel`); slash commands generally do not work as native thread replies.
 - Responses are published as `human.response` events on the bus.
 - Proactive messages become `human.guidance` events, squashed into a numbered list in the prompt.
 - Send failures retry with exponential backoff (3 attempts); if all fail, treated as timeout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ ralph-cli      → CLI entry point, commands (run, plan, task, loops, web)
 ralph-core     → Orchestration logic, event loop, hats, memories, tasks
 ralph-adapters → Backend integrations (Claude, Kiro, Gemini, Codex, Roo, etc.)
 ralph-telegram → Telegram bot for human-in-the-loop communication
+ralph-slack    → Slack Socket Mode daemon, thread routing, and loop-local RObot service
 ralph-tui      → Terminal UI (ratatui-based)
 ralph-e2e      → End-to-end test framework
 ralph-proto    → Protocol definitions
@@ -54,6 +55,7 @@ frontend/      → Web dashboard (@ralph-web/dashboard) - React + Vite + Tailwin
 | `.ralph/loops.json` | Registry of all tracked loops |
 | `.ralph/merge-queue.jsonl` | Event-sourced merge queue |
 | `.ralph/telegram-state.json` | Telegram bot state (chat ID, pending questions) |
+| `.ralph/slack-state.json` | Slack thread bindings, pending questions, event dedupe, and loop process IDs |
 
 ### Code Locations
 
@@ -66,7 +68,8 @@ frontend/      → Web dashboard (@ralph-web/dashboard) - React + Vite + Tailwin
 - **Merge queue**: `crates/ralph-core/src/merge_queue.rs`
 - **CLI commands**: `crates/ralph-cli/src/loops.rs`, `task_cli.rs`
 - **Telegram integration**: `crates/ralph-telegram/src/` (bot, service, state, handler)
-- **RObot config**: `crates/ralph-core/src/config.rs` (`RobotConfig`, `TelegramBotConfig`)
+- **Slack integration**: `crates/ralph-slack/src/` (Socket Mode, daemon, state, handler, service)
+- **RObot config**: `crates/ralph-core/src/config.rs` (`RobotConfig`, `RobotSurface`, `TelegramBotConfig`, `SlackBotConfig`)
 - **Wave system**: `crates/ralph-core/src/wave_tracker.rs`, `wave_detection.rs`, `wave_prompt.rs`
 - **Wave CLI**: `crates/ralph-cli/src/wave.rs`
 - **Web server**: `backend/ralph-web-server/src/` (tRPC routes in `api/`, runners in `runner/`)
@@ -234,17 +237,33 @@ Reports generated in `.e2e-tests/`.
 
 ## RObot (Human-in-the-Loop)
 
-Ralph supports human interaction during orchestration via Telegram. Agents can ask questions and humans can send proactive guidance.
+Ralph supports human interaction during orchestration through provider-backed Telegram and Slack surfaces. Agents can ask questions and humans can send proactive guidance.
 
 ### Configuration
 
 ```yaml
-# ralph.yml
+# Telegram loop-local service
 RObot:
   enabled: true
-  timeout_seconds: 300    # How long to block waiting for a response
+  surface: telegram
+  timeout_seconds: 300
   telegram:
     bot_token: "your-token"  # Or set RALPH_TELEGRAM_BOT_TOKEN env var
+
+# Slack Socket Mode daemon + loop-local service
+RObot:
+  enabled: true
+  surface: slack
+  timeout_seconds: 86400
+  checkin_interval_seconds: 300
+  slack:
+    bot_token: null           # Prefer RALPH_SLACK_BOT_TOKEN
+    app_token: null           # Prefer RALPH_SLACK_APP_TOKEN for daemon --slack
+    channel_ids: [C0123456789]
+    allowed_users: [U0123456789]
+    channel_repos:
+      C0123456789: /absolute/path/to/repo
+    start_mode: app_mention
 ```
 
 ### Event Types
@@ -254,18 +273,20 @@ RObot:
 | `human.interact` | Agent to Human | Agent asks a question; loop blocks until response or timeout |
 | `human.response` | Human to Agent | Reply to a `human.interact` question |
 | `human.guidance` | Human to Agent | Proactive guidance injected as `## ROBOT GUIDANCE` in prompt |
-| `ralph tools interact progress` | Agent to Human | Non-blocking progress notification via Telegram (no event, direct send) |
+| `ralph tools interact progress` | Agent to Human | Non-blocking progress notification via the configured RObot provider (no event, direct send) |
 
 ### How It Works
 
-- The Telegram bot starts only on the **primary loop** (the one holding `.ralph/loop.lock`)
-- When an agent emits `human.interact`, the event loop sends the question via Telegram and **blocks**
-- Responses are published as `human.response` events on the bus
-- Proactive messages become `human.guidance` events, squashed into a numbered list in the prompt
-- Send failures retry with exponential backoff (3 attempts); if all fail, treated as timeout
-- Parallel loops route messages via reply-to, `@loop-id` prefix, or default to primary
+- Telegram uses the existing loop-local bot service and routes by reply/default loop semantics.
+- Slack uses one `ralph bot daemon --slack` Socket Mode process for inbound events; do not make every loop open its own Socket Mode connection.
+- Slack routing is locked: channel -> repo/workspace root, then thread -> loop binding. Slack text cannot choose arbitrary repos.
+- Slack daemon must gate allowed channel/user and dedupe event IDs before spawning loops or writing event files.
+- Slack in-thread commands are plain text/app-mention style (`help`, `status`, `tail [n]`, `stop`/`cancel`); slash commands generally do not work as native thread replies.
+- Responses are published as `human.response` events on the bus.
+- Proactive messages become `human.guidance` events, squashed into a numbered list in the prompt.
+- Send failures retry with exponential backoff (3 attempts); if all fail, treated as timeout.
 
-See `crates/ralph-telegram/README.md` for setup instructions.
+See `docs/guide/telegram.md` and `docs/guide/slack.md` for setup instructions.
 
 ## Diagnostics
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "ralph-api",
  "ralph-core",
  "ralph-proto",
+ "ralph-slack",
  "ralph-telegram",
  "ralph-tui",
  "ratatui",
@@ -2904,6 +2905,25 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ralph-slack"
+version = "2.9.3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "ralph-proto",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/ralph-bench",
     "crates/ralph-e2e",
     "crates/ralph-telegram",
+    "crates/ralph-slack",
     "crates/ralph-api",
 ]
 exclude = [
@@ -148,6 +149,7 @@ ralph-cli = { version = "2.9.3", path = "crates/ralph-cli" }
 ralph-bench = { version = "2.9.3", path = "crates/ralph-bench" }
 ralph-e2e = { version = "2.9.3", path = "crates/ralph-e2e" }
 ralph-telegram = { version = "2.9.3", path = "crates/ralph-telegram" }
+ralph-slack = { version = "2.9.3", path = "crates/ralph-slack" }
 ralph-api = { version = "2.9.3", path = "crates/ralph-api" }
 
 # Telegram bot framework

--- a/README.md
+++ b/README.md
@@ -143,31 +143,46 @@ Ralph implements the [Ralph Wiggum technique](https://ghuntley.com/ralph/) — a
 
 ## RObot (Human-in-the-Loop)
 
-Ralph supports human interaction during orchestration via Telegram. Agents can ask questions and block until answered; humans can send proactive guidance at any time.
+Ralph supports human interaction during orchestration through provider-backed surfaces. Telegram remains the simple loop-local surface; Slack adds a Socket Mode daemon where one Slack thread maps to one Ralph loop.
 
-Quick onboarding (Telegram):
+Quick onboarding:
 
 ```bash
-ralph bot onboard --telegram   # guided setup (token + chat id)
-ralph bot status               # verify config
-ralph bot test                 # send a test message
-ralph run -c ralph.bot.yml -p  "Help the human"
+# Telegram
+ralph bot onboard              # guided setup (token + chat id)
+ralph bot status
+ralph bot test
+ralph run -c ralph.bot.yml -p "Help the human"
+
+# Slack
+export RALPH_SLACK_BOT_TOKEN=xoxb-...
+export RALPH_SLACK_APP_TOKEN=xapp-...
+ralph bot status --slack
+ralph bot test --slack --channel C0123456789 "Ralph Slack is wired"
+ralph bot daemon --slack -c ralph.slack.yml
 ```
 
 ```yaml
-# ralph.yml
+# ralph.yml / ralph.slack.yml
 RObot:
   enabled: true
-  telegram:
-    bot_token: "your-token"  # Or RALPH_TELEGRAM_BOT_TOKEN env var
+  surface: slack              # slack | telegram
+  timeout_seconds: 86400
+  slack:
+    bot_token: null           # Or RALPH_SLACK_BOT_TOKEN
+    app_token: null           # Or RALPH_SLACK_APP_TOKEN for daemon mode
+    channel_ids: [C0123456789]
+    allowed_users: [U0123456789]
+    channel_repos:
+      C0123456789: /absolute/path/to/repo
 ```
 
-- **Agent questions** — Agents emit `human.interact` events; the loop blocks until a response arrives or times out
-- **Proactive guidance** — Send messages anytime to steer the agent mid-loop
-- **Parallel loop routing** — Messages route via reply-to, `@loop-id` prefix, or default to primary
-- **Telegram commands** — `/status`, `/tasks`, `/restart` for real-time loop visibility
+- **Agent questions** — Agents emit `human.interact` events; the loop blocks until a response arrives or times out.
+- **Proactive guidance** — Plain human replies become `human.guidance` when no question is pending.
+- **Slack thread routing** — Channel maps to repo/workspace root; thread maps to loop. Slack text cannot choose arbitrary repos.
+- **Commands** — Slack thread text commands are `help`, `status`, `tail [n]`, and `stop` / `cancel`; Telegram keeps its provider-specific commands.
 
-See the [Telegram guide](https://mikeyobrien.github.io/ralph-orchestrator/guide/telegram/) for setup instructions.
+See the [Telegram guide](https://mikeyobrien.github.io/ralph-orchestrator/guide/telegram/) and [Slack guide](https://mikeyobrien.github.io/ralph-orchestrator/guide/slack/) for setup instructions.
 
 ## Documentation
 
@@ -178,6 +193,7 @@ Full documentation is available at **[mikeyobrien.github.io/ralph-orchestrator](
 - [Configuration](https://mikeyobrien.github.io/ralph-orchestrator/guide/configuration/)
 - [CLI Reference](https://mikeyobrien.github.io/ralph-orchestrator/guide/cli-reference/)
 - [Presets](https://mikeyobrien.github.io/ralph-orchestrator/guide/presets/)
+- [Slack Integration](https://mikeyobrien.github.io/ralph-orchestrator/guide/slack/)
 - [Concepts: Hats & Events](https://mikeyobrien.github.io/ralph-orchestrator/concepts/hats-and-events/)
 - [Architecture](https://mikeyobrien.github.io/ralph-orchestrator/advanced/architecture/)
 
@@ -225,13 +241,19 @@ Ralph uses specialized personas (hats) that coordinate through events. Each hat 
 ### RObot (Human-in-the-Loop)
 
 **What is RObot?**
-RObot enables human interaction during orchestration via Telegram. Agents can ask questions and block until answered; humans can send proactive guidance mid-loop.
+RObot enables human interaction during orchestration through Telegram or Slack. Agents can ask questions and block until answered; humans can send proactive guidance mid-loop.
 
-**How do I set up Telegram integration?**
+**How do I set up human-in-the-loop chat?**
 ```bash
-ralph bot onboard --telegram   # guided setup
-ralph bot status               # verify config
-ralph bot test                 # send a test message
+# Telegram
+ralph bot onboard
+ralph bot status
+ralph bot test
+
+# Slack
+ralph bot status --slack
+ralph bot test --slack --channel C0123456789 "Ralph Slack is wired"
+ralph bot daemon --slack -c ralph.slack.yml
 ```
 
 ### Web Dashboard

--- a/README.md
+++ b/README.md
@@ -173,14 +173,16 @@ RObot:
     app_token: null           # Or RALPH_SLACK_APP_TOKEN for daemon mode
     channel_ids: [C0123456789]
     allowed_users: [U0123456789]
+    repo_aliases:
+      ralph: /absolute/path/to/repo
     channel_repos:
-      C0123456789: /absolute/path/to/repo
+      C0123456789: ralph
 ```
 
 - **Agent questions** — Agents emit `human.interact` events; the loop blocks until a response arrives or times out.
 - **Proactive guidance** — Plain human replies become `human.guidance` when no question is pending.
-- **Slack thread routing** — Channel maps to repo/workspace root; thread maps to loop. Slack text cannot choose arbitrary repos.
-- **Commands** — Slack thread text commands are `help`, `status`, `tail [n]`, and `stop` / `cancel`; Telegram keeps its provider-specific commands.
+- **Slack thread routing** — `repo_aliases` maps safe aliases to repo roots; `channel_repos` maps channels to default aliases. Slack text can choose configured aliases and safe subdirectories, never arbitrary absolute paths.
+- **Commands** — Slack thread text commands are `help`, `repo`, `status`, `tail [n]`, and `stop` / `cancel`; Telegram keeps its provider-specific commands.
 
 See the [Telegram guide](https://mikeyobrien.github.io/ralph-orchestrator/guide/telegram/) and [Slack guide](https://mikeyobrien.github.io/ralph-orchestrator/guide/slack/) for setup instructions.
 

--- a/crates/ralph-cli/Cargo.toml
+++ b/crates/ralph-cli/Cargo.toml
@@ -23,6 +23,7 @@ ralph-proto.workspace = true
 ralph-core.workspace = true
 ralph-adapters.workspace = true
 ralph-telegram.workspace = true
+ralph-slack.workspace = true
 ralph-tui.workspace = true
 ralph-api.workspace = true
 

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -777,43 +777,7 @@ async fn run_slack_daemon(
         "No Slack app token available. Set RALPH_SLACK_APP_TOKEN or configure RObot.slack.app_token",
     )?;
     let slack = config.robot.slack.clone().unwrap_or_default();
-    if slack.channel_ids.is_empty()
-        || slack.allowed_users.is_empty()
-        || slack.repo_aliases.is_empty()
-        || slack.channel_repos.is_empty()
-    {
-        anyhow::bail!(
-            "Slack daemon requires explicit RObot.slack.channel_ids, RObot.slack.allowed_users, RObot.slack.repo_aliases, and RObot.slack.channel_repos"
-        );
-    }
-    let mut repo_aliases = BTreeMap::new();
-    for (alias, repo_root) in &slack.repo_aliases {
-        if !repo_root.is_absolute() {
-            anyhow::bail!(
-                "Slack repo alias {alias} must be an absolute path: {}",
-                repo_root.display()
-            );
-        }
-        let canonical = repo_root.canonicalize().with_context(|| {
-            format!(
-                "Slack repo alias {alias} does not exist: {}",
-                repo_root.display()
-            )
-        })?;
-        repo_aliases.insert(alias.clone(), canonical);
-    }
-    let mut channel_repos = BTreeMap::new();
-    for channel_id in &slack.channel_ids {
-        let Some(alias) = slack.channel_repos.get(channel_id) else {
-            anyhow::bail!(
-                "Slack channel {channel_id} is missing RObot.slack.channel_repos mapping"
-            );
-        };
-        if !repo_aliases.contains_key(alias) {
-            anyhow::bail!("Slack channel {channel_id} references unknown repo alias {alias}");
-        }
-        channel_repos.insert(channel_id.clone(), alias.clone());
-    }
+    let (repo_aliases, channel_repos) = resolve_slack_repo_routing(&slack)?;
 
     if use_colors {
         println!("\x1b[1mRalph Daemon\x1b[0m (Slack Socket Mode)");
@@ -838,6 +802,117 @@ async fn run_slack_daemon(
     );
     ralph_slack::socket_mode::run_socket_mode(&socket_url, daemon).await?;
     Ok(())
+}
+
+fn resolve_slack_repo_routing(
+    slack: &ralph_core::SlackBotConfig,
+) -> Result<(BTreeMap<String, PathBuf>, BTreeMap<String, String>)> {
+    if slack.channel_ids.is_empty()
+        || slack.allowed_users.is_empty()
+        || slack.channel_repos.is_empty()
+    {
+        anyhow::bail!(
+            "Slack daemon requires explicit RObot.slack.channel_ids, RObot.slack.allowed_users, and RObot.slack.channel_repos"
+        );
+    }
+
+    let mut repo_aliases = BTreeMap::new();
+    for (alias, repo_root) in &slack.repo_aliases {
+        if !is_safe_repo_alias(alias) {
+            anyhow::bail!(
+                "Slack repo alias {alias} is invalid; use only letters, numbers, hyphen, or underscore"
+            );
+        }
+        if !repo_root.is_absolute() {
+            anyhow::bail!(
+                "Slack repo alias {alias} must be an absolute path: {}",
+                repo_root.display()
+            );
+        }
+        let canonical = repo_root.canonicalize().with_context(|| {
+            format!(
+                "Slack repo alias {alias} does not exist: {}",
+                repo_root.display()
+            )
+        })?;
+        repo_aliases.insert(alias.clone(), canonical);
+    }
+
+    let mut channel_repos = BTreeMap::new();
+    for channel_id in &slack.channel_ids {
+        let Some(selector) = slack.channel_repos.get(channel_id) else {
+            anyhow::bail!(
+                "Slack channel {channel_id} is missing RObot.slack.channel_repos mapping"
+            );
+        };
+        if repo_aliases.contains_key(selector) {
+            channel_repos.insert(channel_id.clone(), selector.clone());
+            continue;
+        }
+
+        let legacy_repo_root = PathBuf::from(selector);
+        if !legacy_repo_root.is_absolute() {
+            anyhow::bail!("Slack channel {channel_id} references unknown repo alias {selector}");
+        }
+        let canonical = legacy_repo_root.canonicalize().with_context(|| {
+            format!(
+                "Slack legacy repo root for channel {channel_id} does not exist: {}",
+                legacy_repo_root.display()
+            )
+        })?;
+        let alias = insert_legacy_repo_alias(&mut repo_aliases, channel_id, canonical);
+        channel_repos.insert(channel_id.clone(), alias);
+    }
+
+    Ok((repo_aliases, channel_repos))
+}
+
+fn insert_legacy_repo_alias(
+    repo_aliases: &mut BTreeMap<String, PathBuf>,
+    channel_id: &str,
+    canonical_root: PathBuf,
+) -> String {
+    if let Some((alias, _)) = repo_aliases
+        .iter()
+        .find(|(_, root)| root.as_path() == canonical_root.as_path())
+    {
+        return alias.clone();
+    }
+
+    let base = format!("channel-{}", sanitize_repo_alias_component(channel_id));
+    let mut alias = base.clone();
+    let mut suffix = 2usize;
+    while repo_aliases.contains_key(&alias) {
+        alias = format!("{base}-{suffix}");
+        suffix += 1;
+    }
+    repo_aliases.insert(alias.clone(), canonical_root);
+    alias
+}
+
+fn sanitize_repo_alias_component(raw: &str) -> String {
+    let sanitized = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "legacy".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn is_safe_repo_alias(alias: &str) -> bool {
+    !alias.is_empty()
+        && alias
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1472,6 +1547,7 @@ fn print_status(use_colors: bool, msg: &str) {
 mod tests {
     use super::*;
     use crate::test_support::CwdGuard;
+    use std::collections::HashMap;
     use std::path::PathBuf;
 
     #[test]
@@ -1990,6 +2066,67 @@ mod tests {
         assert!(onboard.slack);
         assert_eq!(onboard.channel_ids, vec!["C123"]);
         assert_eq!(onboard.allowed_users, vec!["U123"]);
+    }
+
+    #[test]
+    fn test_resolve_slack_repo_routing_uses_safe_aliases() {
+        let repo = tempfile::tempdir().unwrap();
+        let slack = ralph_core::SlackBotConfig {
+            channel_ids: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            repo_aliases: HashMap::from([("ralph".to_string(), repo.path().to_path_buf())]),
+            channel_repos: HashMap::from([("C123".to_string(), "ralph".to_string())]),
+            ..Default::default()
+        };
+
+        let (repo_aliases, channel_repos) = resolve_slack_repo_routing(&slack).unwrap();
+
+        assert_eq!(channel_repos.get("C123").map(String::as_str), Some("ralph"));
+        assert_eq!(
+            repo_aliases.get("ralph"),
+            Some(&repo.path().canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_resolve_slack_repo_routing_accepts_legacy_absolute_channel_repos() {
+        let repo = tempfile::tempdir().unwrap();
+        let slack = ralph_core::SlackBotConfig {
+            channel_ids: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            channel_repos: HashMap::from([(
+                "C123".to_string(),
+                repo.path().to_string_lossy().to_string(),
+            )]),
+            ..Default::default()
+        };
+
+        let (repo_aliases, channel_repos) = resolve_slack_repo_routing(&slack).unwrap();
+
+        let alias = channel_repos.get("C123").unwrap();
+        assert_eq!(alias, "channel-C123");
+        assert_eq!(
+            repo_aliases.get(alias),
+            Some(&repo.path().canonicalize().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_resolve_slack_repo_routing_rejects_unknown_non_absolute_selector() {
+        let slack = ralph_core::SlackBotConfig {
+            channel_ids: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            channel_repos: HashMap::from([("C123".to_string(), "missing".to_string())]),
+            ..Default::default()
+        };
+
+        let err = resolve_slack_repo_routing(&slack).expect_err("expected unknown alias error");
+
+        assert!(
+            err.to_string()
+                .contains("Slack channel C123 references unknown repo alias missing"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -7,6 +7,7 @@
 //! - `ralph bot token set <token>` — Store/overwrite the bot token
 
 use anyhow::{Context, Result};
+use chrono::{Duration, Utc};
 use clap::{Parser, Subcommand};
 use ralph_core::RalphConfig;
 use std::collections::BTreeMap;
@@ -38,6 +39,8 @@ pub enum BotCommands {
     Token(TokenArgs),
     /// Run as a persistent daemon, listening on Telegram and starting loops on demand
     Daemon(DaemonArgs),
+    /// List or prune archived Slack thread bindings
+    SlackArchives(SlackArchivesArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -123,6 +126,24 @@ pub struct DaemonArgs {
     pub slack: bool,
 }
 
+#[derive(Parser, Debug)]
+pub struct SlackArchivesArgs {
+    #[command(subcommand)]
+    pub command: SlackArchiveCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SlackArchiveCommands {
+    /// List completed/failed/stopped Slack loop thread bindings
+    List,
+    /// Prune local archived binding records, worktrees, and logs older than N days
+    Prune {
+        /// Retention window in days
+        #[arg(long, default_value_t = 30)]
+        older_than_days: i64,
+    },
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // DISPATCHER
 // ─────────────────────────────────────────────────────────────────────────────
@@ -147,7 +168,52 @@ pub async fn execute(
         BotCommands::Daemon(daemon_args) => {
             run_daemon(daemon_args, config_sources, hats_source, use_colors).await
         }
+        BotCommands::SlackArchives(archives_args) => slack_archives(archives_args, use_colors),
     }
+}
+
+fn slack_archives(args: SlackArchivesArgs, _use_colors: bool) -> Result<()> {
+    let workspace_root = std::env::current_dir().context("Failed to resolve current directory")?;
+    let manager =
+        ralph_slack::SlackStateManager::new(workspace_root.join(".ralph/slack-state.json"));
+    match args.command {
+        SlackArchiveCommands::List => {
+            let bindings = manager.archived_threads()?;
+            if bindings.is_empty() {
+                println!("No archived Slack thread bindings found.");
+                return Ok(());
+            }
+            println!("Archived Slack thread bindings:");
+            for binding in bindings {
+                println!(
+                    "{}	{:?}	channel={}	thread={}	repo={}	final_card={}	parent={}",
+                    binding.loop_id,
+                    binding.status,
+                    binding.channel_id,
+                    binding.thread_ts,
+                    binding.workspace_root.display(),
+                    binding.final_card_ts.as_deref().unwrap_or("none"),
+                    binding.parent_loop_id.as_deref().unwrap_or("none")
+                );
+            }
+        }
+        SlackArchiveCommands::Prune { older_than_days } => {
+            if older_than_days < 0 {
+                anyhow::bail!("--older-than-days must be non-negative");
+            }
+            let cutoff = Utc::now() - Duration::days(older_than_days);
+            let pruned = manager.prune_archived_older_than(cutoff)?;
+            println!(
+                "Pruned {} archived Slack binding(s) older than {} day(s). Slack history was not mutated.",
+                pruned.len(),
+                older_than_days
+            );
+            for loop_id in pruned {
+                println!("  {loop_id}");
+            }
+        }
+    }
+    Ok(())
 }
 
 fn bot_token(args: TokenArgs, use_colors: bool) -> Result<()> {
@@ -1972,6 +2038,25 @@ mod tests {
         assert!(onboard.slack);
         assert_eq!(onboard.channel_ids, vec!["C123"]);
         assert_eq!(onboard.allowed_users, vec!["U123"]);
+    }
+
+    #[test]
+    fn test_slack_archive_cli_flags_parse() {
+        let args = BotArgs::try_parse_from([
+            "ralph",
+            "slack-archives",
+            "prune",
+            "--older-than-days",
+            "14",
+        ])
+        .unwrap();
+        let BotCommands::SlackArchives(archives) = args.command else {
+            panic!("expected slack archives command");
+        };
+        let SlackArchiveCommands::Prune { older_than_days } = archives.command else {
+            panic!("expected prune command");
+        };
+        assert_eq!(older_than_days, 14);
     }
 
     #[test]

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -779,32 +779,40 @@ async fn run_slack_daemon(
     let slack = config.robot.slack.clone().unwrap_or_default();
     if slack.channel_ids.is_empty()
         || slack.allowed_users.is_empty()
+        || slack.repo_aliases.is_empty()
         || slack.channel_repos.is_empty()
     {
         anyhow::bail!(
-            "Slack daemon requires explicit RObot.slack.channel_ids, RObot.slack.allowed_users, and RObot.slack.channel_repos"
+            "Slack daemon requires explicit RObot.slack.channel_ids, RObot.slack.allowed_users, RObot.slack.repo_aliases, and RObot.slack.channel_repos"
         );
     }
-    let mut channel_repos = BTreeMap::new();
-    for channel_id in &slack.channel_ids {
-        let Some(repo_root) = slack.channel_repos.get(channel_id) else {
-            anyhow::bail!(
-                "Slack channel {channel_id} is missing RObot.slack.channel_repos mapping"
-            );
-        };
+    let mut repo_aliases = BTreeMap::new();
+    for (alias, repo_root) in &slack.repo_aliases {
         if !repo_root.is_absolute() {
             anyhow::bail!(
-                "Slack repo root for channel {channel_id} must be absolute: {}",
+                "Slack repo alias {alias} must be an absolute path: {}",
                 repo_root.display()
             );
         }
         let canonical = repo_root.canonicalize().with_context(|| {
             format!(
-                "Slack repo root for channel {channel_id} does not exist: {}",
+                "Slack repo alias {alias} does not exist: {}",
                 repo_root.display()
             )
         })?;
-        channel_repos.insert(channel_id.clone(), canonical);
+        repo_aliases.insert(alias.clone(), canonical);
+    }
+    let mut channel_repos = BTreeMap::new();
+    for channel_id in &slack.channel_ids {
+        let Some(alias) = slack.channel_repos.get(channel_id) else {
+            anyhow::bail!(
+                "Slack channel {channel_id} is missing RObot.slack.channel_repos mapping"
+            );
+        };
+        if !repo_aliases.contains_key(alias) {
+            anyhow::bail!("Slack channel {channel_id} references unknown repo alias {alias}");
+        }
+        channel_repos.insert(channel_id.clone(), alias.clone());
     }
 
     if use_colors {
@@ -821,6 +829,7 @@ async fn run_slack_daemon(
             workspace_root: workspace_root.clone(),
             allowed_channels: slack.channel_ids,
             allowed_users: slack.allowed_users,
+            repo_aliases,
             channel_repos,
         },
         state,
@@ -1148,11 +1157,20 @@ fn save_slack_robot_config(
     );
     let cwd = std::env::current_dir()
         .context("Failed to resolve current directory for Slack channel_repos")?;
+    let mut repo_aliases = serde_yaml::Mapping::new();
+    repo_aliases.insert(
+        serde_yaml::Value::String("ralph".to_string()),
+        serde_yaml::Value::String(cwd.to_string_lossy().to_string()),
+    );
+    slack_map.insert(
+        serde_yaml::Value::String("repo_aliases".to_string()),
+        serde_yaml::Value::Mapping(repo_aliases),
+    );
     let mut channel_repos = serde_yaml::Mapping::new();
     for channel_id in channel_ids {
         channel_repos.insert(
             serde_yaml::Value::String(channel_id.clone()),
-            serde_yaml::Value::String(cwd.to_string_lossy().to_string()),
+            serde_yaml::Value::String("ralph".to_string()),
         );
     }
     slack_map.insert(

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -490,7 +490,7 @@ async fn onboard_slack(args: OnboardArgs, use_colors: bool) -> Result<()> {
         println!("=====================");
     }
     println!(
-        "Required Slack scopes: chat:write, app_mentions:read, commands (for slash commands), and channel history for thread replies."
+        "Required Slack scopes: chat:write, files:write, app_mentions:read, commands (for slash commands), and channel history for thread replies."
     );
     println!("Socket Mode requires an xapp-... app token for `ralph bot daemon --slack`.");
 

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -14,7 +14,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tracing::warn;
 
-use crate::{ConfigSource, HatsSource};
+use crate::{ConfigSource, HatsSource, default_config_path};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CLI STRUCTS
@@ -138,9 +138,11 @@ pub async fn execute(
             onboard_slack(onboard_args, use_colors).await
         }
         BotCommands::Onboard(onboard_args) => onboard_telegram(onboard_args, use_colors).await,
-        BotCommands::Status(status_args) if status_args.slack => bot_status_slack(use_colors),
+        BotCommands::Status(status_args) if status_args.slack => {
+            bot_status_slack(config_sources, use_colors)
+        }
         BotCommands::Status(_) => bot_status(use_colors).await,
-        BotCommands::Test(test_args) => bot_test(test_args, use_colors).await,
+        BotCommands::Test(test_args) => bot_test(test_args, config_sources, use_colors).await,
         BotCommands::Token(token_args) => bot_token(token_args, use_colors),
         BotCommands::Daemon(daemon_args) => {
             run_daemon(daemon_args, config_sources, hats_source, use_colors).await
@@ -517,7 +519,7 @@ async fn onboard_slack(args: OnboardArgs, use_colors: bool) -> Result<()> {
     Ok(())
 }
 
-fn bot_status_slack(use_colors: bool) -> Result<()> {
+fn bot_status_slack(config_sources: &[ConfigSource], use_colors: bool) -> Result<()> {
     println!();
     if use_colors {
         println!("\x1b[1mRalph Slack Bot Status\x1b[0m");
@@ -538,8 +540,12 @@ fn bot_status_slack(use_colors: bool) -> Result<()> {
         print_status(use_colors, "Env var: RALPH_SLACK_APP_TOKEN not set");
     }
 
-    if let Some(config) = load_slack_config_from(Path::new("ralph.yml")) {
-        print_success(use_colors, "Config: RObot.slack present in ralph.yml");
+    let config_path = slack_config_path_from_sources(config_sources);
+    if let Some(config) = load_slack_config_from(&config_path) {
+        print_success(
+            use_colors,
+            &format!("Config: RObot.slack present in {}", config_path.display()),
+        );
         if !config.channel_ids.is_empty() {
             print_success(
                 use_colors,
@@ -553,7 +559,10 @@ fn bot_status_slack(use_colors: bool) -> Result<()> {
             );
         }
     } else {
-        print_status(use_colors, "Config: no RObot.slack in ralph.yml");
+        print_status(
+            use_colors,
+            &format!("Config: no RObot.slack in {}", config_path.display()),
+        );
     }
 
     let state_path = Path::new(".ralph/slack-state.json");
@@ -573,9 +582,9 @@ fn bot_status_slack(use_colors: bool) -> Result<()> {
 // TEST COMMAND
 // ─────────────────────────────────────────────────────────────────────────────
 
-async fn bot_test(args: TestArgs, use_colors: bool) -> Result<()> {
+async fn bot_test(args: TestArgs, config_sources: &[ConfigSource], use_colors: bool) -> Result<()> {
     if args.slack {
-        return bot_test_slack(args, use_colors).await;
+        return bot_test_slack(args, config_sources, use_colors).await;
     }
 
     // Resolve token
@@ -605,15 +614,20 @@ async fn bot_test(args: TestArgs, use_colors: bool) -> Result<()> {
     Ok(())
 }
 
-async fn bot_test_slack(args: TestArgs, use_colors: bool) -> Result<()> {
+async fn bot_test_slack(
+    args: TestArgs,
+    config_sources: &[ConfigSource],
+    use_colors: bool,
+) -> Result<()> {
+    let config_path = slack_config_path_from_sources(config_sources);
     let token = std::env::var("RALPH_SLACK_BOT_TOKEN")
         .ok()
-        .or_else(|| load_slack_config_from(Path::new("ralph.yml")).and_then(|config| config.bot_token))
+        .or_else(|| load_slack_config_from(&config_path).and_then(|config| config.bot_token))
         .context("No Slack bot token available. Set RALPH_SLACK_BOT_TOKEN or run `ralph bot onboard --slack --token <token>`")?;
     let channel = args
         .channel
         .or_else(|| {
-            load_slack_config_from(Path::new("ralph.yml"))
+            load_slack_config_from(&config_path)
                 .and_then(|config| config.channel_ids.into_iter().next())
         })
         .context(
@@ -1172,6 +1186,18 @@ fn save_slack_robot_config(
         .context("Failed to serialize config")?;
     std::fs::write(config_path, yaml_str).context("Failed to write ralph.yml")?;
     Ok(())
+}
+
+fn slack_config_path_from_sources(config_sources: &[ConfigSource]) -> PathBuf {
+    config_sources
+        .iter()
+        .find_map(|source| match source {
+            ConfigSource::File(path) => Some(path.clone()),
+            ConfigSource::Builtin(_) | ConfigSource::Remote(_) | ConfigSource::Override { .. } => {
+                None
+            }
+        })
+        .unwrap_or_else(default_config_path)
 }
 
 fn load_slack_config_from(path: &Path) -> Option<ralph_core::SlackBotConfig> {

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -9,6 +9,7 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use ralph_core::RalphConfig;
+use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use tracing::warn;
@@ -30,7 +31,7 @@ pub enum BotCommands {
     /// Interactive setup wizard for Telegram bot
     Onboard(OnboardArgs),
     /// Check current bot configuration status
-    Status,
+    Status(StatusArgs),
     /// Send a test message to verify the bot works
     Test(TestArgs),
     /// Manage bot tokens
@@ -41,9 +42,25 @@ pub enum BotCommands {
 
 #[derive(Parser, Debug)]
 pub struct OnboardArgs {
+    /// Configure Slack instead of Telegram
+    #[arg(long)]
+    pub slack: bool,
+
     /// Skip interactive token prompt, provide token directly
     #[arg(long)]
     pub token: Option<String>,
+
+    /// Slack app-level token for Socket Mode (xapp-...); never printed
+    #[arg(long)]
+    pub app_token: Option<String>,
+
+    /// Allowed Slack channel ID (repeatable)
+    #[arg(long = "channel")]
+    pub channel_ids: Vec<String>,
+
+    /// Allowed Slack user ID (repeatable)
+    #[arg(long = "user")]
+    pub allowed_users: Vec<String>,
 
     /// Skip chat_id detection, provide chat_id directly
     #[arg(long)]
@@ -55,7 +72,22 @@ pub struct OnboardArgs {
 }
 
 #[derive(Parser, Debug)]
+pub struct StatusArgs {
+    /// Check Slack bot configuration instead of Telegram
+    #[arg(long)]
+    pub slack: bool,
+}
+
+#[derive(Parser, Debug)]
 pub struct TestArgs {
+    /// Send through Slack instead of Telegram
+    #[arg(long)]
+    pub slack: bool,
+
+    /// Slack channel ID for --slack test messages
+    #[arg(long)]
+    pub channel: Option<String>,
+
     /// Message to send (default: "Hello from Ralph!")
     #[arg(default_value = "Hello from Ralph!")]
     pub message: String,
@@ -85,7 +117,11 @@ pub struct SetTokenArgs {
 }
 
 #[derive(Parser, Debug)]
-pub struct DaemonArgs {}
+pub struct DaemonArgs {
+    /// Run Slack Socket Mode daemon instead of Telegram daemon
+    #[arg(long)]
+    pub slack: bool,
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // DISPATCHER
@@ -98,8 +134,12 @@ pub async fn execute(
     use_colors: bool,
 ) -> Result<()> {
     match args.command {
+        BotCommands::Onboard(onboard_args) if onboard_args.slack => {
+            onboard_slack(onboard_args, use_colors).await
+        }
         BotCommands::Onboard(onboard_args) => onboard_telegram(onboard_args, use_colors).await,
-        BotCommands::Status => bot_status(use_colors).await,
+        BotCommands::Status(status_args) if status_args.slack => bot_status_slack(use_colors),
+        BotCommands::Status(_) => bot_status(use_colors).await,
         BotCommands::Test(test_args) => bot_test(test_args, use_colors).await,
         BotCommands::Token(token_args) => bot_token(token_args, use_colors),
         BotCommands::Daemon(daemon_args) => {
@@ -440,11 +480,104 @@ async fn bot_status(use_colors: bool) -> Result<()> {
     Ok(())
 }
 
+async fn onboard_slack(args: OnboardArgs, use_colors: bool) -> Result<()> {
+    println!();
+    if use_colors {
+        println!("\x1b[1mRalph Slack Bot Setup\x1b[0m");
+        println!("\x1b[1m=====================\x1b[0m");
+    } else {
+        println!("Ralph Slack Bot Setup");
+        println!("=====================");
+    }
+    println!(
+        "Required Slack scopes: chat:write, app_mentions:read, commands (for slash commands), and channel history for thread replies."
+    );
+    println!("Socket Mode requires an xapp-... app token for `ralph bot daemon --slack`.");
+
+    save_slack_robot_config(
+        args.timeout,
+        args.token.as_deref(),
+        args.app_token.as_deref(),
+        &args.channel_ids,
+        &args.allowed_users,
+    )?;
+    print_success(use_colors, "Slack RObot config written to ralph.yml");
+    if args.token.is_none() {
+        print_status(
+            use_colors,
+            "Set RALPH_SLACK_BOT_TOKEN or add RObot.slack.bot_token before running Slack commands",
+        );
+    }
+    if args.app_token.is_none() {
+        print_status(
+            use_colors,
+            "Set RALPH_SLACK_APP_TOKEN or add RObot.slack.app_token before running daemon --slack",
+        );
+    }
+    Ok(())
+}
+
+fn bot_status_slack(use_colors: bool) -> Result<()> {
+    println!();
+    if use_colors {
+        println!("\x1b[1mRalph Slack Bot Status\x1b[0m");
+        println!("\x1b[1m======================\x1b[0m");
+    } else {
+        println!("Ralph Slack Bot Status");
+        println!("======================");
+    }
+
+    if std::env::var("RALPH_SLACK_BOT_TOKEN").is_ok() {
+        print_success(use_colors, "Env var: RALPH_SLACK_BOT_TOKEN set");
+    } else {
+        print_status(use_colors, "Env var: RALPH_SLACK_BOT_TOKEN not set");
+    }
+    if std::env::var("RALPH_SLACK_APP_TOKEN").is_ok() {
+        print_success(use_colors, "Env var: RALPH_SLACK_APP_TOKEN set");
+    } else {
+        print_status(use_colors, "Env var: RALPH_SLACK_APP_TOKEN not set");
+    }
+
+    if let Some(config) = load_slack_config_from(Path::new("ralph.yml")) {
+        print_success(use_colors, "Config: RObot.slack present in ralph.yml");
+        if !config.channel_ids.is_empty() {
+            print_success(
+                use_colors,
+                &format!("Allowed channels: {}", config.channel_ids.join(", ")),
+            );
+        }
+        if !config.allowed_users.is_empty() {
+            print_success(
+                use_colors,
+                &format!("Allowed users: {}", config.allowed_users.join(", ")),
+            );
+        }
+    } else {
+        print_status(use_colors, "Config: no RObot.slack in ralph.yml");
+    }
+
+    let state_path = Path::new(".ralph/slack-state.json");
+    if state_path.exists() {
+        let state = ralph_slack::SlackStateManager::new(state_path).load_or_default()?;
+        print_success(
+            use_colors,
+            &format!("Slack state: {} bound thread(s)", state.threads.len()),
+        );
+    } else {
+        print_status(use_colors, "Slack state: not found");
+    }
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // TEST COMMAND
 // ─────────────────────────────────────────────────────────────────────────────
 
 async fn bot_test(args: TestArgs, use_colors: bool) -> Result<()> {
+    if args.slack {
+        return bot_test_slack(args, use_colors).await;
+    }
+
     // Resolve token
     let token = resolve_token().context(
         "No bot token available. Run `ralph bot onboard` or set RALPH_TELEGRAM_BOT_TOKEN",
@@ -472,16 +605,40 @@ async fn bot_test(args: TestArgs, use_colors: bool) -> Result<()> {
     Ok(())
 }
 
+async fn bot_test_slack(args: TestArgs, use_colors: bool) -> Result<()> {
+    let token = std::env::var("RALPH_SLACK_BOT_TOKEN")
+        .ok()
+        .or_else(|| load_slack_config_from(Path::new("ralph.yml")).and_then(|config| config.bot_token))
+        .context("No Slack bot token available. Set RALPH_SLACK_BOT_TOKEN or run `ralph bot onboard --slack --token <token>`")?;
+    let channel = args
+        .channel
+        .or_else(|| {
+            load_slack_config_from(Path::new("ralph.yml"))
+                .and_then(|config| config.channel_ids.into_iter().next())
+        })
+        .context(
+            "No Slack channel available. Pass --channel C... or configure RObot.slack.channel_ids",
+        )?;
+
+    print!("  Sending Slack message to channel {}...", channel);
+    io::stdout().flush()?;
+    let api = ralph_slack::SlackApi::new(token, None);
+    api.post_message(&channel, None, &args.message).await?;
+    println!();
+    print_success(use_colors, "Slack message sent!");
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // DAEMON COMMAND
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Run the bot daemon — delegates to the configured communication adapter.
 ///
-/// Currently only Telegram is supported. The adapter implements
-/// [`DaemonAdapter`] and handles all platform-specific concerns.
+/// Telegram and Slack are supported. The adapter implements
+/// [`DaemonAdapter`] or the Slack daemon seam and handles platform-specific concerns.
 async fn run_daemon(
-    _args: DaemonArgs,
+    args: DaemonArgs,
     config_sources: &[ConfigSource],
     hats_source: Option<&HatsSource>,
     use_colors: bool,
@@ -551,6 +708,12 @@ async fn run_daemon(
         warn!("Using resolved runtime config: {}", config_path.display());
     }
 
+    let use_slack =
+        args.slack || matches!(config.robot.surface(), Ok(ralph_core::RobotSurface::Slack));
+    if use_slack {
+        return run_slack_daemon(config, config_path, workspace_root, use_colors).await;
+    }
+
     // Resolve bot token and chat_id for Telegram adapter
     let token = config.robot.resolve_bot_token().context(
         "No bot token available. Run `ralph bot onboard` or set RALPH_TELEGRAM_BOT_TOKEN",
@@ -584,6 +747,73 @@ async fn run_daemon(
 
     adapter.run_daemon(workspace_root, start_loop).await?;
 
+    Ok(())
+}
+
+async fn run_slack_daemon(
+    config: RalphConfig,
+    config_path: PathBuf,
+    workspace_root: PathBuf,
+    use_colors: bool,
+) -> Result<()> {
+    let bot_token = config.robot.resolve_slack_bot_token().context(
+        "No Slack bot token available. Set RALPH_SLACK_BOT_TOKEN or configure RObot.slack.bot_token",
+    )?;
+    let app_token = config.robot.resolve_slack_app_token().context(
+        "No Slack app token available. Set RALPH_SLACK_APP_TOKEN or configure RObot.slack.app_token",
+    )?;
+    let slack = config.robot.slack.clone().unwrap_or_default();
+    if slack.channel_ids.is_empty()
+        || slack.allowed_users.is_empty()
+        || slack.channel_repos.is_empty()
+    {
+        anyhow::bail!(
+            "Slack daemon requires explicit RObot.slack.channel_ids, RObot.slack.allowed_users, and RObot.slack.channel_repos"
+        );
+    }
+    let mut channel_repos = BTreeMap::new();
+    for channel_id in &slack.channel_ids {
+        let Some(repo_root) = slack.channel_repos.get(channel_id) else {
+            anyhow::bail!(
+                "Slack channel {channel_id} is missing RObot.slack.channel_repos mapping"
+            );
+        };
+        if !repo_root.is_absolute() {
+            anyhow::bail!(
+                "Slack repo root for channel {channel_id} must be absolute: {}",
+                repo_root.display()
+            );
+        }
+        let canonical = repo_root.canonicalize().with_context(|| {
+            format!(
+                "Slack repo root for channel {channel_id} does not exist: {}",
+                repo_root.display()
+            )
+        })?;
+        channel_repos.insert(channel_id.clone(), canonical);
+    }
+
+    if use_colors {
+        println!("\x1b[1mRalph Daemon\x1b[0m (Slack Socket Mode)");
+    } else {
+        println!("Ralph Daemon (Slack Socket Mode)");
+    }
+
+    let api = ralph_slack::SlackApi::new(bot_token, None);
+    let socket_url = api.open_socket_mode_url(&app_token).await?;
+    let state = ralph_slack::SlackStateManager::new(workspace_root.join(".ralph/slack-state.json"));
+    let daemon = ralph_slack::SlackDaemon::new(
+        ralph_slack::SlackDaemonConfig {
+            workspace_root: workspace_root.clone(),
+            allowed_channels: slack.channel_ids,
+            allowed_users: slack.allowed_users,
+            channel_repos,
+        },
+        state,
+        ralph_slack::CommandLoopSpawner::new(Some(config_path)),
+        ralph_slack::SlackApiNotifier::new(api),
+    );
+    ralph_slack::socket_mode::run_socket_mode(&socket_url, daemon).await?;
     Ok(())
 }
 
@@ -850,6 +1080,109 @@ fn save_robot_config(timeout: u64, bot_token: Option<&str>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn save_slack_robot_config(
+    timeout: u64,
+    bot_token: Option<&str>,
+    app_token: Option<&str>,
+    channel_ids: &[String],
+    allowed_users: &[String],
+) -> Result<()> {
+    let config_path = Path::new("ralph.yml");
+    let doc = if config_path.exists() {
+        let content = std::fs::read_to_string(config_path).context("Failed to read ralph.yml")?;
+        serde_yaml::from_str(&content).context("Failed to parse ralph.yml")?
+    } else {
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+    };
+    let mut root = match doc {
+        serde_yaml::Value::Mapping(map) => map,
+        _ => serde_yaml::Mapping::new(),
+    };
+
+    let mut slack_map = serde_yaml::Mapping::new();
+    if let Some(token) = bot_token {
+        slack_map.insert(
+            serde_yaml::Value::String("bot_token".to_string()),
+            serde_yaml::Value::String(token.to_string()),
+        );
+    }
+    if let Some(token) = app_token {
+        slack_map.insert(
+            serde_yaml::Value::String("app_token".to_string()),
+            serde_yaml::Value::String(token.to_string()),
+        );
+    }
+    slack_map.insert(
+        serde_yaml::Value::String("channel_ids".to_string()),
+        serde_yaml::Value::Sequence(
+            channel_ids
+                .iter()
+                .map(|id| serde_yaml::Value::String(id.clone()))
+                .collect(),
+        ),
+    );
+    slack_map.insert(
+        serde_yaml::Value::String("allowed_users".to_string()),
+        serde_yaml::Value::Sequence(
+            allowed_users
+                .iter()
+                .map(|id| serde_yaml::Value::String(id.clone()))
+                .collect(),
+        ),
+    );
+    let cwd = std::env::current_dir()
+        .context("Failed to resolve current directory for Slack channel_repos")?;
+    let mut channel_repos = serde_yaml::Mapping::new();
+    for channel_id in channel_ids {
+        channel_repos.insert(
+            serde_yaml::Value::String(channel_id.clone()),
+            serde_yaml::Value::String(cwd.to_string_lossy().to_string()),
+        );
+    }
+    slack_map.insert(
+        serde_yaml::Value::String("channel_repos".to_string()),
+        serde_yaml::Value::Mapping(channel_repos),
+    );
+
+    let mut robot_map = serde_yaml::Mapping::new();
+    robot_map.insert(
+        serde_yaml::Value::String("enabled".to_string()),
+        serde_yaml::Value::Bool(true),
+    );
+    robot_map.insert(
+        serde_yaml::Value::String("surface".to_string()),
+        serde_yaml::Value::String("slack".to_string()),
+    );
+    robot_map.insert(
+        serde_yaml::Value::String("timeout_seconds".to_string()),
+        serde_yaml::Value::Number(serde_yaml::Number::from(timeout)),
+    );
+    robot_map.insert(
+        serde_yaml::Value::String("slack".to_string()),
+        serde_yaml::Value::Mapping(slack_map),
+    );
+    root.insert(
+        serde_yaml::Value::String("RObot".to_string()),
+        serde_yaml::Value::Mapping(robot_map),
+    );
+
+    let yaml_str = serde_yaml::to_string(&serde_yaml::Value::Mapping(root))
+        .context("Failed to serialize config")?;
+    std::fs::write(config_path, yaml_str).context("Failed to write ralph.yml")?;
+    Ok(())
+}
+
+fn load_slack_config_from(path: &Path) -> Option<ralph_core::SlackBotConfig> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let config: serde_yaml::Value = serde_yaml::from_str(&content).ok()?;
+    let slack = config
+        .get("RObot")
+        .or_else(|| config.get("robot"))
+        .and_then(|r| r.get("slack"))?
+        .clone();
+    serde_yaml::from_value(slack).ok()
 }
 
 /// Write resolved config to a temporary runtime file so loop_runner receives a config path.
@@ -1131,7 +1464,7 @@ mod tests {
     async fn test_run_daemon_rejects_builtin_config() {
         let sources = vec![ConfigSource::Builtin("tdd".to_string())];
 
-        let err = run_daemon(DaemonArgs {}, &sources, None, false)
+        let err = run_daemon(DaemonArgs { slack: false }, &sources, None, false)
             .await
             .expect_err("expected daemon setup error");
         assert!(
@@ -1147,7 +1480,7 @@ mod tests {
             "https://example.com/ralph.yml".to_string(),
         )];
 
-        let err = run_daemon(DaemonArgs {}, &sources, None, false)
+        let err = run_daemon(DaemonArgs { slack: false }, &sources, None, false)
             .await
             .expect_err("expected remote config error");
         assert!(
@@ -1163,7 +1496,7 @@ mod tests {
         let _cwd = CwdGuard::set(temp_dir.path());
 
         let sources = vec![ConfigSource::File(PathBuf::from("missing.yml"))];
-        let err = run_daemon(DaemonArgs {}, &sources, None, false)
+        let err = run_daemon(DaemonArgs { slack: false }, &sources, None, false)
             .await
             .expect_err("expected missing config error");
         assert!(
@@ -1589,6 +1922,60 @@ mod tests {
         std::fs::write(".ralph/telegram-state.json", "not-json").unwrap();
 
         assert_eq!(resolve_chat_id(), None);
+    }
+
+    #[test]
+    fn test_slack_cli_flags_parse() {
+        let args = BotArgs::try_parse_from([
+            "ralph",
+            "onboard",
+            "--slack",
+            "--token",
+            "xoxb-test",
+            "--app-token",
+            "xapp-test",
+            "--channel",
+            "C123",
+            "--user",
+            "U123",
+        ])
+        .unwrap();
+        let BotCommands::Onboard(onboard) = args.command else {
+            panic!("expected onboard command");
+        };
+        assert!(onboard.slack);
+        assert_eq!(onboard.channel_ids, vec!["C123"]);
+        assert_eq!(onboard.allowed_users, vec!["U123"]);
+    }
+
+    #[test]
+    fn test_save_slack_robot_config_writes_provider_config() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let _cwd = CwdGuard::set(temp_dir.path());
+
+        save_slack_robot_config(
+            600,
+            Some("xoxb-test"),
+            Some("xapp-test"),
+            &["C123".to_string()],
+            &["U123".to_string()],
+        )
+        .unwrap();
+
+        let content = std::fs::read_to_string("ralph.yml").unwrap();
+        let config: serde_yaml::Value = serde_yaml::from_str(&content).unwrap();
+        let robot = config.get("RObot").unwrap();
+        assert_eq!(robot.get("surface").and_then(|v| v.as_str()), Some("slack"));
+        assert_eq!(
+            robot
+                .get("slack")
+                .and_then(|s| s.get("bot_token"))
+                .and_then(|v| v.as_str()),
+            Some("xoxb-test")
+        );
+        let loaded = load_slack_config_from(Path::new("ralph.yml")).unwrap();
+        assert_eq!(loaded.channel_ids, vec!["C123"]);
+        assert_eq!(loaded.allowed_users, vec!["U123"]);
     }
 
     #[test]

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -232,9 +232,11 @@ pub async fn run_loop_impl(
     // Initialize event loop with context for proper path resolution
     let mut event_loop = EventLoop::with_context(config.clone(), ctx.clone());
 
-    // Inject robot service (Telegram) for human-in-the-loop communication
+    // Inject robot service for human-in-the-loop communication. Telegram owns inbound
+    // polling from the primary daemon; Slack worktree loops still need outbound access
+    // to the daemon-owned thread, so provider dispatch decides whether worktrees are eligible.
     if config.robot.enabled
-        && ctx.is_primary()
+        && should_inject_robot_service(&config, &ctx)
         && let Some(service) = create_robot_service(&config, &ctx)
     {
         event_loop.set_robot_service(service);
@@ -4942,11 +4944,37 @@ pub async fn start_loop(
     .await
 }
 
-/// Creates a robot service (Telegram) for human-in-the-loop communication.
+/// Creates a robot service for human-in-the-loop communication.
 ///
-/// Called by `run_loop_impl` when `robot.enabled` is true and this is the primary loop.
+/// Called by `run_loop_impl` when `robot.enabled` is true and provider rules allow
+/// this loop context to post outbound messages.
 /// Returns `None` if the service cannot be created or started.
 fn create_robot_service(
+    config: &RalphConfig,
+    context: &LoopContext,
+) -> Option<Box<dyn ralph_proto::RobotService>> {
+    match config.robot.surface() {
+        Ok(ralph_core::RobotSurface::Telegram) => create_telegram_robot_service(config, context),
+        Ok(ralph_core::RobotSurface::Slack) => create_slack_robot_service(config, context),
+        Err(e) => {
+            warn!(error = %e, "Failed to resolve robot surface");
+            None
+        }
+    }
+}
+
+fn should_inject_robot_service(config: &RalphConfig, context: &LoopContext) -> bool {
+    match config.robot.surface() {
+        Ok(ralph_core::RobotSurface::Telegram) => context.is_primary(),
+        Ok(ralph_core::RobotSurface::Slack) => true,
+        Err(e) => {
+            warn!(error = %e, "Failed to resolve robot surface");
+            false
+        }
+    }
+}
+
+fn create_telegram_robot_service(
     config: &RalphConfig,
     context: &LoopContext,
 ) -> Option<Box<dyn ralph_proto::RobotService>> {
@@ -4983,6 +5011,68 @@ fn create_robot_service(
             None
         }
     }
+}
+
+fn create_slack_robot_service(
+    config: &RalphConfig,
+    context: &LoopContext,
+) -> Option<Box<dyn ralph_proto::RobotService>> {
+    let loop_id = std::env::var("RALPH_LOOP_ID")
+        .ok()
+        .or_else(|| context.loop_id().map(String::from))
+        .unwrap_or_else(|| "main".to_string());
+    let timeout_secs = config.robot.timeout_seconds.unwrap_or(300);
+    let bot_token = config.robot.resolve_slack_bot_token();
+    let repo_root = context.repo_root().to_path_buf();
+    let binding = resolve_slack_thread_binding(&repo_root, &loop_id);
+    let channel_id = std::env::var("RALPH_SLACK_CHANNEL_ID")
+        .ok()
+        .or_else(|| binding.clone().map(|binding| binding.channel_id));
+    let thread_ts = std::env::var("RALPH_SLACK_THREAD_TS")
+        .ok()
+        .or_else(|| binding.map(|binding| binding.thread_ts));
+    let Some(channel_id) = channel_id else {
+        warn!(loop_id = %loop_id, "Slack robot surface configured but no Slack channel binding was found");
+        return None;
+    };
+    let Some(thread_ts) = thread_ts else {
+        warn!(loop_id = %loop_id, "Slack robot surface configured but no Slack thread binding was found");
+        return None;
+    };
+
+    match ralph_slack::SlackService::new(
+        repo_root,
+        bot_token,
+        timeout_secs,
+        loop_id,
+        channel_id,
+        thread_ts,
+        None,
+    ) {
+        Ok(service) => {
+            info!(
+                timeout_secs = service.timeout_secs(),
+                "Slack robot human-in-the-loop service active"
+            );
+            Some(Box::new(service))
+        }
+        Err(e) => {
+            warn!(error = %e, "Failed to create Slack robot service");
+            None
+        }
+    }
+}
+
+fn resolve_slack_thread_binding(
+    repo_root: &std::path::Path,
+    loop_id: &str,
+) -> Option<ralph_slack::SlackThreadBinding> {
+    let manager = ralph_slack::SlackStateManager::new(repo_root.join(".ralph/slack-state.json"));
+    manager
+        .load()
+        .ok()
+        .flatten()
+        .and_then(|state| state.threads.get(loop_id).cloned())
 }
 
 // ── Wave Execution ──────────────────────────────────────────────────────────

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -5031,6 +5031,10 @@ fn create_slack_robot_service(
     let thread_ts = std::env::var("RALPH_SLACK_THREAD_TS")
         .ok()
         .or_else(|| binding.map(|binding| binding.thread_ts));
+    let state_path = std::env::var("RALPH_SLACK_STATE_PATH")
+        .ok()
+        .filter(|path| !path.trim().is_empty())
+        .map(std::path::PathBuf::from);
     let Some(channel_id) = channel_id else {
         warn!(loop_id = %loop_id, "Slack robot surface configured but no Slack channel binding was found");
         return None;
@@ -5040,7 +5044,7 @@ fn create_slack_robot_service(
         return None;
     };
 
-    match ralph_slack::SlackService::new(
+    match ralph_slack::SlackService::new_with_state_path(
         repo_root,
         bot_token,
         timeout_secs,
@@ -5048,6 +5052,7 @@ fn create_slack_robot_service(
         channel_id,
         thread_ts,
         None,
+        state_path,
     ) {
         Ok(service) => {
             info!(

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -236,6 +236,25 @@ fn resolve_marker_target(workspace_root: &Path, marker_value: &str) -> PathBuf {
     }
 }
 
+fn resolve_emit_events_file(
+    workspace_root: &Path,
+    current_events_marker: &Path,
+    fallback_file: &Path,
+    env_events_file: Option<std::ffi::OsString>,
+    honor_env_events_file: bool,
+) -> PathBuf {
+    if honor_env_events_file
+        && let Some(path) = env_events_file
+        && !path.is_empty()
+    {
+        return PathBuf::from(path);
+    }
+
+    fs::read_to_string(current_events_marker)
+        .map(|s| resolve_marker_target(workspace_root, &s))
+        .unwrap_or_else(|_| fallback_file.to_path_buf())
+}
+
 /// Verbosity level for streaming output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Verbosity {
@@ -2571,17 +2590,17 @@ fn emit_command_with_root(
         record["wave_index"] = serde_json::Value::Number(wave_index.into());
     }
 
-    // Resolve events file: RALPH_EVENTS_FILE env > marker file > CLI arg
-    // This ensures `ralph emit` writes to the same events file as the active run
-    let events_file = std::env::var("RALPH_EVENTS_FILE")
-        .ok()
-        .filter(|p| !p.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            fs::read_to_string(&current_events_marker)
-                .map(|s| resolve_marker_target(&workspace_root, &s))
-                .unwrap_or_else(|_| args.file.clone())
-        });
+    // Resolve events file: RALPH_EVENTS_FILE env > marker file > CLI arg.
+    // When an explicit root is provided (internal/test helpers), do not honor the
+    // ambient RALPH_EVENTS_FILE from an active Ralph loop; otherwise unit tests
+    // that exercise `ralph emit` can leak demo events into the live loop JSONL.
+    let events_file = resolve_emit_events_file(
+        &workspace_root,
+        &current_events_marker,
+        &args.file,
+        std::env::var_os("RALPH_EVENTS_FILE"),
+        root.is_none(),
+    );
 
     // Ensure parent directory exists
     if let Some(parent) = events_file.parent()
@@ -3225,6 +3244,41 @@ mod tests {
             .expect("read events");
         assert!(events.contains("\"topic\":\"debug.step\""));
         assert!(events.contains("task_id=demo"));
+    }
+
+    #[test]
+    fn test_explicit_emit_root_ignores_ambient_events_file_override() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let workspace = temp_dir.path().to_path_buf();
+        std::fs::create_dir_all(workspace.join(".ralph")).expect("ralph dir");
+        std::fs::write(
+            workspace.join(".ralph/current-events"),
+            ".ralph/events-20260309-test.jsonl\n",
+        )
+        .expect("write marker");
+        let ambient_live_events = workspace.join("live-loop-events.jsonl");
+        let fallback = PathBuf::from(".ralph/events.jsonl");
+
+        let explicit_root_target = resolve_emit_events_file(
+            &workspace,
+            &workspace.join(".ralph/current-events"),
+            &fallback,
+            Some(ambient_live_events.clone().into_os_string()),
+            false,
+        );
+        assert_eq!(
+            explicit_root_target,
+            workspace.join(".ralph/events-20260309-test.jsonl")
+        );
+
+        let live_loop_target = resolve_emit_events_file(
+            &workspace,
+            &workspace.join(".ralph/current-events"),
+            &fallback,
+            Some(ambient_live_events.clone().into_os_string()),
+            true,
+        );
+        assert_eq!(live_loop_target, ambient_live_events);
     }
 
     #[test]

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -211,6 +211,7 @@ pub(crate) fn resolve_path_from_workspace(
     resolve_workspace_root(root).join(path)
 }
 
+#[cfg(test)]
 fn urgent_steer_path_from_workspace(root: Option<&PathBuf>) -> PathBuf {
     resolve_workspace_root(root).join(".ralph/urgent-steer.json")
 }
@@ -227,6 +228,13 @@ pub(crate) fn discover_workspace_root(start: &Path) -> Option<PathBuf> {
     })
 }
 
+fn discover_ralph_workspace_root(start: &Path) -> Option<PathBuf> {
+    start
+        .ancestors()
+        .find(|dir| dir.join(".ralph").is_dir())
+        .map(Path::to_path_buf)
+}
+
 fn resolve_marker_target(workspace_root: &Path, marker_value: &str) -> PathBuf {
     let path = PathBuf::from(marker_value.trim());
     if path.is_absolute() {
@@ -234,6 +242,29 @@ fn resolve_marker_target(workspace_root: &Path, marker_value: &str) -> PathBuf {
     } else {
         workspace_root.join(path)
     }
+}
+
+fn resolve_emit_workspace_context(
+    root: Option<&PathBuf>,
+    cwd: &Path,
+    env_workspace_root: Option<std::ffi::OsString>,
+    force_honor_env_events_file: bool,
+) -> (PathBuf, bool) {
+    if let Some(root) = root {
+        return (root.clone(), force_honor_env_events_file);
+    }
+
+    if let Some(local_root) = discover_ralph_workspace_root(cwd) {
+        return (local_root, force_honor_env_events_file);
+    }
+
+    if let Some(value) = env_workspace_root
+        && !value.is_empty()
+    {
+        return (PathBuf::from(value), true);
+    }
+
+    (cwd.to_path_buf(), true)
 }
 
 fn resolve_emit_events_file(
@@ -252,7 +283,7 @@ fn resolve_emit_events_file(
 
     fs::read_to_string(current_events_marker)
         .map(|s| resolve_marker_target(workspace_root, &s))
-        .unwrap_or_else(|_| fallback_file.to_path_buf())
+        .unwrap_or_else(|_| workspace_root.join(fallback_file))
 }
 
 /// Verbosity level for streaming output.
@@ -2525,11 +2556,20 @@ fn emit_command_with_root(
     root: Option<&PathBuf>,
 ) -> Result<()> {
     let use_colors = color_mode.should_use_colors();
-    let workspace_root = resolve_workspace_root(root);
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let is_wave_emit =
+        std::env::var("RALPH_WAVE_WORKER").is_ok() || std::env::var("RALPH_WAVE_ID").is_ok();
+    let (workspace_root, honor_env_events_file) = resolve_emit_workspace_context(
+        root,
+        &cwd,
+        std::env::var_os("RALPH_WORKSPACE_ROOT"),
+        is_wave_emit,
+    );
     let current_events_marker = workspace_root.join(".ralph/current-events");
 
     if std::env::var("RALPH_WAVE_ID").is_err() {
-        let urgent_steer_store = UrgentSteerStore::new(urgent_steer_path_from_workspace(root));
+        let urgent_steer_store =
+            UrgentSteerStore::new(workspace_root.join(".ralph/urgent-steer.json"));
         if let Some(record) = urgent_steer_store
             .take()
             .context("Failed to read urgent-steer marker")?
@@ -2590,16 +2630,16 @@ fn emit_command_with_root(
         record["wave_index"] = serde_json::Value::Number(wave_index.into());
     }
 
-    // Resolve events file: RALPH_EVENTS_FILE env > marker file > CLI arg.
-    // When an explicit root is provided (internal/test helpers), do not honor the
-    // ambient RALPH_EVENTS_FILE from an active Ralph loop; otherwise unit tests
-    // that exercise `ralph emit` can leak demo events into the live loop JSONL.
+    // Resolve events file. Plain `ralph emit` prefers a local `.ralph/current-events`
+    // marker over ambient loop env vars, so nested commands/tests cannot leak demo events
+    // into their parent loop. Wave workers opt back into `RALPH_EVENTS_FILE` because
+    // their per-worker events file is intentionally provided through env.
     let events_file = resolve_emit_events_file(
         &workspace_root,
         &current_events_marker,
         &args.file,
         std::env::var_os("RALPH_EVENTS_FILE"),
-        root.is_none(),
+        honor_env_events_file,
     );
 
     // Ensure parent directory exists
@@ -3279,6 +3319,96 @@ mod tests {
             true,
         );
         assert_eq!(live_loop_target, ambient_live_events);
+    }
+
+    #[test]
+    fn test_emit_context_prefers_local_ralph_marker_over_ambient_loop_env() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let live_workspace = temp_dir.path().join("live-loop");
+        let local_workspace = temp_dir.path().join("repo-worktree");
+        std::fs::create_dir_all(live_workspace.join(".ralph")).expect("live ralph dir");
+        std::fs::create_dir_all(local_workspace.join(".ralph")).expect("local ralph dir");
+        std::fs::write(
+            local_workspace.join(".ralph/current-events"),
+            ".ralph/events-local.jsonl\n",
+        )
+        .expect("write marker");
+        let ambient_live_events = live_workspace.join(".ralph/events-live.jsonl");
+
+        let (workspace_root, honor_env_events_file) = resolve_emit_workspace_context(
+            None,
+            &local_workspace,
+            Some(live_workspace.clone().into_os_string()),
+            false,
+        );
+        assert_eq!(workspace_root, local_workspace);
+        assert!(
+            !honor_env_events_file,
+            "plain ralph emit in a local workspace must ignore ambient loop RALPH_EVENTS_FILE"
+        );
+
+        let target = resolve_emit_events_file(
+            &workspace_root,
+            &workspace_root.join(".ralph/current-events"),
+            &PathBuf::from(".ralph/events.jsonl"),
+            Some(ambient_live_events.into_os_string()),
+            honor_env_events_file,
+        );
+        assert_eq!(target, workspace_root.join(".ralph/events-local.jsonl"));
+    }
+
+    #[test]
+    fn test_wave_emit_context_honors_worker_events_file_inside_local_workspace() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let live_workspace = temp_dir.path().join("live-loop");
+        let local_workspace = temp_dir.path().join("repo-worktree");
+        std::fs::create_dir_all(live_workspace.join(".ralph")).expect("live ralph dir");
+        std::fs::create_dir_all(local_workspace.join(".ralph")).expect("local ralph dir");
+        std::fs::write(
+            local_workspace.join(".ralph/current-events"),
+            ".ralph/events-local.jsonl\n",
+        )
+        .expect("write marker");
+        let worker_events = local_workspace.join(".ralph/wave-worker-0.jsonl");
+
+        let (workspace_root, honor_env_events_file) = resolve_emit_workspace_context(
+            None,
+            &local_workspace,
+            Some(live_workspace.into_os_string()),
+            true,
+        );
+        assert_eq!(workspace_root, local_workspace);
+        assert!(
+            honor_env_events_file,
+            "wave worker ralph emit must still honor RALPH_EVENTS_FILE"
+        );
+
+        let target = resolve_emit_events_file(
+            &workspace_root,
+            &workspace_root.join(".ralph/current-events"),
+            &PathBuf::from(".ralph/events.jsonl"),
+            Some(worker_events.clone().into_os_string()),
+            honor_env_events_file,
+        );
+        assert_eq!(target, worker_events);
+    }
+
+    #[test]
+    fn test_emit_context_uses_ambient_workspace_when_no_local_ralph_workspace() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let live_workspace = temp_dir.path().join("live-loop");
+        let unrelated_cwd = temp_dir.path().join("scratch");
+        std::fs::create_dir_all(live_workspace.join(".ralph")).expect("live ralph dir");
+        std::fs::create_dir_all(&unrelated_cwd).expect("scratch dir");
+
+        let (workspace_root, honor_env_events_file) = resolve_emit_workspace_context(
+            None,
+            &unrelated_cwd,
+            Some(live_workspace.clone().into_os_string()),
+            false,
+        );
+        assert_eq!(workspace_root, live_workspace);
+        assert!(honor_env_events_file);
     }
 
     #[test]

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -767,7 +767,7 @@ struct RunArgs {
     /// Explicit loop ID to use with --continue.
     /// Reuses tasks from the specified loop instead of generating a new ID.
     /// If omitted with --continue, reuses the existing current-loop-id marker.
-    #[arg(long, requires = "continue_mode")]
+    #[arg(long)]
     loop_id: Option<String>,
 
     // ─────────────────────────────────────────────────────────────────────────

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -2138,10 +2138,15 @@ pub struct SlackBotConfig {
     #[serde(default)]
     pub allowed_users: Vec<String>,
 
-    /// Explicit Slack channel ID -> repo/workspace root mapping.
-    /// Slack-started loops use the repo root for the channel that owns the thread.
+    /// Safe Slack repo alias -> repo/workspace root mapping.
+    /// Slack users can select only these aliases, never arbitrary paths.
     #[serde(default)]
-    pub channel_repos: HashMap<String, PathBuf>,
+    pub repo_aliases: HashMap<String, PathBuf>,
+
+    /// Explicit Slack channel ID -> repo alias mapping.
+    /// Slack-started loops use the repo alias default for the channel that owns the thread.
+    #[serde(default)]
+    pub channel_repos: HashMap<String, String>,
 
     /// How Slack should start Ralph loops.
     pub start_mode: Option<SlackStartMode>,

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -1941,7 +1941,7 @@ impl HatConfig {
 /// Enables bidirectional communication between AI agents and humans
 /// during orchestration loops. When enabled, agents can emit `human.interact`
 /// events to request clarification (blocking the loop), and humans can
-/// send proactive guidance via Telegram.
+/// send proactive guidance through the configured RObot provider.
 ///
 /// Example configuration:
 /// ```yaml
@@ -1962,17 +1962,43 @@ pub struct RobotConfig {
     /// Required when enabled (no default — must be explicit).
     pub timeout_seconds: Option<u64>,
 
-    /// Interval in seconds between periodic check-in messages sent via Telegram.
+    /// Interval in seconds between periodic check-in messages sent via the configured provider.
     /// When set, Ralph sends a status message every N seconds so the human
     /// knows it's still working. If `None`, no check-ins are sent.
     pub checkin_interval_seconds: Option<u64>,
 
+    /// Explicit human-in-the-loop surface. If omitted, Ralph infers from the
+    /// configured provider subsection and preserves legacy Telegram behavior.
+    #[serde(default)]
+    pub surface: Option<RobotSurface>,
+
     /// Telegram bot configuration.
     #[serde(default)]
     pub telegram: Option<TelegramBotConfig>,
+
+    /// Slack bot configuration.
+    #[serde(default)]
+    pub slack: Option<SlackBotConfig>,
 }
 
 impl RobotConfig {
+    /// Returns the configured RObot surface, inferring legacy Telegram configs when omitted.
+    pub fn surface(&self) -> Result<RobotSurface, ConfigError> {
+        if let Some(surface) = self.surface {
+            return Ok(surface);
+        }
+
+        match (self.telegram.is_some(), self.slack.is_some()) {
+            (true, false) => Ok(RobotSurface::Telegram),
+            (false, true) => Ok(RobotSurface::Slack),
+            (true, true) => Err(ConfigError::RobotMissingField {
+                field: "RObot.surface".to_string(),
+                hint: "Both RObot.telegram and RObot.slack are configured; set RObot.surface to either 'telegram' or 'slack' explicitly".to_string(),
+            }),
+            (false, false) => Ok(RobotSurface::Telegram),
+        }
+    }
+
     /// Validates the RObot config. Returns an error if enabled but misconfigured.
     pub fn validate(&self) -> Result<(), ConfigError> {
         if !self.enabled {
@@ -1986,13 +2012,25 @@ impl RobotConfig {
             });
         }
 
-        // Bot token must be available from config, keychain, or env var
-        if self.resolve_bot_token().is_none() {
-            return Err(ConfigError::RobotMissingField {
-                field: "RObot.telegram.bot_token".to_string(),
-                hint: "Run `ralph bot onboard --telegram`, set RALPH_TELEGRAM_BOT_TOKEN env var, or set RObot.telegram.bot_token in config"
-                    .to_string(),
-            });
+        match self.surface()? {
+            RobotSurface::Telegram => {
+                // Bot token must be available from config, keychain, or env var.
+                if self.resolve_bot_token().is_none() {
+                    return Err(ConfigError::RobotMissingField {
+                        field: "RObot.telegram.bot_token".to_string(),
+                        hint: "Run `ralph bot onboard`, set RALPH_TELEGRAM_BOT_TOKEN env var, or set RObot.telegram.bot_token in config"
+                            .to_string(),
+                    });
+                }
+            }
+            RobotSurface::Slack => {
+                if self.resolve_slack_bot_token().is_none() {
+                    return Err(ConfigError::RobotMissingField {
+                        field: "RObot.slack.bot_token".to_string(),
+                        hint: "Set RALPH_SLACK_BOT_TOKEN env var or set RObot.slack.bot_token in config".to_string(),
+                    });
+                }
+            }
         }
 
         Ok(())
@@ -2043,6 +2081,70 @@ impl RobotConfig {
                 .and_then(|telegram| telegram.api_url.clone())
         })
     }
+
+    /// Resolves the Slack bot token from `RALPH_SLACK_BOT_TOKEN` or config.
+    pub fn resolve_slack_bot_token(&self) -> Option<String> {
+        std::env::var("RALPH_SLACK_BOT_TOKEN").ok().or_else(|| {
+            self.slack
+                .as_ref()
+                .and_then(|slack| slack.bot_token.clone())
+        })
+    }
+
+    /// Resolves the Slack app token from `RALPH_SLACK_APP_TOKEN` or config.
+    pub fn resolve_slack_app_token(&self) -> Option<String> {
+        std::env::var("RALPH_SLACK_APP_TOKEN").ok().or_else(|| {
+            self.slack
+                .as_ref()
+                .and_then(|slack| slack.app_token.clone())
+        })
+    }
+}
+
+/// Human-in-the-loop surface provider for RObot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RobotSurface {
+    Telegram,
+    Slack,
+}
+
+/// Slack RObot start mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SlackStartMode {
+    AppMention,
+    SlashCommand,
+    Both,
+}
+
+/// Slack bot configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SlackBotConfig {
+    /// Bot token. Optional if `RALPH_SLACK_BOT_TOKEN` env var is set.
+    pub bot_token: Option<String>,
+
+    /// Socket Mode app token. Optional for loop-local Slack service; required by daemon mode.
+    pub app_token: Option<String>,
+
+    /// Signing secret for Events API deployments.
+    pub signing_secret: Option<String>,
+
+    /// Allowed Slack channel IDs.
+    #[serde(default)]
+    pub channel_ids: Vec<String>,
+
+    /// Allowed Slack user IDs.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+
+    /// Explicit Slack channel ID -> repo/workspace root mapping.
+    /// Slack-started loops use the repo root for the channel that owns the thread.
+    #[serde(default)]
+    pub channel_repos: HashMap<String, PathBuf>,
+
+    /// How Slack should start Ralph loops.
+    pub start_mode: Option<SlackStartMode>,
 }
 
 /// Telegram bot configuration.
@@ -3407,7 +3509,9 @@ hooks:
         let config = RalphConfig::default();
         assert!(!config.robot.enabled);
         assert!(config.robot.timeout_seconds.is_none());
+        assert!(config.robot.surface.is_none());
         assert!(config.robot.telegram.is_none());
+        assert!(config.robot.slack.is_none());
     }
 
     #[test]
@@ -3438,6 +3542,114 @@ RObot:
 
         // Validation should pass
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_robot_config_legacy_telegram_infers_surface() {
+        let yaml = r#"
+RObot:
+  enabled: true
+  timeout_seconds: 300
+  telegram:
+    bot_token: "123456:ABC-DEF"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(config.robot.surface().unwrap(), RobotSurface::Telegram);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_robot_config_slack_surface_validates_bot_token() {
+        let yaml = r#"
+RObot:
+  enabled: true
+  surface: slack
+  timeout_seconds: 86400
+  slack:
+    bot_token: "***"
+    app_token: "xapp-test-token"
+    channel_ids: ["C0B79UQP117"]
+    allowed_users: ["U123456789"]
+    start_mode: both
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(config.robot.surface().unwrap(), RobotSurface::Slack);
+        assert_eq!(
+            config.robot.resolve_slack_bot_token(),
+            Some("***".to_string())
+        );
+        assert_eq!(
+            config.robot.resolve_slack_app_token(),
+            Some("xapp-test-token".to_string())
+        );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_robot_config_both_surfaces_without_explicit_surface_is_ambiguous() {
+        let yaml = r#"
+RObot:
+  enabled: true
+  timeout_seconds: 300
+  telegram:
+    bot_token: "123456:ABC-DEF"
+  slack:
+    bot_token: "***"
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(&err, ConfigError::RobotMissingField { field, .. }
+                if field == "RObot.surface"),
+            "Expected ambiguous surface validation failure, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_robot_config_slack_missing_timeout_fails_before_token() {
+        let yaml = r#"
+RObot:
+  enabled: true
+  surface: slack
+  slack: {}
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(&err, ConfigError::RobotMissingField { field, .. }
+                if field == "RObot.timeout_seconds"),
+            "Expected timeout validation failure first, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_robot_config_slack_missing_bot_token_fails() {
+        if std::env::var("RALPH_SLACK_BOT_TOKEN").is_ok() {
+            return;
+        }
+
+        let yaml = r#"
+RObot:
+  enabled: true
+  surface: slack
+  timeout_seconds: 300
+  slack: {}
+"#;
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(&err, ConfigError::RobotMissingField { field, .. }
+                if field == "RObot.slack.bot_token"),
+            "Expected Slack bot_token validation failure, got: {:?}",
+            err
+        );
     }
 
     #[test]
@@ -3479,7 +3691,9 @@ RObot:
             enabled: true,
             timeout_seconds: None,
             checkin_interval_seconds: None,
+            surface: None,
             telegram: None,
+            slack: None,
         };
         let result = robot.validate();
         assert!(result.is_err());
@@ -3501,10 +3715,12 @@ RObot:
             enabled: true,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
+            surface: None,
             telegram: Some(TelegramBotConfig {
                 bot_token: Some("config-token".to_string()),
                 api_url: None,
             }),
+            slack: None,
         };
 
         // When RALPH_TELEGRAM_BOT_TOKEN is not set, config token is returned
@@ -3522,7 +3738,9 @@ RObot:
             enabled: true,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
+            surface: None,
             telegram: None,
+            slack: None,
         };
 
         // Without env var AND without config token, resolve returns None
@@ -3540,10 +3758,12 @@ RObot:
             enabled: true,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
+            surface: None,
             telegram: Some(TelegramBotConfig {
                 bot_token: Some("test-token".to_string()),
                 api_url: None,
             }),
+            slack: None,
         };
         assert!(robot.validate().is_ok());
     }
@@ -3560,7 +3780,9 @@ RObot:
             enabled: true,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
+            surface: None,
             telegram: None,
+            slack: None,
         };
         let result = robot.validate();
         assert!(result.is_err());
@@ -3585,10 +3807,12 @@ RObot:
             enabled: true,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
+            surface: None,
             telegram: Some(TelegramBotConfig {
                 bot_token: None,
                 api_url: None,
             }),
+            slack: None,
         };
         let result = robot.validate();
         assert!(result.is_err());

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -2145,6 +2145,11 @@ pub struct SlackBotConfig {
 
     /// How Slack should start Ralph loops.
     pub start_mode: Option<SlackStartMode>,
+
+    /// Opt in to Slack AI streaming APIs (`chat.startStream` / `chat.appendStream` / `chat.stopStream`).
+    /// When false or omitted, the Slack surface keeps using normal message/card update fallbacks.
+    #[serde(default)]
+    pub streaming: bool,
 }
 
 /// Telegram bot configuration.
@@ -2294,6 +2299,28 @@ features:
             config.features.preflight.skip,
             vec!["telegram".to_string(), "git".to_string()]
         );
+    }
+
+    #[test]
+    fn test_slack_streaming_capability_defaults_to_fallback_and_can_opt_in() {
+        let fallback_yaml = r#"
+RObot:
+  surface: slack
+  slack:
+    bot_token: token
+"#;
+        let fallback: RalphConfig = serde_yaml::from_str(fallback_yaml).unwrap();
+        assert!(!fallback.robot.slack.unwrap().streaming);
+
+        let streaming_yaml = r#"
+RObot:
+  surface: slack
+  slack:
+    bot_token: token
+    streaming: true
+"#;
+        let streaming: RalphConfig = serde_yaml::from_str(streaming_yaml).unwrap();
+        assert!(streaming.robot.slack.unwrap().streaming);
     }
 
     #[test]

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -2302,6 +2302,38 @@ features:
     }
 
     #[test]
+    fn slack_preset_reviewer_can_emit_completion_promise() {
+        let preset_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../ralph.slack.yml");
+        let yaml = std::fs::read_to_string(&preset_path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", preset_path.display()));
+        let config: RalphConfig = serde_yaml::from_str(&yaml).expect("parse ralph.slack.yml");
+        assert_eq!(
+            config.cli.backend, "codex",
+            "Slack preset default backend must match the live-smoke/runtime path"
+        );
+
+        let reviewer = config
+            .hats
+            .get("reviewer")
+            .expect("Slack preset must define a reviewer hat");
+        assert!(
+            reviewer
+                .publishes
+                .iter()
+                .any(|topic| topic == &config.event_loop.completion_promise),
+            "reviewer must be allowed to publish the completion promise so approved Slack loops can terminate cleanly"
+        );
+        assert!(
+            reviewer.instructions.contains("ralph emit")
+                && reviewer
+                    .instructions
+                    .contains(&config.event_loop.completion_promise),
+            "reviewer instructions must tell the agent to emit the completion event, not only print prose"
+        );
+    }
+
+    #[test]
     fn test_slack_streaming_capability_defaults_to_fallback_and_can_opt_in() {
         let fallback_yaml = r#"
 RObot:
@@ -2309,6 +2341,7 @@ RObot:
   slack:
     bot_token: token
 "#;
+
         let fallback: RalphConfig = serde_yaml::from_str(fallback_yaml).unwrap();
         assert!(!fallback.robot.slack.unwrap().streaming);
 

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -3576,14 +3576,14 @@ RObot:
         let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
 
         assert_eq!(config.robot.surface().unwrap(), RobotSurface::Slack);
-        assert_eq!(
-            config.robot.resolve_slack_bot_token(),
-            Some("***".to_string())
-        );
-        assert_eq!(
-            config.robot.resolve_slack_app_token(),
-            Some("xapp-test-token".to_string())
-        );
+        let expected_bot_token = std::env::var("RALPH_SLACK_BOT_TOKEN")
+            .ok()
+            .or_else(|| Some("***".to_string()));
+        let expected_app_token = std::env::var("RALPH_SLACK_APP_TOKEN")
+            .ok()
+            .or_else(|| Some("xapp-test-token".to_string()));
+        assert_eq!(config.robot.resolve_slack_bot_token(), expected_bot_token);
+        assert_eq!(config.robot.resolve_slack_app_token(), expected_app_token);
         assert!(config.validate().is_ok());
     }
 

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -2157,6 +2157,31 @@ impl EventLoop {
         Value::Object(context)
     }
 
+    fn human_interact_attachments(context: &Map<String, Value>) -> Vec<(PathBuf, Option<String>)> {
+        let Some(Value::Array(attachments)) =
+            context.get("attachments").or_else(|| context.get("files"))
+        else {
+            return Vec::new();
+        };
+
+        attachments
+            .iter()
+            .filter_map(|attachment| {
+                let map = attachment.as_object()?;
+                let path = map
+                    .get("path")
+                    .or_else(|| map.get("file_path"))
+                    .and_then(Value::as_str)?;
+                let caption = map
+                    .get("caption")
+                    .or_else(|| map.get("title"))
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                Some((PathBuf::from(path), caption))
+            })
+            .collect()
+    }
+
     fn is_restart_request_payload(payload: &str) -> bool {
         let payload = payload.to_ascii_lowercase();
         payload.contains("restart yourself") || payload.contains("restart ralph")
@@ -2637,6 +2662,33 @@ impl EventLoop {
                 // Block: poll events file for human.response
                 // Per spec, even on send failure we treat as timeout (continue without blocking)
                 if send_ok {
+                    let attachments = Self::human_interact_attachments(&context);
+                    if !attachments.is_empty() {
+                        let mut uploaded = 0;
+                        let mut errors = Vec::new();
+                        for (file_path, caption) in attachments {
+                            match robot_service.send_file(&file_path, caption.as_deref()) {
+                                Ok(message_id) => {
+                                    if message_id > 0 {
+                                        uploaded += 1;
+                                    }
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        error = %error,
+                                        path = %file_path.display(),
+                                        "Failed to send human.interact attachment via robot service"
+                                    );
+                                    errors.push(Value::String(error.to_string()));
+                                }
+                            }
+                        }
+                        context.insert("attachment_uploads".to_string(), Value::from(uploaded));
+                        if !errors.is_empty() {
+                            context.insert("attachment_errors".to_string(), Value::Array(errors));
+                        }
+                    }
+
                     // Read the active events path from the current-events marker,
                     // falling back to the default events.jsonl if not available.
                     let events_path = self

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -3789,6 +3789,48 @@ hats:
 }
 
 #[test]
+fn test_scope_enforcement_allows_reviewer_completion_after_human_approval() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let yaml = r#"
+event_loop:
+  enforce_hat_scope: true
+hats:
+  planner:
+    name: "Planner"
+    triggers: ["plan.start", "human.response"]
+    publishes: ["human.interact", "work.start"]
+  executor:
+    name: "Executor"
+    triggers: ["work.start", "human.guidance"]
+    publishes: ["work.done", "human.interact"]
+  reviewer:
+    name: "Reviewer"
+    triggers: ["work.done"]
+    publishes: ["plan.start", "human.interact", "LOOP_COMPLETE"]
+"#;
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+
+    // This represents the reviewer turn after the Slack human has approved/signaled done.
+    event_loop.state.last_active_hat_ids = vec![HatId::new("reviewer")];
+
+    write_event_to_jsonl(&events_path, "LOOP_COMPLETE", "approved");
+    let _ = event_loop.process_events_from_jsonl();
+
+    assert_eq!(
+        event_loop.check_completion_event(),
+        Some(TerminationReason::CompletionPromise),
+        "reviewer must be allowed to terminate approved human-in-the-loop flows"
+    );
+}
+
+#[test]
 fn test_scope_enforcement_allows_authorized_event() {
     use tempfile::TempDir;
 

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 #[test]
+fn human_interact_attachments_extracts_structured_file_payloads_only() {
+    let context = EventLoop::parse_human_interact_context(
+        r#"{"question":"Review artifact?","attachments":[{"path":"/tmp/report.txt","caption":"Report"}],"ignored":"MEDIA:/tmp/raw-token.txt"}"#,
+    );
+    let Value::Object(map) = context else {
+        panic!("expected object context");
+    };
+
+    let attachments = EventLoop::human_interact_attachments(&map);
+
+    assert_eq!(attachments.len(), 1);
+    assert_eq!(attachments[0].0, PathBuf::from("/tmp/report.txt"));
+    assert_eq!(attachments[0].1.as_deref(), Some("Report"));
+}
+
+#[test]
 fn test_initialization_routes_to_ralph_in_multihat_mode() {
     // Per "Hatless Ralph" architecture: When custom hats are defined,
     // Ralph is always the executor. Custom hats define topology only.

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -63,8 +63,8 @@ pub mod worktree;
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
     CliConfig, ConfigError, CoreConfig, EventLoopConfig, EventMetadata, FeaturesConfig, HatBackend,
-    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, ScratchpadConfig,
-    SkillOverride, SkillsConfig,
+    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, RobotSurface,
+    ScratchpadConfig, SkillOverride, SkillsConfig, SlackBotConfig,
 };
 // Re-export loop_name types (also available via FeaturesConfig.loop_naming)
 pub use diagnostics::DiagnosticsCollector;

--- a/crates/ralph-proto/src/robot.rs
+++ b/crates/ralph-proto/src/robot.rs
@@ -57,6 +57,15 @@ pub trait RobotService: Send + Sync {
         context: Option<&CheckinContext>,
     ) -> anyhow::Result<i32>;
 
+    /// Send a local file artifact to the human.
+    ///
+    /// The default is a safe no-op so non-file-capable surfaces do not gain an
+    /// implicit upload path. Implementations that support files are responsible
+    /// for validating the path before reading it.
+    fn send_file(&self, _file_path: &Path, _caption: Option<&str>) -> anyhow::Result<i32> {
+        Ok(0)
+    }
+
     /// Get the configured response timeout in seconds.
     fn timeout_secs(&self) -> u64;
 

--- a/crates/ralph-slack/Cargo.toml
+++ b/crates/ralph-slack/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ralph-slack"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Slack integration for human-in-the-loop orchestration in Ralph"
+
+[lints]
+workspace = true
+
+[dependencies]
+ralph-proto.workspace = true
+
+tokio.workspace = true
+async-trait.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+chrono.workspace = true
+reqwest.workspace = true
+tokio-tungstenite.workspace = true
+futures.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/ralph-slack/src/api.rs
+++ b/crates/ralph-slack/src/api.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::error::{SlackError, SlackResult};
+use crate::renderer::SlackRenderedMessage;
 
 const DEFAULT_SLACK_API_BASE_URL: &str = "https://slack.com";
 
@@ -39,14 +40,26 @@ impl SlackApi {
         thread_ts: Option<&str>,
         text: &str,
     ) -> SlackResult<String> {
-        let mut body = json!({
-            "channel": channel,
-            "text": text,
-        });
-        if let Some(thread_ts) = thread_ts {
-            body["thread_ts"] = json!(thread_ts);
-        }
+        let body = self.message_body(channel, thread_ts, text, None);
+        self.post_message_body(body).await
+    }
 
+    pub async fn post_blocks(
+        &self,
+        channel: &str,
+        thread_ts: Option<&str>,
+        message: &SlackRenderedMessage,
+    ) -> SlackResult<String> {
+        let body = self.message_body(
+            channel,
+            thread_ts,
+            &message.text,
+            Some(message.blocks.clone()),
+        );
+        self.post_message_body(body).await
+    }
+
+    async fn post_message_body(&self, body: serde_json::Value) -> SlackResult<String> {
         let response = self
             .client
             .post(self.api_url("/api/chat.postMessage"))
@@ -66,6 +79,26 @@ impl SlackApi {
                     .unwrap_or_else(|| "unknown Slack API error".to_string()),
             ))
         }
+    }
+
+    fn message_body(
+        &self,
+        channel: &str,
+        thread_ts: Option<&str>,
+        text: &str,
+        blocks: Option<Vec<serde_json::Value>>,
+    ) -> serde_json::Value {
+        let mut body = json!({
+            "channel": channel,
+            "text": text,
+        });
+        if let Some(thread_ts) = thread_ts {
+            body["thread_ts"] = json!(thread_ts);
+        }
+        if let Some(blocks) = blocks {
+            body["blocks"] = json!(blocks);
+        }
+        body
     }
 
     pub async fn open_socket_mode_url(&self, app_token: &str) -> SlackResult<String> {

--- a/crates/ralph-slack/src/api.rs
+++ b/crates/ralph-slack/src/api.rs
@@ -157,6 +157,27 @@ impl SlackApi {
         self.post_stream_ack("/api/chat.stopStream", body).await
     }
 
+    pub async fn set_assistant_thread_status(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        status: &str,
+    ) -> SlackResult<()> {
+        let body = json!({
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "status": status,
+        });
+        let envelope: UpdateMessageResponse = self
+            .post_api_json("/api/assistant.threads.setStatus", body)
+            .await?;
+        if envelope.ok {
+            Ok(())
+        } else {
+            Err(slack_api_error(envelope.error))
+        }
+    }
+
     pub fn is_streaming_fallback_error(error: &SlackError) -> bool {
         matches!(
             error,

--- a/crates/ralph-slack/src/api.rs
+++ b/crates/ralph-slack/src/api.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::Path;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::error::{SlackError, SlackResult};
@@ -72,6 +72,126 @@ impl SlackApi {
             Some(message.blocks.clone()),
         );
         self.update_message_body(body).await
+    }
+
+    pub async fn start_stream(
+        &self,
+        channel: &str,
+        thread_ts: &str,
+        recipient_user_id: Option<&str>,
+        recipient_team_id: Option<&str>,
+        markdown_text: Option<&str>,
+        chunks: Vec<SlackStreamChunk>,
+    ) -> SlackResult<String> {
+        let mut body = json!({
+            "channel": channel,
+            "thread_ts": thread_ts,
+            "task_display_mode": "timeline",
+        });
+        if let Some(markdown_text) = markdown_text {
+            body["markdown_text"] = json!(markdown_text);
+        }
+        if let Some(recipient_user_id) = recipient_user_id {
+            body["recipient_user_id"] = json!(recipient_user_id);
+        }
+        if let Some(recipient_team_id) = recipient_team_id {
+            body["recipient_team_id"] = json!(recipient_team_id);
+        }
+        if !chunks.is_empty() {
+            body["chunks"] = json!(chunks);
+        }
+        let envelope: StreamMessageResponse =
+            self.post_api_json("/api/chat.startStream", body).await?;
+        if envelope.ok {
+            envelope
+                .ts
+                .ok_or_else(|| SlackError::Api("chat.startStream missing ts".to_string()))
+        } else {
+            Err(slack_api_error(envelope.error))
+        }
+    }
+
+    pub async fn append_stream(
+        &self,
+        channel: &str,
+        stream_ts: &str,
+        markdown_text: &str,
+        chunks: Vec<SlackStreamChunk>,
+    ) -> SlackResult<()> {
+        let mut body = json!({
+            "channel": channel,
+            "ts": stream_ts,
+            "markdown_text": markdown_text,
+        });
+        if !chunks.is_empty() {
+            body["chunks"] = json!(chunks);
+        }
+        self.post_stream_ack("/api/chat.appendStream", body).await
+    }
+
+    pub async fn stop_stream(
+        &self,
+        channel: &str,
+        stream_ts: &str,
+        markdown_text: Option<&str>,
+        chunks: Vec<SlackStreamChunk>,
+        blocks: Option<Vec<serde_json::Value>>,
+        metadata: Option<serde_json::Value>,
+    ) -> SlackResult<()> {
+        let mut body = json!({
+            "channel": channel,
+            "ts": stream_ts,
+        });
+        if let Some(markdown_text) = markdown_text {
+            body["markdown_text"] = json!(markdown_text);
+        }
+        if !chunks.is_empty() {
+            body["chunks"] = json!(chunks);
+        }
+        if let Some(blocks) = blocks {
+            body["blocks"] = json!(blocks);
+        }
+        if let Some(metadata) = metadata {
+            body["metadata"] = metadata;
+        }
+        self.post_stream_ack("/api/chat.stopStream", body).await
+    }
+
+    pub fn is_streaming_fallback_error(error: &SlackError) -> bool {
+        matches!(
+            error,
+            SlackError::Api(code)
+                if matches!(
+                    code.as_str(),
+                    "unsupported_method"
+                        | "missing_scope"
+                        | "method_not_supported_for_channel_type"
+                        | "not_allowed_token_type"
+                )
+        )
+    }
+
+    async fn post_stream_ack(&self, path: &str, body: serde_json::Value) -> SlackResult<()> {
+        let envelope: UpdateMessageResponse = self.post_api_json(path, body).await?;
+        if envelope.ok {
+            Ok(())
+        } else {
+            Err(slack_api_error(envelope.error))
+        }
+    }
+
+    async fn post_api_json<T>(&self, path: &str, body: serde_json::Value) -> SlackResult<T>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let response = self
+            .client
+            .post(self.api_url(path))
+            .bearer_auth(&self.bot_token)
+            .json(&body)
+            .send()
+            .await?;
+        Ok(response.json().await?)
     }
 
     async fn update_message_body(&self, body: serde_json::Value) -> SlackResult<()> {
@@ -268,6 +388,45 @@ impl SlackApi {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type")]
+pub enum SlackStreamChunk {
+    #[serde(rename = "markdown_text")]
+    MarkdownText { text: String },
+    #[serde(rename = "task_update")]
+    TaskUpdate {
+        id: String,
+        title: String,
+        status: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        details: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
+    },
+}
+
+impl SlackStreamChunk {
+    pub fn markdown_text(text: impl Into<String>) -> Self {
+        Self::MarkdownText { text: text.into() }
+    }
+
+    pub fn task_update(
+        id: impl Into<String>,
+        title: impl Into<String>,
+        status: impl Into<String>,
+        details: Option<&str>,
+        output: Option<&str>,
+    ) -> Self {
+        Self::TaskUpdate {
+            id: id.into(),
+            title: title.into(),
+            status: status.into(),
+            details: details.map(ToOwned::to_owned),
+            output: output.map(ToOwned::to_owned),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct PostMessageResponse {
     ok: bool,
@@ -279,6 +438,17 @@ struct PostMessageResponse {
 struct UpdateMessageResponse {
     ok: bool,
     error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamMessageResponse {
+    ok: bool,
+    ts: Option<String>,
+    error: Option<String>,
+}
+
+fn slack_api_error(error: Option<String>) -> SlackError {
+    SlackError::Api(error.unwrap_or_else(|| "unknown Slack API error".to_string()))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/ralph-slack/src/api.rs
+++ b/crates/ralph-slack/src/api.rs
@@ -1,0 +1,97 @@
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::error::{SlackError, SlackResult};
+
+const DEFAULT_SLACK_API_BASE_URL: &str = "https://slack.com";
+
+#[derive(Debug, Clone)]
+pub struct SlackApi {
+    bot_token: String,
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl SlackApi {
+    pub fn new(bot_token: String, base_url: Option<String>) -> Self {
+        Self {
+            bot_token,
+            client: reqwest::Client::new(),
+            base_url: base_url.unwrap_or_else(|| DEFAULT_SLACK_API_BASE_URL.to_string()),
+        }
+    }
+
+    pub async fn post_message(
+        &self,
+        channel: &str,
+        thread_ts: Option<&str>,
+        text: &str,
+    ) -> SlackResult<String> {
+        let mut body = json!({
+            "channel": channel,
+            "text": text,
+        });
+        if let Some(thread_ts) = thread_ts {
+            body["thread_ts"] = json!(thread_ts);
+        }
+
+        let response = self
+            .client
+            .post(self.api_url("/api/chat.postMessage"))
+            .bearer_auth(&self.bot_token)
+            .json(&body)
+            .send()
+            .await?;
+        let envelope: PostMessageResponse = response.json().await?;
+        if envelope.ok {
+            envelope
+                .ts
+                .ok_or_else(|| SlackError::Api("chat.postMessage missing ts".to_string()))
+        } else {
+            Err(SlackError::Api(
+                envelope
+                    .error
+                    .unwrap_or_else(|| "unknown Slack API error".to_string()),
+            ))
+        }
+    }
+
+    pub async fn open_socket_mode_url(&self, app_token: &str) -> SlackResult<String> {
+        let response = self
+            .client
+            .post(self.api_url("/api/apps.connections.open"))
+            .bearer_auth(app_token)
+            .send()
+            .await?;
+        let envelope: SocketModeOpenResponse = response.json().await?;
+        if envelope.ok {
+            envelope
+                .url
+                .ok_or_else(|| SlackError::Api("apps.connections.open missing url".to_string()))
+        } else {
+            Err(SlackError::Api(
+                envelope
+                    .error
+                    .unwrap_or_else(|| "unknown Slack API error".to_string()),
+            ))
+        }
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url.trim_end_matches('/'), path)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PostMessageResponse {
+    ok: bool,
+    ts: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SocketModeOpenResponse {
+    ok: bool,
+    url: Option<String>,
+    error: Option<String>,
+}

--- a/crates/ralph-slack/src/api.rs
+++ b/crates/ralph-slack/src/api.rs
@@ -59,6 +59,41 @@ impl SlackApi {
         self.post_message_body(body).await
     }
 
+    pub async fn update_blocks(
+        &self,
+        channel: &str,
+        message_ts: &str,
+        message: &SlackRenderedMessage,
+    ) -> SlackResult<()> {
+        let body = self.update_body(
+            channel,
+            message_ts,
+            &message.text,
+            Some(message.blocks.clone()),
+        );
+        self.update_message_body(body).await
+    }
+
+    async fn update_message_body(&self, body: serde_json::Value) -> SlackResult<()> {
+        let response = self
+            .client
+            .post(self.api_url("/api/chat.update"))
+            .bearer_auth(&self.bot_token)
+            .json(&body)
+            .send()
+            .await?;
+        let envelope: UpdateMessageResponse = response.json().await?;
+        if envelope.ok {
+            Ok(())
+        } else {
+            Err(SlackError::Api(
+                envelope
+                    .error
+                    .unwrap_or_else(|| "unknown Slack API error".to_string()),
+            ))
+        }
+    }
+
     async fn post_message_body(&self, body: serde_json::Value) -> SlackResult<String> {
         let response = self
             .client
@@ -95,6 +130,24 @@ impl SlackApi {
         if let Some(thread_ts) = thread_ts {
             body["thread_ts"] = json!(thread_ts);
         }
+        if let Some(blocks) = blocks {
+            body["blocks"] = json!(blocks);
+        }
+        body
+    }
+
+    fn update_body(
+        &self,
+        channel: &str,
+        message_ts: &str,
+        text: &str,
+        blocks: Option<Vec<serde_json::Value>>,
+    ) -> serde_json::Value {
+        let mut body = json!({
+            "channel": channel,
+            "ts": message_ts,
+            "text": text,
+        });
         if let Some(blocks) = blocks {
             body["blocks"] = json!(blocks);
         }
@@ -219,6 +272,12 @@ impl SlackApi {
 struct PostMessageResponse {
     ok: bool,
     ts: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UpdateMessageResponse {
+    ok: bool,
     error: Option<String>,
 }
 

--- a/crates/ralph-slack/src/api.rs
+++ b/crates/ralph-slack/src/api.rs
@@ -1,3 +1,6 @@
+use std::fmt;
+use std::path::Path;
+
 use serde::Deserialize;
 use serde_json::json;
 
@@ -5,11 +8,20 @@ use crate::error::{SlackError, SlackResult};
 
 const DEFAULT_SLACK_API_BASE_URL: &str = "https://slack.com";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SlackApi {
     bot_token: String,
     client: reqwest::Client,
     base_url: String,
+}
+
+impl fmt::Debug for SlackApi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SlackApi")
+            .field("bot_token", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
 }
 
 impl SlackApi {
@@ -77,6 +89,94 @@ impl SlackApi {
         }
     }
 
+    pub async fn upload_file_external(
+        &self,
+        channel: &str,
+        thread_ts: &str,
+        file_path: &Path,
+        filename: &str,
+        length: u64,
+        caption: Option<&str>,
+    ) -> SlackResult<()> {
+        let upload = self.get_upload_url_external(filename, length).await?;
+        let bytes = tokio::fs::read(file_path).await?;
+        self.client
+            .post(&upload.upload_url)
+            .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
+            .body(bytes)
+            .send()
+            .await?
+            .error_for_status()?;
+        self.complete_upload_external(channel, thread_ts, &upload.file_id, filename, caption)
+            .await
+    }
+
+    async fn get_upload_url_external(
+        &self,
+        filename: &str,
+        length: u64,
+    ) -> SlackResult<GetUploadUrlExternalResponse> {
+        let length = length.to_string();
+        let response = self
+            .client
+            .post(self.api_url("/api/files.getUploadURLExternal"))
+            .bearer_auth(&self.bot_token)
+            .form(&[("filename", filename), ("length", length.as_str())])
+            .send()
+            .await?;
+        let envelope: GetUploadUrlExternalResponse = response.json().await?;
+        if envelope.ok {
+            if envelope.upload_url.is_empty() || envelope.file_id.is_empty() {
+                return Err(SlackError::Api(
+                    "files.getUploadURLExternal missing upload_url or file_id".to_string(),
+                ));
+            }
+            Ok(envelope)
+        } else {
+            Err(SlackError::Api(
+                envelope
+                    .error
+                    .unwrap_or_else(|| "unknown Slack API error".to_string()),
+            ))
+        }
+    }
+
+    async fn complete_upload_external(
+        &self,
+        channel: &str,
+        thread_ts: &str,
+        file_id: &str,
+        filename: &str,
+        caption: Option<&str>,
+    ) -> SlackResult<()> {
+        let file = json!({
+            "id": file_id,
+            "title": caption.unwrap_or(filename),
+        });
+        let body = json!({
+            "files": [file],
+            "channel_id": channel,
+            "thread_ts": thread_ts,
+        });
+        let response = self
+            .client
+            .post(self.api_url("/api/files.completeUploadExternal"))
+            .bearer_auth(&self.bot_token)
+            .json(&body)
+            .send()
+            .await?;
+        let envelope: CompleteUploadExternalResponse = response.json().await?;
+        if envelope.ok {
+            Ok(())
+        } else {
+            Err(SlackError::Api(
+                envelope
+                    .error
+                    .unwrap_or_else(|| "unknown Slack API error".to_string()),
+            ))
+        }
+    }
+
     fn api_url(&self, path: &str) -> String {
         format!("{}{}", self.base_url.trim_end_matches('/'), path)
     }
@@ -93,5 +193,21 @@ struct PostMessageResponse {
 struct SocketModeOpenResponse {
     ok: bool,
     url: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetUploadUrlExternalResponse {
+    ok: bool,
+    #[serde(default)]
+    upload_url: String,
+    #[serde(default)]
+    file_id: String,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompleteUploadExternalResponse {
+    ok: bool,
     error: Option<String>,
 }

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -62,6 +62,7 @@ impl CommandLoopSpawner {
 impl LoopSpawner for CommandLoopSpawner {
     async fn spawn_loop(&self, request: StartLoopRequest) -> SlackResult<Option<u32>> {
         let executable = std::env::current_exe().map_err(SlackError::Io)?;
+        let worktree_path = ensure_slack_loop_worktree(&request.workspace_root, &request.loop_id)?;
         let log_dir = request.workspace_root.join(".ralph/slack-loop-logs");
         std::fs::create_dir_all(&log_dir).map_err(SlackError::Io)?;
         let log_path = log_dir.join(format!("{}.log", request.loop_id));
@@ -73,7 +74,7 @@ impl LoopSpawner for CommandLoopSpawner {
         let stderr = stdout.try_clone().map_err(SlackError::Io)?;
         let mut command = Command::new(executable);
         command
-            .current_dir(&request.workspace_root)
+            .current_dir(&worktree_path)
             .arg("run")
             .arg("-a")
             .arg("-p")
@@ -101,6 +102,36 @@ impl LoopSpawner for CommandLoopSpawner {
         }
         Ok(())
     }
+}
+
+fn ensure_slack_loop_worktree(workspace_root: &Path, loop_id: &str) -> SlackResult<PathBuf> {
+    let worktree_path = workspace_root.join(".worktrees").join(loop_id);
+    if worktree_path.exists() {
+        return Ok(worktree_path);
+    }
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent).map_err(SlackError::Io)?;
+    }
+    let branch = format!("ralph-slack-{loop_id}");
+    let status = Command::new("git")
+        .current_dir(workspace_root)
+        .args([
+            "worktree",
+            "add",
+            "-B",
+            &branch,
+            &worktree_path.to_string_lossy(),
+            "HEAD",
+        ])
+        .status()
+        .map_err(SlackError::Io)?;
+    if !status.success() {
+        return Err(SlackError::EventWrite(format!(
+            "failed to create Slack loop worktree {}",
+            worktree_path.display()
+        )));
+    }
+    Ok(worktree_path)
 }
 
 #[derive(Debug, Clone)]
@@ -381,15 +412,63 @@ pub fn slack_loop_env(
     loop_id: &str,
     channel_id: &str,
     thread_ts: &str,
-    workspace_root: &Path,
+    _workspace_root: &Path,
 ) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("RALPH_LOOP_ID".to_string(), loop_id.to_string()),
         ("RALPH_SLACK_CHANNEL_ID".to_string(), channel_id.to_string()),
         ("RALPH_SLACK_THREAD_TS".to_string(), thread_ts.to_string()),
-        (
-            "RALPH_WORKSPACE_ROOT".to_string(),
-            workspace_root.to_string_lossy().to_string(),
-        ),
     ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slack_loop_env_does_not_force_workspace_root() {
+        let env = slack_loop_env("loop-1", "C123", "1780.1", Path::new("/repo"));
+        assert_eq!(env.get("RALPH_LOOP_ID").unwrap(), "loop-1");
+        assert_eq!(env.get("RALPH_SLACK_CHANNEL_ID").unwrap(), "C123");
+        assert_eq!(env.get("RALPH_SLACK_THREAD_TS").unwrap(), "1780.1");
+        assert!(!env.contains_key("RALPH_WORKSPACE_ROOT"));
+    }
+
+    #[test]
+    fn ensure_slack_loop_worktree_creates_and_reuses_worktree() {
+        let repo = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        std::fs::write(repo.path().join("README.md"), "smoke").unwrap();
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(repo.path())
+            .status()
+            .unwrap();
+
+        let path = ensure_slack_loop_worktree(repo.path(), "slack-C123-1780-1").unwrap();
+        assert!(path.join("README.md").exists());
+        assert_eq!(
+            ensure_slack_loop_worktree(repo.path(), "slack-C123-1780-1").unwrap(),
+            path
+        );
+    }
 }

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -56,6 +56,13 @@ pub trait ThreadNotifier: Send + Sync + Clone + 'static {
         self.post_thread_message(channel_id, thread_ts, &message.text)
             .await
     }
+
+    async fn update_thread_blocks(
+        &self,
+        channel_id: &str,
+        message_ts: &str,
+        message: &SlackRenderedMessage,
+    ) -> SlackResult<()>;
 }
 
 #[derive(Debug, Clone)]
@@ -181,6 +188,17 @@ impl ThreadNotifier for SlackApiNotifier {
     ) -> SlackResult<String> {
         self.api
             .post_blocks(channel_id, Some(thread_ts), message)
+            .await
+    }
+
+    async fn update_thread_blocks(
+        &self,
+        channel_id: &str,
+        message_ts: &str,
+        message: &SlackRenderedMessage,
+    ) -> SlackResult<()> {
+        self.api
+            .update_blocks(channel_id, message_ts, message)
             .await
     }
 }
@@ -419,27 +437,25 @@ fn monitor_loop_completion<N>(
     N: ThreadNotifier,
 {
     tokio::spawn(async move {
-        let mut last_reported_line_count = 0;
+        let started_at = std::time::Instant::now();
+        let mut checkpoint = ProgressCheckpoint::default();
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             let event_path = events_path(&workspace_root, &loop_id);
             if let Ok(contents) = std::fs::read_to_string(&event_path) {
-                if let Some(update) = latest_progress_update(&contents, last_reported_line_count) {
-                    last_reported_line_count = update.line_count;
-                    let message = SlackBlocks::progress_card(
-                        &loop_id,
-                        update.iteration,
-                        update.hat.as_deref(),
-                        &update.topic,
-                        &update.payload,
-                        None,
-                    );
-                    if let Err(error) = notifier
-                        .post_thread_blocks(&channel_id, &thread_ts, &message)
-                        .await
-                    {
-                        tracing::warn!(%loop_id, ?error, "failed to post Slack loop progress update");
-                    }
+                if let Err(error) = sync_loop_progress_once(
+                    &state_manager,
+                    notifier.clone(),
+                    &loop_id,
+                    &channel_id,
+                    &thread_ts,
+                    &contents,
+                    started_at.elapsed(),
+                    &mut checkpoint,
+                )
+                .await
+                {
+                    tracing::warn!(%loop_id, ?error, "failed to sync Slack loop progress update");
                 }
             }
             if !process_is_alive(process_id) {
@@ -482,6 +498,71 @@ fn monitor_loop_completion<N>(
             }
         }
     });
+}
+
+const MIN_PROGRESS_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ProgressCheckpoint {
+    last_reported_line_count: usize,
+    last_sent_at: Option<std::time::Duration>,
+}
+
+pub async fn sync_loop_progress_once<N>(
+    state_manager: &SlackStateManager,
+    notifier: N,
+    loop_id: &str,
+    channel_id: &str,
+    thread_ts: &str,
+    contents: &str,
+    elapsed: std::time::Duration,
+    checkpoint: &mut ProgressCheckpoint,
+) -> SlackResult<bool>
+where
+    N: ThreadNotifier,
+{
+    let Some(update) = latest_progress_update(contents, checkpoint.last_reported_line_count) else {
+        return Ok(false);
+    };
+    if let Some(last_sent_at) = checkpoint.last_sent_at {
+        if elapsed.saturating_sub(last_sent_at) < MIN_PROGRESS_UPDATE_INTERVAL {
+            return Ok(false);
+        }
+    }
+
+    let message = SlackBlocks::progress_card(
+        loop_id,
+        update.iteration,
+        update.hat.as_deref(),
+        &update.topic,
+        &update.payload,
+        Some(elapsed.as_secs()),
+    );
+    let progress_message_ts = state_manager
+        .load_or_default()?
+        .threads
+        .get(loop_id)
+        .and_then(|binding| binding.progress_message_ts.clone());
+
+    if let Some(progress_message_ts) = progress_message_ts {
+        notifier
+            .update_thread_blocks(channel_id, &progress_message_ts, &message)
+            .await?;
+    } else {
+        let progress_message_ts = notifier
+            .post_thread_blocks(channel_id, thread_ts, &message)
+            .await?;
+        state_manager.set_thread_message_timestamps(
+            loop_id,
+            None,
+            Some(&progress_message_ts),
+            None,
+            None,
+        )?;
+    }
+    checkpoint.last_reported_line_count = update.line_count;
+    checkpoint.last_sent_at = Some(elapsed);
+    Ok(true)
 }
 
 fn process_is_alive(process_id: u32) -> bool {

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -384,14 +384,30 @@ fn monitor_loop_completion<N>(
     N: ThreadNotifier,
 {
     tokio::spawn(async move {
+        let event_path = events_path(&workspace_root, &loop_id);
+        let mut last_reported_line_count = 0;
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            if let Ok(contents) = std::fs::read_to_string(&event_path) {
+                if let Some(update) = latest_progress_update(&contents, last_reported_line_count) {
+                    last_reported_line_count = update.line_count;
+                    if let Err(error) = notifier
+                        .post_thread_message(
+                            &channel_id,
+                            &thread_ts,
+                            &format_progress_update(&loop_id, &update),
+                        )
+                        .await
+                    {
+                        tracing::warn!(%loop_id, ?error, "failed to post Slack loop progress update");
+                    }
+                }
+            }
             if !process_is_alive(process_id) {
                 break;
             }
         }
 
-        let event_path = events_path(&workspace_root, &loop_id);
         let contents = std::fs::read_to_string(&event_path).unwrap_or_default();
         let completed = contents.contains("\"topic\":\"LOOP_COMPLETE\"")
             || contents.contains("## Reason\\ncompleted")
@@ -429,6 +445,73 @@ fn process_is_alive(process_id: u32) -> bool {
         .status()
         .map(|status| status.success())
         .unwrap_or(false)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SlackProgressUpdate {
+    line_count: usize,
+    iteration: Option<u64>,
+    hat: Option<String>,
+    topic: String,
+    payload: String,
+}
+
+fn latest_progress_update(
+    contents: &str,
+    last_reported_line_count: usize,
+) -> Option<SlackProgressUpdate> {
+    let mut latest = None;
+    for (idx, line) in contents.lines().enumerate() {
+        let line_count = idx + 1;
+        if line_count <= last_reported_line_count || line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let topic = value
+            .get("topic")
+            .and_then(|value| value.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let payload = event_payload_text(value.get("payload"));
+        latest = Some(SlackProgressUpdate {
+            line_count,
+            iteration: value.get("iteration").and_then(|value| value.as_u64()),
+            hat: value
+                .get("hat")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+            topic,
+            payload,
+        });
+    }
+    latest
+}
+
+fn event_payload_text(payload: Option<&serde_json::Value>) -> String {
+    match payload {
+        Some(serde_json::Value::String(text)) => text.clone(),
+        Some(value) => value.to_string(),
+        None => String::new(),
+    }
+}
+
+fn format_progress_update(loop_id: &str, update: &SlackProgressUpdate) -> String {
+    let iteration = update
+        .iteration
+        .map(|iteration| iteration.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let hat = update.hat.as_deref().unwrap_or("agent");
+    let mut payload = redact_secrets(&update.payload);
+    if payload.len() > 1000 {
+        payload.truncate(1000);
+        payload.push_str("…");
+    }
+    format!(
+        "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nTopic: {}\nLast message:\n```\n{}\n```",
+        update.topic, payload
+    )
 }
 
 fn help_text() -> &'static str {
@@ -498,6 +581,42 @@ pub fn slack_loop_env(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn progress_update_uses_iteration_hat_topic_and_last_message() {
+        let contents = concat!(
+            r#"{"ts":"2026-01-01T00:00:00Z","iteration":1,"hat":"planner","topic":"work.start","payload":"first"}"#,
+            "\n",
+            r#"{"ts":"2026-01-01T00:00:01Z","iteration":2,"hat":"executor","topic":"work.done","payload":"created token-secret-token-abc file"}"#,
+            "\n"
+        );
+
+        let update = latest_progress_update(contents, 1).expect("latest update");
+        assert_eq!(update.line_count, 2);
+        assert_eq!(update.iteration, Some(2));
+        assert_eq!(update.hat.as_deref(), Some("executor"));
+        assert_eq!(update.topic, "work.done");
+        assert_eq!(update.payload, "created token-secret-token-abc file");
+
+        let text = format_progress_update("loop-1", &update);
+        assert!(text.contains("Loop: loop-1"));
+        assert!(text.contains("Iteration: 2"));
+        assert!(text.contains("Hat: executor"));
+        assert!(text.contains("Topic: work.done"));
+        assert!(text.contains("created [redacted] file"));
+    }
+
+    #[test]
+    fn progress_update_handles_agent_written_events_without_hat() {
+        let contents =
+            r#"{"topic":"human.guidance","payload":{"note":"steer"},"ts":"2026-01-01T00:00:00Z"}"#;
+        let update = latest_progress_update(contents, 0).expect("latest update");
+        assert_eq!(update.iteration, None);
+        assert_eq!(update.hat, None);
+        assert_eq!(update.topic, "human.guidance");
+        assert_eq!(update.payload, r#"{"note":"steer"}"#);
+        assert!(format_progress_update("loop-2", &update).contains("Hat: agent"));
+    }
 
     #[test]
     fn slack_loop_env_does_not_force_workspace_root() {

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -91,20 +91,15 @@ impl LoopSpawner for CommandLoopSpawner {
             .map_err(SlackError::Io)?;
         let stderr = stdout.try_clone().map_err(SlackError::Io)?;
         let mut command = Command::new(executable);
+        configure_slack_loop_command(
+            &mut command,
+            &worktree_path,
+            &request,
+            self.config_path.as_deref(),
+        );
         command
-            .current_dir(&worktree_path)
-            .arg("run")
-            .arg("--autonomous")
-            .arg("-b")
-            .arg("claude")
-            .arg("-p")
-            .arg(&request.prompt)
-            .envs(&request.env)
             .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr));
-        if let Some(config_path) = &self.config_path {
-            command.arg("-c").arg(config_path);
-        }
         let mut child = command.spawn().map_err(SlackError::Io)?;
         let process_id = child.id();
         std::thread::spawn(move || {
@@ -125,6 +120,24 @@ impl LoopSpawner for CommandLoopSpawner {
             )));
         }
         Ok(())
+    }
+}
+
+fn configure_slack_loop_command(
+    command: &mut Command,
+    worktree_path: &Path,
+    request: &StartLoopRequest,
+    config_path: Option<&Path>,
+) {
+    command
+        .current_dir(worktree_path)
+        .arg("run")
+        .arg("--autonomous")
+        .arg("-p")
+        .arg(&request.prompt)
+        .envs(&request.env);
+    if let Some(config_path) = config_path {
+        command.arg("-c").arg(config_path);
     }
 }
 
@@ -921,6 +934,42 @@ mod tests {
             "/repo/.ralph/slack-state.json"
         );
         assert!(!env.contains_key("RALPH_WORKSPACE_ROOT"));
+    }
+
+    #[test]
+    fn slack_loop_command_uses_config_backend_without_hardcoded_claude() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().join("worktree");
+        let config = dir.path().join("ralph.slack.yml");
+        let request = StartLoopRequest {
+            loop_id: "slack-C123-1780-1".to_string(),
+            prompt: "do the thing".to_string(),
+            channel_id: "C123".to_string(),
+            thread_ts: "1780.1".to_string(),
+            workspace_root: dir.path().to_path_buf(),
+            env: BTreeMap::new(),
+        };
+        let mut command = Command::new("ralph");
+
+        configure_slack_loop_command(&mut command, &worktree, &request, Some(&config));
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "--autonomous",
+                "-p",
+                "do the thing",
+                "-c",
+                config.to_str().unwrap(),
+            ]
+        );
+        assert!(!args.iter().any(|arg| arg == "-b" || arg == "claude"));
+        assert_eq!(command.get_current_dir(), Some(worktree.as_path()));
     }
 
     #[test]

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -85,8 +85,12 @@ impl LoopSpawner for CommandLoopSpawner {
         if let Some(config_path) = &self.config_path {
             command.arg("-c").arg(config_path);
         }
-        let child = command.spawn().map_err(SlackError::Io)?;
-        Ok(Some(child.id()))
+        let mut child = command.spawn().map_err(SlackError::Io)?;
+        let process_id = child.id();
+        std::thread::spawn(move || {
+            let _ = child.wait();
+        });
+        Ok(Some(process_id))
     }
 
     async fn stop_loop(&self, process_id: u32) -> SlackResult<()> {
@@ -235,6 +239,17 @@ where
                     .await?;
                 self.state_manager
                     .set_thread_process_id(loop_id, process_id)?;
+                if let Some(process_id) = process_id {
+                    monitor_loop_completion(
+                        self.state_manager.clone(),
+                        self.notifier.clone(),
+                        loop_id.clone(),
+                        channel_id.clone(),
+                        thread_ts.clone(),
+                        root_for_start.clone(),
+                        process_id,
+                    );
+                }
             }
             HandlerAction::Command {
                 command,
@@ -355,6 +370,65 @@ where
         }
         Ok(())
     }
+}
+
+fn monitor_loop_completion<N>(
+    state_manager: SlackStateManager,
+    notifier: N,
+    loop_id: String,
+    channel_id: String,
+    thread_ts: String,
+    workspace_root: PathBuf,
+    process_id: u32,
+) where
+    N: ThreadNotifier,
+{
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            if !process_is_alive(process_id) {
+                break;
+            }
+        }
+
+        let event_path = events_path(&workspace_root, &loop_id);
+        let contents = std::fs::read_to_string(&event_path).unwrap_or_default();
+        let completed = contents.contains("\"topic\":\"LOOP_COMPLETE\"")
+            || contents.contains("## Reason\\ncompleted")
+            || contents.contains("\"payload\":\"## Reason\\ncompleted");
+        let status = if completed {
+            SlackThreadStatus::Completed
+        } else {
+            SlackThreadStatus::Failed
+        };
+        if let Err(error) = state_manager.finish_thread(&loop_id, status.clone()) {
+            tracing::warn!(%loop_id, ?error, "failed to mark Slack loop finished");
+        }
+        let status_label = match status {
+            SlackThreadStatus::Completed => "completed",
+            SlackThreadStatus::Failed => "failed",
+            SlackThreadStatus::Running => "running",
+            SlackThreadStatus::Stopped => "stopped",
+        };
+        let text = format!(
+            "Ralph loop {status_label}\nLoop: {loop_id}\nTry `tail 10` in this thread for recent events."
+        );
+        if let Err(error) = notifier
+            .post_thread_message(&channel_id, &thread_ts, &text)
+            .await
+        {
+            tracing::warn!(%loop_id, ?error, "failed to post Slack loop completion update");
+        }
+    });
+}
+
+fn process_is_alive(process_id: u32) -> bool {
+    Command::new("kill")
+        .arg("-0")
+        .arg(process_id.to_string())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 fn help_text() -> &'static str {

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -1,0 +1,385 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use async_trait::async_trait;
+
+use crate::api::SlackApi;
+use crate::error::{SlackError, SlackResult};
+use crate::handler::{
+    HandlerAction, SlackMessageEvent, ThreadCommand, events_path, handle_message,
+};
+use crate::state::{SlackStateManager, SlackThreadBinding, SlackThreadStatus};
+
+#[derive(Debug, Clone)]
+pub struct SlackDaemonConfig {
+    pub workspace_root: PathBuf,
+    pub allowed_channels: Vec<String>,
+    pub allowed_users: Vec<String>,
+    pub channel_repos: BTreeMap<String, PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartLoopRequest {
+    pub loop_id: String,
+    pub prompt: String,
+    pub channel_id: String,
+    pub thread_ts: String,
+    pub workspace_root: PathBuf,
+    pub env: BTreeMap<String, String>,
+}
+
+#[async_trait]
+pub trait LoopSpawner: Send + Sync + Clone + 'static {
+    async fn spawn_loop(&self, request: StartLoopRequest) -> SlackResult<Option<u32>>;
+
+    async fn stop_loop(&self, process_id: u32) -> SlackResult<()>;
+}
+
+#[async_trait]
+pub trait ThreadNotifier: Send + Sync + Clone + 'static {
+    async fn post_thread_message(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        text: &str,
+    ) -> SlackResult<String>;
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandLoopSpawner {
+    config_path: Option<PathBuf>,
+}
+
+impl CommandLoopSpawner {
+    pub fn new(config_path: Option<PathBuf>) -> Self {
+        Self { config_path }
+    }
+}
+
+#[async_trait]
+impl LoopSpawner for CommandLoopSpawner {
+    async fn spawn_loop(&self, request: StartLoopRequest) -> SlackResult<Option<u32>> {
+        let executable = std::env::current_exe().map_err(SlackError::Io)?;
+        let mut command = Command::new(executable);
+        command
+            .current_dir(&request.workspace_root)
+            .arg("run")
+            .arg("--no-tui")
+            .arg("--loop-id")
+            .arg(&request.loop_id)
+            .arg("-p")
+            .arg(&request.prompt)
+            .envs(&request.env);
+        if let Some(config_path) = &self.config_path {
+            command.arg("-c").arg(config_path);
+        }
+        let child = command.spawn().map_err(SlackError::Io)?;
+        Ok(Some(child.id()))
+    }
+
+    async fn stop_loop(&self, process_id: u32) -> SlackResult<()> {
+        let status = Command::new("kill")
+            .arg("-TERM")
+            .arg(process_id.to_string())
+            .status()
+            .map_err(SlackError::Io)?;
+        if !status.success() {
+            return Err(SlackError::EventWrite(format!(
+                "failed to terminate Slack loop process {process_id}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SlackApiNotifier {
+    api: SlackApi,
+}
+
+impl SlackApiNotifier {
+    pub fn new(api: SlackApi) -> Self {
+        Self { api }
+    }
+}
+
+#[async_trait]
+impl ThreadNotifier for SlackApiNotifier {
+    async fn post_thread_message(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        text: &str,
+    ) -> SlackResult<String> {
+        self.api
+            .post_message(channel_id, Some(thread_ts), text)
+            .await
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SlackDaemon<S, N> {
+    config: SlackDaemonConfig,
+    state_manager: SlackStateManager,
+    spawner: S,
+    notifier: N,
+}
+
+impl<S, N> SlackDaemon<S, N>
+where
+    S: LoopSpawner,
+    N: ThreadNotifier,
+{
+    pub fn new(
+        config: SlackDaemonConfig,
+        state_manager: SlackStateManager,
+        spawner: S,
+        notifier: N,
+    ) -> Self {
+        Self {
+            config,
+            state_manager,
+            spawner,
+            notifier,
+        }
+    }
+
+    pub async fn handle_event(&self, event: SlackMessageEvent) -> SlackResult<HandlerAction> {
+        if event.thread_ts.is_none()
+            && event.app_mention
+            && !self.config.channel_repos.contains_key(&event.channel_id)
+        {
+            return self.handle_unmapped_start_event(event).await;
+        }
+
+        let root_for_start = self
+            .config
+            .channel_repos
+            .get(&event.channel_id)
+            .cloned()
+            .unwrap_or_else(|| self.config.workspace_root.clone());
+        let action = handle_message(
+            &self.state_manager,
+            &root_for_start,
+            &self.config.allowed_channels,
+            &self.config.allowed_users,
+            event,
+        )?;
+
+        match &action {
+            HandlerAction::StartLoop {
+                loop_id,
+                prompt,
+                channel_id,
+                thread_ts,
+            } => {
+                self.notifier
+                    .post_thread_message(
+                        channel_id,
+                        thread_ts,
+                        &format!("🤖 Ralph loop started\nLoop: {}\nStatus: running", loop_id),
+                    )
+                    .await?;
+                let process_id = self
+                    .spawner
+                    .spawn_loop(StartLoopRequest {
+                        loop_id: loop_id.clone(),
+                        prompt: prompt.clone(),
+                        channel_id: channel_id.clone(),
+                        thread_ts: thread_ts.clone(),
+                        workspace_root: root_for_start.clone(),
+                        env: slack_loop_env(loop_id, channel_id, thread_ts, &root_for_start),
+                    })
+                    .await?;
+                self.state_manager
+                    .set_thread_process_id(loop_id, process_id)?;
+            }
+            HandlerAction::Command {
+                command,
+                loop_id,
+                channel_id,
+                thread_ts,
+                user_id,
+            } => {
+                self.handle_thread_command(command, loop_id, channel_id, thread_ts, user_id)
+                    .await?;
+            }
+            HandlerAction::Ignored => {}
+            HandlerAction::Duplicate | HandlerAction::Appended { .. } => {}
+        }
+        Ok(action)
+    }
+
+    async fn handle_unmapped_start_event(
+        &self,
+        event: SlackMessageEvent,
+    ) -> SlackResult<HandlerAction> {
+        if event.bot_id.is_some() {
+            return Ok(HandlerAction::Ignored);
+        }
+        let Some(user_id) = event.user_id.as_deref() else {
+            return Ok(HandlerAction::Ignored);
+        };
+        if self.config.allowed_channels.is_empty()
+            || !self
+                .config
+                .allowed_channels
+                .iter()
+                .any(|channel| channel == &event.channel_id)
+        {
+            return Ok(HandlerAction::Ignored);
+        }
+        if self.config.allowed_users.is_empty()
+            || !self.config.allowed_users.iter().any(|user| user == user_id)
+        {
+            return Ok(HandlerAction::Ignored);
+        }
+        if let Some(event_id) = event.event_id.as_deref() {
+            if !self.state_manager.mark_event_seen(event_id)? {
+                return Ok(HandlerAction::Duplicate);
+            }
+        }
+
+        self.notifier
+            .post_thread_message(
+                &event.channel_id,
+                &event.ts,
+                "Ralph is not configured for this Slack channel; ask an operator to add RObot.slack.channel_repos for this channel.",
+            )
+            .await?;
+        Ok(HandlerAction::Ignored)
+    }
+
+    async fn handle_thread_command(
+        &self,
+        command: &ThreadCommand,
+        loop_id: &str,
+        channel_id: &str,
+        thread_ts: &str,
+        user_id: &str,
+    ) -> SlackResult<()> {
+        let state = self.state_manager.load_or_default()?;
+        let Some(binding) = state.threads.get(loop_id) else {
+            return Ok(());
+        };
+        match command {
+            ThreadCommand::Help => {
+                self.notifier
+                    .post_thread_message(channel_id, thread_ts, help_text())
+                    .await?;
+            }
+            ThreadCommand::Status => {
+                self.notifier
+                    .post_thread_message(
+                        channel_id,
+                        thread_ts,
+                        &status_text(binding, state.pending_questions.contains_key(loop_id)),
+                    )
+                    .await?;
+            }
+            ThreadCommand::Tail { n } => {
+                self.notifier
+                    .post_thread_message(
+                        channel_id,
+                        thread_ts,
+                        &tail_text(&events_path(&binding.workspace_root, loop_id), *n),
+                    )
+                    .await?;
+            }
+            ThreadCommand::Stop => {
+                if user_id != binding.created_by {
+                    self.notifier
+                        .post_thread_message(
+                            channel_id,
+                            thread_ts,
+                            "Only the Slack user who started this Ralph thread can stop it.",
+                        )
+                        .await?;
+                    return Ok(());
+                }
+                if let Some(process_id) = binding.process_id {
+                    self.spawner.stop_loop(process_id).await?;
+                }
+                self.state_manager
+                    .set_thread_status(loop_id, SlackThreadStatus::Stopped)?;
+                self.notifier
+                    .post_thread_message(
+                        channel_id,
+                        thread_ts,
+                        &format!("stopped Ralph loop {loop_id}. Further guidance in this thread is ignored."),
+                    )
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn help_text() -> &'static str {
+    "Ralph Slack commands: help, status, tail [n], stop/cancel. Plain replies become guidance, or answer the pending human question."
+}
+
+fn status_text(binding: &SlackThreadBinding, pending_question: bool) -> String {
+    format!(
+        "Ralph thread status\nloop: {}\nrepo: {}\nthread status: {:?}\npending question: {}\nprocess id: {}",
+        binding.loop_id,
+        binding.workspace_root.display(),
+        binding.status,
+        if pending_question { "yes" } else { "no" },
+        binding
+            .process_id
+            .map(|pid| pid.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    )
+}
+
+fn tail_text(path: &Path, n: usize) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let lines: Vec<_> = contents.lines().rev().take(n).collect();
+            if lines.is_empty() {
+                return "No events yet.".to_string();
+            }
+            let mut redacted = lines.into_iter().rev().collect::<Vec<_>>().join("\n");
+            redacted = redact_secrets(&redacted);
+            if redacted.len() > 3000 {
+                redacted.truncate(3000);
+                redacted.push_str("…");
+            }
+            format!("Latest Ralph events:\n```\n{}\n```", redacted)
+        }
+        Err(_) => "No event file found for this loop yet.".to_string(),
+    }
+}
+
+fn redact_secrets(text: &str) -> String {
+    let mut out = text.to_string();
+    for marker in ["secret-token-", "token-", "xoxb-", "xapp-"] {
+        while let Some(start) = out.to_ascii_lowercase().find(marker) {
+            let end = out[start..]
+                .find(|c: char| c.is_whitespace() || c == '"' || c == '\'')
+                .map(|offset| start + offset)
+                .unwrap_or(out.len());
+            out.replace_range(start..end, "[redacted]");
+        }
+    }
+    out
+}
+
+pub fn slack_loop_env(
+    loop_id: &str,
+    channel_id: &str,
+    thread_ts: &str,
+    workspace_root: &Path,
+) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("RALPH_LOOP_ID".to_string(), loop_id.to_string()),
+        ("RALPH_SLACK_CHANNEL_ID".to_string(), channel_id.to_string()),
+        ("RALPH_SLACK_THREAD_TS".to_string(), thread_ts.to_string()),
+        (
+            "RALPH_WORKSPACE_ROOT".to_string(),
+            workspace_root.to_string_lossy().to_string(),
+        ),
+    ])
+}

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs::OpenOptions;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use async_trait::async_trait;
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use crate::api::SlackApi;
 use crate::error::{SlackError, SlackResult};
 use crate::handler::{
-    HandlerAction, SlackMessageEvent, ThreadCommand, events_path, handle_message,
+    HandlerAction, SlackMessageEvent, ThreadCommand, events_path, handle_message_with_repo,
 };
 use crate::renderer::{SlackBlocks, SlackRenderedMessage, redact_secrets};
 use crate::state::{SlackStateManager, SlackThreadBinding, SlackThreadStatus};
@@ -18,7 +18,8 @@ pub struct SlackDaemonConfig {
     pub workspace_root: PathBuf,
     pub allowed_channels: Vec<String>,
     pub allowed_users: Vec<String>,
-    pub channel_repos: BTreeMap<String, PathBuf>,
+    pub repo_aliases: BTreeMap<String, PathBuf>,
+    pub channel_repos: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,6 +29,9 @@ pub struct StartLoopRequest {
     pub channel_id: String,
     pub thread_ts: String,
     pub workspace_root: PathBuf,
+    pub state_path: PathBuf,
+    pub repo_alias: Option<String>,
+    pub repo_dir: Option<PathBuf>,
     pub env: BTreeMap<String, String>,
 }
 
@@ -81,6 +85,11 @@ impl LoopSpawner for CommandLoopSpawner {
     async fn spawn_loop(&self, request: StartLoopRequest) -> SlackResult<Option<u32>> {
         let executable = std::env::current_exe().map_err(SlackError::Io)?;
         let worktree_path = ensure_slack_loop_worktree(&request.workspace_root, &request.loop_id)?;
+        let workdir = request
+            .repo_dir
+            .as_deref()
+            .map(|repo_dir| worktree_path.join(repo_dir))
+            .unwrap_or_else(|| worktree_path.clone());
         let log_dir = request.workspace_root.join(".ralph/slack-loop-logs");
         std::fs::create_dir_all(&log_dir).map_err(SlackError::Io)?;
         let log_path = log_dir.join(format!("{}.log", request.loop_id));
@@ -93,7 +102,7 @@ impl LoopSpawner for CommandLoopSpawner {
         let mut command = Command::new(executable);
         configure_slack_loop_command(
             &mut command,
-            &worktree_path,
+            &workdir,
             &request,
             self.config_path.as_deref(),
         );
@@ -269,22 +278,21 @@ where
     }
 
     pub async fn handle_event(&self, event: SlackMessageEvent) -> SlackResult<HandlerAction> {
-        if event.thread_ts.is_none()
-            && event.app_mention
-            && !self.config.channel_repos.contains_key(&event.channel_id)
-        {
-            return self.handle_unmapped_start_event(event).await;
-        }
+        let mut event = event;
+        let target_for_start = if event.thread_ts.is_none() && event.app_mention {
+            match self.resolve_start_event(&mut event).await? {
+                Some(target) => target,
+                None => return Ok(HandlerAction::Ignored),
+            }
+        } else {
+            RepoTarget::default_root(self.config.workspace_root.clone())
+        };
 
-        let root_for_start = self
-            .config
-            .channel_repos
-            .get(&event.channel_id)
-            .cloned()
-            .unwrap_or_else(|| self.config.workspace_root.clone());
-        let action = handle_message(
+        let action = handle_message_with_repo(
             &self.state_manager,
-            &root_for_start,
+            &target_for_start.root,
+            target_for_start.alias.as_deref(),
+            target_for_start.dir.as_deref(),
             &self.config.allowed_channels,
             &self.config.allowed_users,
             event,
@@ -300,7 +308,7 @@ where
                 let start_message = SlackBlocks::start_card(
                     loop_id,
                     prompt,
-                    Some(&root_for_start.display().to_string()),
+                    Some(&target_for_start.summary()),
                     None,
                 );
                 let start_card_ts = self
@@ -321,8 +329,18 @@ where
                         prompt: prompt.clone(),
                         channel_id: channel_id.clone(),
                         thread_ts: thread_ts.clone(),
-                        workspace_root: root_for_start.clone(),
-                        env: slack_loop_env(loop_id, channel_id, thread_ts, &root_for_start),
+                        workspace_root: target_for_start.root.clone(),
+                        state_path: self.state_manager.path().to_path_buf(),
+                        repo_alias: target_for_start.alias.clone(),
+                        repo_dir: target_for_start.dir.clone(),
+                        env: slack_loop_env(
+                            loop_id,
+                            channel_id,
+                            thread_ts,
+                            self.state_manager.path(),
+                            target_for_start.alias.as_deref(),
+                            target_for_start.dir.as_deref(),
+                        ),
                     })
                     .await?;
                 self.state_manager
@@ -334,7 +352,7 @@ where
                         loop_id.clone(),
                         channel_id.clone(),
                         thread_ts.clone(),
-                        root_for_start.clone(),
+                        target_for_start.root.clone(),
                         process_id,
                     );
                 }
@@ -355,15 +373,15 @@ where
         Ok(action)
     }
 
-    async fn handle_unmapped_start_event(
+    async fn resolve_start_event(
         &self,
-        event: SlackMessageEvent,
-    ) -> SlackResult<HandlerAction> {
+        event: &mut SlackMessageEvent,
+    ) -> SlackResult<Option<RepoTarget>> {
         if event.bot_id.is_some() {
-            return Ok(HandlerAction::Ignored);
+            return Ok(None);
         }
         let Some(user_id) = event.user_id.as_deref() else {
-            return Ok(HandlerAction::Ignored);
+            return Ok(None);
         };
         if self.config.allowed_channels.is_empty()
             || !self
@@ -372,27 +390,78 @@ where
                 .iter()
                 .any(|channel| channel == &event.channel_id)
         {
-            return Ok(HandlerAction::Ignored);
+            return Ok(None);
         }
         if self.config.allowed_users.is_empty()
             || !self.config.allowed_users.iter().any(|user| user == user_id)
         {
-            return Ok(HandlerAction::Ignored);
-        }
-        if let Some(event_id) = event.event_id.as_deref() {
-            if !self.state_manager.mark_event_seen(event_id)? {
-                return Ok(HandlerAction::Duplicate);
-            }
+            return Ok(None);
         }
 
-        self.notifier
-            .post_thread_message(
-                &event.channel_id,
-                &event.ts,
-                "Ralph is not configured for this Slack channel; ask an operator to add RObot.slack.channel_repos for this channel.",
+        let prompt = strip_app_mention_for_start(&event.text);
+        let parsed = match parse_start_repo_directives(&prompt) {
+            Ok(parsed) => parsed,
+            Err(message) => {
+                if !self.mark_start_event_seen(event)? {
+                    return Ok(None);
+                }
+                self.notifier
+                    .post_thread_message(&event.channel_id, &event.ts, &message)
+                    .await?;
+                return Ok(None);
+            }
+        };
+        let target = match resolve_repo_target(
+            &self.config.repo_aliases,
+            self.config
+                .channel_repos
+                .get(&event.channel_id)
+                .map(String::as_str),
+            parsed.repo_alias.as_deref(),
+            parsed.dir.as_deref(),
+        ) {
+            Ok(Some(target)) => target,
+            Ok(None) => {
+                if !self.mark_start_event_seen(event)? {
+                    return Ok(None);
+                }
+                self.post_repo_clarification(event).await?;
+                return Ok(None);
+            }
+            Err(message) => {
+                if !self.mark_start_event_seen(event)? {
+                    return Ok(None);
+                }
+                self.notifier
+                    .post_thread_message(&event.channel_id, &event.ts, &message)
+                    .await?;
+                return Ok(None);
+            }
+        };
+        event.text = rewrite_start_text_with_prompt(&event.text, &parsed.prompt);
+        Ok(Some(target))
+    }
+
+    fn mark_start_event_seen(&self, event: &SlackMessageEvent) -> SlackResult<bool> {
+        match event.event_id.as_deref() {
+            Some(event_id) => self.state_manager.mark_event_seen(event_id),
+            None => Ok(true),
+        }
+    }
+
+    async fn post_repo_clarification(&self, event: &SlackMessageEvent) -> SlackResult<()> {
+        let aliases = configured_alias_list(&self.config.repo_aliases);
+        let message = if aliases.is_empty() {
+            "human.interact: Which repo should Ralph use? No safe repo aliases are configured; ask an operator to set RObot.slack.repo_aliases and channel_repos.".to_string()
+        } else {
+            format!(
+                "human.interact: Which repo should Ralph use? Reply with a new mention like `@Ralph repo=<alias> ...`. Configured aliases: {aliases}"
             )
+        };
+        self.notifier
+            .post_thread_message(&event.channel_id, &event.ts, &message)
             .await?;
-        Ok(HandlerAction::Ignored)
+        Ok(())
     }
 
     async fn handle_thread_command(
@@ -411,6 +480,11 @@ where
             ThreadCommand::Help => {
                 self.notifier
                     .post_thread_blocks(channel_id, thread_ts, &SlackBlocks::help_card())
+                    .await?;
+            }
+            ThreadCommand::Repo => {
+                self.notifier
+                    .post_thread_message(channel_id, thread_ts, &repo_command_text(binding))
                     .await?;
             }
             ThreadCommand::Status => {
@@ -461,6 +535,219 @@ where
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoTarget {
+    pub alias: Option<String>,
+    pub root: PathBuf,
+    pub dir: Option<PathBuf>,
+}
+
+impl RepoTarget {
+    fn default_root(root: PathBuf) -> Self {
+        Self {
+            alias: None,
+            root,
+            dir: None,
+        }
+    }
+
+    fn summary(&self) -> String {
+        match (&self.alias, &self.dir) {
+            (Some(alias), Some(dir)) => {
+                format!(
+                    "{alias}:{} ({})",
+                    dir.display(),
+                    self.root.join(dir).display()
+                )
+            }
+            (Some(alias), None) => format!("{alias} ({})", self.root.display()),
+            (None, Some(dir)) => format!("{} (dir {})", self.root.display(), dir.display()),
+            (None, None) => self.root.display().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedStartRepoDirectives {
+    pub repo_alias: Option<String>,
+    pub dir: Option<PathBuf>,
+    pub prompt: String,
+}
+
+pub fn parse_start_repo_directives(prompt: &str) -> Result<ParsedStartRepoDirectives, String> {
+    let mut remaining = prompt.trim();
+    let mut repo_alias = None;
+    let mut dir = None;
+
+    if let Some(after_in) = remaining.strip_prefix("in ") {
+        let Some((candidate, after_colon)) = after_in.split_once(':') else {
+            return Err("Slack repo selector `in <alias>:` must include `:`.".to_string());
+        };
+        let candidate = candidate.trim();
+        if is_valid_repo_alias(candidate) {
+            repo_alias = Some(candidate.to_string());
+            remaining = after_colon.trim_start();
+        } else {
+            return Err(invalid_repo_alias_message(candidate));
+        }
+    }
+
+    let mut prompt_parts = Vec::new();
+    let mut parsing_directives = true;
+    for part in remaining.split_whitespace() {
+        if parsing_directives {
+            if let Some(value) = part.strip_prefix("repo=") {
+                if is_valid_repo_alias(value) {
+                    repo_alias = Some(value.to_string());
+                    continue;
+                }
+                return Err(invalid_repo_alias_message(value));
+            }
+            if let Some(value) = part.strip_prefix("dir=") {
+                if !value.is_empty() {
+                    dir = Some(PathBuf::from(value));
+                    continue;
+                }
+                return Err("Slack repo dir cannot be empty.".to_string());
+            }
+            parsing_directives = false;
+        }
+        prompt_parts.push(part);
+    }
+
+    Ok(ParsedStartRepoDirectives {
+        repo_alias,
+        dir,
+        prompt: prompt_parts.join(" "),
+    })
+}
+
+pub fn resolve_repo_target(
+    repo_aliases: &BTreeMap<String, PathBuf>,
+    channel_default_alias: Option<&str>,
+    explicit_alias: Option<&str>,
+    dir: Option<&Path>,
+) -> Result<Option<RepoTarget>, String> {
+    let alias = explicit_alias.or(channel_default_alias);
+    let Some(alias) = alias else {
+        return Ok(None);
+    };
+    let Some(root) = repo_aliases.get(alias) else {
+        return Err(format!(
+            "Unknown repo alias `{alias}`. Configured aliases: {}",
+            configured_alias_list(repo_aliases)
+        ));
+    };
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|error| format!("Repo alias `{alias}` is not usable: {error}"))?;
+    let safe_dir = match dir {
+        Some(dir) => Some(validate_repo_subdir(&canonical_root, dir)?),
+        None => None,
+    };
+    Ok(Some(RepoTarget {
+        alias: Some(alias.to_string()),
+        root: canonical_root,
+        dir: safe_dir,
+    }))
+}
+
+pub fn validate_repo_subdir(repo_root: &Path, dir: &Path) -> Result<PathBuf, String> {
+    if dir.as_os_str().is_empty() || dir == Path::new(".") {
+        return Ok(PathBuf::new());
+    }
+    if dir.is_absolute() {
+        return Err("Slack repo dir must be relative to the repo root.".to_string());
+    }
+    if dir.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return Err("Slack repo dir cannot contain `..` or absolute path components.".to_string());
+    }
+    let full = repo_root.join(dir);
+    let canonical = full
+        .canonicalize()
+        .map_err(|error| format!("Slack repo dir `{}` is not usable: {error}", dir.display()))?;
+    if !canonical.starts_with(repo_root) {
+        return Err("Slack repo dir must stay inside the configured repo root.".to_string());
+    }
+    canonical
+        .strip_prefix(repo_root)
+        .map(Path::to_path_buf)
+        .map_err(|_| "Slack repo dir must stay inside the configured repo root.".to_string())
+}
+
+fn repo_command_text(binding: &SlackThreadBinding) -> String {
+    let alias = binding.repo_alias.as_deref().unwrap_or("unbound");
+    let dir = binding
+        .repo_dir
+        .as_deref()
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .map(|dir| dir.display().to_string())
+        .unwrap_or_else(|| ".".to_string());
+    let worktree = binding
+        .workspace_root
+        .join(".worktrees")
+        .join(&binding.loop_id);
+    let branch = format!("ralph-slack-{}", binding.loop_id);
+    format!(
+        "Repo\nalias: `{alias}`\nroot: `{}`\ndir: `{dir}`\nloop: `{}`\nworktree: `{}`\nbranch: `{branch}`",
+        binding.workspace_root.display(),
+        binding.loop_id,
+        worktree.display()
+    )
+}
+
+fn configured_alias_list(repo_aliases: &BTreeMap<String, PathBuf>) -> String {
+    if repo_aliases.is_empty() {
+        return "none".to_string();
+    }
+    repo_aliases
+        .keys()
+        .map(|alias| format!("`{alias}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn is_valid_repo_alias(alias: &str) -> bool {
+    !alias.is_empty()
+        && alias
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn invalid_repo_alias_message(alias: &str) -> String {
+    if alias.is_empty() {
+        return "Slack repo alias cannot be empty.".to_string();
+    }
+    format!(
+        "Slack repo alias `{alias}` is invalid. Use only letters, numbers, hyphen, or underscore."
+    )
+}
+
+fn strip_app_mention_for_start(text: &str) -> String {
+    let trimmed = text.trim();
+    if let Some(rest) = trimmed.strip_prefix("<@") {
+        if let Some((_, prompt)) = rest.split_once('>') {
+            return prompt.trim().to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+fn rewrite_start_text_with_prompt(original: &str, prompt: &str) -> String {
+    let trimmed = original.trim();
+    if let Some(rest) = trimmed.strip_prefix("<@") {
+        if let Some((mention, _)) = rest.split_once('>') {
+            return format!("<@{mention}> {}", prompt.trim()).trim().to_string();
+        }
+    }
+    prompt.trim().to_string()
 }
 
 fn monitor_loop_completion<N>(
@@ -838,20 +1125,29 @@ pub fn slack_loop_env(
     loop_id: &str,
     channel_id: &str,
     thread_ts: &str,
-    workspace_root: &Path,
+    state_path: &Path,
+    repo_alias: Option<&str>,
+    repo_dir: Option<&Path>,
 ) -> BTreeMap<String, String> {
-    BTreeMap::from([
+    let mut env = BTreeMap::from([
         ("RALPH_LOOP_ID".to_string(), loop_id.to_string()),
         ("RALPH_SLACK_CHANNEL_ID".to_string(), channel_id.to_string()),
         ("RALPH_SLACK_THREAD_TS".to_string(), thread_ts.to_string()),
         (
             "RALPH_SLACK_STATE_PATH".to_string(),
-            workspace_root
-                .join(".ralph/slack-state.json")
-                .to_string_lossy()
-                .to_string(),
+            state_path.to_string_lossy().to_string(),
         ),
-    ])
+    ]);
+    if let Some(repo_alias) = repo_alias {
+        env.insert("RALPH_SLACK_REPO_ALIAS".to_string(), repo_alias.to_string());
+    }
+    if let Some(repo_dir) = repo_dir {
+        env.insert(
+            "RALPH_SLACK_REPO_DIR".to_string(),
+            repo_dir.to_string_lossy().to_string(),
+        );
+    }
+    env
 }
 
 #[cfg(test)]
@@ -925,13 +1221,25 @@ mod tests {
 
     #[test]
     fn slack_loop_env_shares_root_state_without_forcing_workspace_root() {
-        let env = slack_loop_env("loop-1", "C123", "1780.1", Path::new("/repo"));
+        let env = slack_loop_env(
+            "loop-1",
+            "C123",
+            "1780.1",
+            Path::new("/daemon/.ralph/slack-state.json"),
+            Some("ralph"),
+            Some(Path::new("crates/ralph-slack")),
+        );
         assert_eq!(env.get("RALPH_LOOP_ID").unwrap(), "loop-1");
         assert_eq!(env.get("RALPH_SLACK_CHANNEL_ID").unwrap(), "C123");
         assert_eq!(env.get("RALPH_SLACK_THREAD_TS").unwrap(), "1780.1");
+        assert_eq!(env.get("RALPH_SLACK_REPO_ALIAS").unwrap(), "ralph");
+        assert_eq!(
+            env.get("RALPH_SLACK_REPO_DIR").unwrap(),
+            "crates/ralph-slack"
+        );
         assert_eq!(
             env.get("RALPH_SLACK_STATE_PATH").unwrap(),
-            "/repo/.ralph/slack-state.json"
+            "/daemon/.ralph/slack-state.json"
         );
         assert!(!env.contains_key("RALPH_WORKSPACE_ROOT"));
     }
@@ -947,6 +1255,9 @@ mod tests {
             channel_id: "C123".to_string(),
             thread_ts: "1780.1".to_string(),
             workspace_root: dir.path().to_path_buf(),
+            state_path: dir.path().join(".ralph/slack-state.json"),
+            repo_alias: None,
+            repo_dir: None,
             env: BTreeMap::new(),
         };
         let mut command = Command::new("ralph");

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
+use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use async_trait::async_trait;
 
@@ -61,16 +62,25 @@ impl CommandLoopSpawner {
 impl LoopSpawner for CommandLoopSpawner {
     async fn spawn_loop(&self, request: StartLoopRequest) -> SlackResult<Option<u32>> {
         let executable = std::env::current_exe().map_err(SlackError::Io)?;
+        let log_dir = request.workspace_root.join(".ralph/slack-loop-logs");
+        std::fs::create_dir_all(&log_dir).map_err(SlackError::Io)?;
+        let log_path = log_dir.join(format!("{}.log", request.loop_id));
+        let stdout = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .map_err(SlackError::Io)?;
+        let stderr = stdout.try_clone().map_err(SlackError::Io)?;
         let mut command = Command::new(executable);
         command
             .current_dir(&request.workspace_root)
             .arg("run")
-            .arg("--no-tui")
-            .arg("--loop-id")
-            .arg(&request.loop_id)
+            .arg("-a")
             .arg("-p")
             .arg(&request.prompt)
-            .envs(&request.env);
+            .envs(&request.env)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr));
         if let Some(config_path) = &self.config_path {
             command.arg("-c").arg(config_path);
         }

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fs::OpenOptions;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use async_trait::async_trait;
 
@@ -67,6 +68,15 @@ pub trait ThreadNotifier: Send + Sync + Clone + 'static {
         message_ts: &str,
         message: &SlackRenderedMessage,
     ) -> SlackResult<()>;
+
+    async fn set_assistant_thread_status(
+        &self,
+        _channel_id: &str,
+        _thread_ts: &str,
+        _status: &str,
+    ) -> SlackResult<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -225,6 +235,17 @@ impl ThreadNotifier for SlackApiNotifier {
             .update_blocks(channel_id, message_ts, message)
             .await
     }
+
+    async fn set_assistant_thread_status(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        status: &str,
+    ) -> SlackResult<()> {
+        self.api
+            .set_assistant_thread_status(channel_id, thread_ts, status)
+            .await
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -333,6 +354,13 @@ where
                     None,
                     None,
                 )?;
+                self.notifier
+                    .set_assistant_thread_status(
+                        channel_id,
+                        thread_ts,
+                        &format_start_thread_status(&target_for_action, loop_id),
+                    )
+                    .await?;
                 let process_id = self
                     .spawner
                     .spawn_loop(StartLoopRequest {
@@ -356,6 +384,13 @@ where
                     .await?;
                 self.state_manager
                     .set_thread_process_id(loop_id, process_id)?;
+                self.notifier
+                    .set_assistant_thread_status(
+                        channel_id,
+                        thread_ts,
+                        &format_spawned_thread_status(&target_for_action),
+                    )
+                    .await?;
                 if let Some(process_id) = process_id {
                     monitor_loop_completion(
                         self.state_manager.clone(),
@@ -573,6 +608,9 @@ where
                         &format!("stopped Ralph loop {loop_id}. Further guidance in this thread is ignored."),
                     )
                     .await?;
+                self.notifier
+                    .set_assistant_thread_status(channel_id, thread_ts, "")
+                    .await?;
             }
         }
         Ok(())
@@ -609,6 +647,71 @@ impl RepoTarget {
             (None, None) => self.root.display().to_string(),
         }
     }
+
+    fn assistant_status_context(&self) -> Option<&str> {
+        self.alias.as_deref()
+    }
+}
+
+fn format_start_thread_status(target: &RepoTarget, loop_id: &str) -> String {
+    let status = match target.assistant_status_context() {
+        Some(alias) => format!("is starting loop {loop_id} in {alias}"),
+        None => format!("is starting loop {loop_id}"),
+    };
+    format_assistant_thread_status(&status)
+}
+
+fn format_spawned_thread_status(target: &RepoTarget) -> String {
+    let status = match target.assistant_status_context() {
+        Some(alias) => format!("is working in {alias}"),
+        None => "is working".to_string(),
+    };
+    format_assistant_thread_status(&status)
+}
+
+const MAX_ASSISTANT_THREAD_STATUS_LEN: usize = 120;
+const MIN_ASSISTANT_STATUS_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
+
+fn format_assistant_thread_status(raw: &str) -> String {
+    let redacted = redact_secrets(raw);
+    let stripped = strip_ansi_and_control_chars(&redacted);
+    truncate_status(
+        &collapse_tail_whitespace(&stripped),
+        MAX_ASSISTANT_THREAD_STATUS_LEN,
+    )
+}
+
+fn strip_ansi_and_control_chars(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            if matches!(chars.peek(), Some('[')) {
+                chars.next();
+                for next in chars.by_ref() {
+                    if ('@'..='~').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        if ch.is_control() && !ch.is_whitespace() {
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn truncate_status(value: &str, max_chars: usize) -> String {
+    let mut iter = value.chars();
+    let mut truncated = iter.by_ref().take(max_chars).collect::<String>();
+    if iter.next().is_some() {
+        truncated.pop();
+        truncated.push('…');
+    }
+    truncated
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -972,6 +1075,12 @@ fn monitor_loop_completion<N>(
                 tracing::warn!(%loop_id, ?error, "failed to post Slack loop completion update");
             }
         }
+        if let Err(error) = notifier
+            .set_assistant_thread_status(&channel_id, &thread_ts, "")
+            .await
+        {
+            tracing::warn!(%loop_id, ?error, "failed to clear Slack assistant thread status");
+        }
     });
 }
 
@@ -1015,6 +1124,9 @@ where
         }
     }
 
+    notifier
+        .set_assistant_thread_status(&binding.channel_id, &binding.thread_ts, "")
+        .await?;
     Ok(())
 }
 
@@ -1050,7 +1162,10 @@ const MIN_PROGRESS_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::f
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ProgressCheckpoint {
     last_reported_line_count: usize,
-    last_sent_at: Option<std::time::Duration>,
+    last_sent_at: Option<Duration>,
+    last_status: Option<String>,
+    last_status_sent_at: Option<Duration>,
+    human_needed_status_active: bool,
 }
 
 pub async fn sync_loop_progress_once<N>(
@@ -1069,9 +1184,28 @@ where
     let Some(update) = latest_progress_update(contents, checkpoint.last_reported_line_count) else {
         return Ok(false);
     };
+    let status = assistant_status_for_progress(&update);
+    let urgent_human_needed = update.topic == "human.interact";
+    let pending_human_needed = state_manager
+        .load_or_default()?
+        .pending_questions
+        .contains_key(loop_id);
+    let status_sent = sync_assistant_thread_status(
+        notifier.clone(),
+        channel_id,
+        thread_ts,
+        &status,
+        elapsed,
+        checkpoint,
+        urgent_human_needed,
+        pending_human_needed && !urgent_human_needed,
+    )
+    .await?;
     if let Some(last_sent_at) = checkpoint.last_sent_at {
-        if elapsed.saturating_sub(last_sent_at) < MIN_PROGRESS_UPDATE_INTERVAL {
-            return Ok(false);
+        if update.topic != "human.interact"
+            && elapsed.saturating_sub(last_sent_at) < MIN_PROGRESS_UPDATE_INTERVAL
+        {
+            return Ok(status_sent);
         }
     }
 
@@ -1108,6 +1242,78 @@ where
     checkpoint.last_reported_line_count = update.line_count;
     checkpoint.last_sent_at = Some(elapsed);
     Ok(true)
+}
+
+async fn sync_assistant_thread_status<N>(
+    notifier: N,
+    channel_id: &str,
+    thread_ts: &str,
+    status: &str,
+    elapsed: Duration,
+    checkpoint: &mut ProgressCheckpoint,
+    bypass_throttle: bool,
+    suppress_non_urgent: bool,
+) -> SlackResult<bool>
+where
+    N: ThreadNotifier,
+{
+    if status.is_empty() {
+        notifier
+            .set_assistant_thread_status(channel_id, thread_ts, status)
+            .await?;
+        checkpoint.last_status = Some(status.to_string());
+        checkpoint.last_status_sent_at = Some(elapsed);
+        checkpoint.human_needed_status_active = false;
+        return Ok(true);
+    }
+    if suppress_non_urgent {
+        return Ok(false);
+    }
+    if !bypass_throttle && checkpoint.last_status.as_deref() == Some(status) {
+        return Ok(false);
+    }
+    if !bypass_throttle {
+        if let Some(last_sent_at) = checkpoint.last_status_sent_at {
+            if elapsed.saturating_sub(last_sent_at) < MIN_ASSISTANT_STATUS_UPDATE_INTERVAL {
+                return Ok(false);
+            }
+        }
+    }
+    notifier
+        .set_assistant_thread_status(channel_id, thread_ts, status)
+        .await?;
+    checkpoint.last_status = Some(status.to_string());
+    checkpoint.last_status_sent_at = Some(elapsed);
+    checkpoint.human_needed_status_active = bypass_throttle && status == "needs your answer";
+    Ok(true)
+}
+
+fn assistant_status_for_progress(update: &SlackProgressUpdate) -> String {
+    if update.topic == "human.interact" {
+        return "needs your answer".to_string();
+    }
+
+    let mut parts = Vec::new();
+    if let Some(iteration) = update.iteration {
+        parts.push(format!("iter {iteration}"));
+    }
+    if let Some(hat) = update.hat.as_deref().filter(|hat| !hat.trim().is_empty()) {
+        parts.push(format!("hat {hat}"));
+    }
+    if !update.topic.trim().is_empty() && update.topic != "unknown" {
+        parts.push(update.topic.clone());
+    }
+
+    let semantic = if parts.is_empty() {
+        String::new()
+    } else {
+        format!("is {}", parts.join(" · "))
+    };
+    if !semantic.is_empty() {
+        return format_assistant_thread_status(&semantic);
+    }
+
+    "is working".to_string()
 }
 
 fn process_is_alive(process_id: u32) -> bool {

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -498,6 +498,15 @@ where
                     .post_thread_message(channel_id, thread_ts, &repo_command_text(binding))
                     .await?;
             }
+            ThreadCommand::Obs => {
+                self.notifier
+                    .post_thread_message(
+                        channel_id,
+                        thread_ts,
+                        &obs_text(binding, state.pending_questions.contains_key(loop_id)),
+                    )
+                    .await?;
+            }
             ThreadCommand::Status => {
                 let message = SlackBlocks::status_card(
                     &binding.loop_id,
@@ -736,6 +745,121 @@ fn repo_command_text(binding: &SlackThreadBinding) -> String {
         binding.parent_loop_id.as_deref().unwrap_or("none"),
         worktree.display()
     )
+}
+
+fn obs_text(binding: &SlackThreadBinding, pending_question: bool) -> String {
+    let alias = binding.repo_alias.as_deref().unwrap_or("unbound");
+    let dir = binding
+        .repo_dir
+        .as_deref()
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .map(|dir| dir.display().to_string())
+        .unwrap_or_else(|| ".".to_string());
+    let process_id = binding
+        .process_id
+        .map(|pid| pid.to_string())
+        .unwrap_or_else(|| "none".to_string());
+    let pending = if pending_question { "yes" } else { "no" };
+    let worktree = binding
+        .workspace_root
+        .join(".worktrees")
+        .join(&binding.loop_id);
+    let branch = format!("ralph-slack-{}", binding.loop_id);
+    let event_path = events_path(&binding.workspace_root, &binding.loop_id);
+    let log_path = binding
+        .log_path
+        .clone()
+        .unwrap_or_else(|| slack_loop_log_path(&binding.workspace_root, &binding.loop_id));
+    let cards = format!(
+        "start=`{}` progress=`{}` stream=`{}` final=`{}`",
+        binding.start_card_ts.as_deref().unwrap_or("none"),
+        binding.progress_message_ts.as_deref().unwrap_or("none"),
+        binding.stream_ts.as_deref().unwrap_or("none"),
+        binding.final_card_ts.as_deref().unwrap_or("none")
+    );
+    format!(
+        "Ralph observable\nloop: `{}`\nstatus: `{}`\npending question: `{pending}`\nprocess id: `{process_id}`\nrepo alias: `{alias}`\nrepo root: `{}`\nrepo dir: `{dir}`\nworktree: `{}`\nbranch: `{branch}`\ncards: {cards}\n{}\n{}",
+        binding.loop_id,
+        status_observable_label(&binding.status),
+        binding.workspace_root.display(),
+        worktree.display(),
+        latest_event_observation(&event_path),
+        latest_log_observation(&log_path)
+    )
+}
+
+fn latest_event_observation(event_path: &Path) -> String {
+    match std::fs::read_to_string(event_path) {
+        Ok(contents) => {
+            let line_count = contents
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .count();
+            let Some(update) = latest_progress_update(&contents, 0) else {
+                return format!(
+                    "events: `{}` ({line_count} line(s))\nlatest event: none parseable",
+                    event_path.display()
+                );
+            };
+            let iteration = update
+                .iteration
+                .map(|iteration| iteration.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let hat = update.hat.as_deref().unwrap_or("agent");
+            let topic = update.topic;
+            let payload =
+                collapse_tail_whitespace(&truncate_tail_payload(&redact_secrets(&update.payload)));
+            if payload.is_empty() {
+                format!(
+                    "events: `{}` ({line_count} line(s))\nlatest event: iter `{iteration}` · hat `{hat}` · topic `{topic}`",
+                    event_path.display()
+                )
+            } else {
+                format!(
+                    "events: `{}` ({line_count} line(s))\nlatest event: iter `{iteration}` · hat `{hat}` · topic `{topic}`\nlatest message: {payload}",
+                    event_path.display()
+                )
+            }
+        }
+        Err(error) => format!(
+            "events: `{}` (missing: {error})\nlatest event: none",
+            event_path.display()
+        ),
+    }
+}
+
+fn latest_log_observation(log_path: &Path) -> String {
+    match std::fs::read_to_string(log_path) {
+        Ok(contents) => {
+            let line_count = contents
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .count();
+            let latest = contents
+                .lines()
+                .rev()
+                .find(|line| !line.trim().is_empty())
+                .map(|line| collapse_tail_whitespace(&truncate_tail_payload(&redact_secrets(line))))
+                .unwrap_or_else(|| "none".to_string());
+            format!(
+                "log: `{}` ({line_count} line(s))\nlatest log: {latest}",
+                log_path.display()
+            )
+        }
+        Err(error) => format!(
+            "log: `{}` (missing: {error})\nlatest log: none",
+            log_path.display()
+        ),
+    }
+}
+
+fn status_observable_label(status: &SlackThreadStatus) -> &'static str {
+    match status {
+        SlackThreadStatus::Running => "running",
+        SlackThreadStatus::Completed => "completed",
+        SlackThreadStatus::Failed => "failed",
+        SlackThreadStatus::Stopped => "stopped",
+    }
 }
 
 fn configured_alias_list(repo_aliases: &BTreeMap<String, PathBuf>) -> String {

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -11,7 +11,7 @@ use crate::handler::{
     HandlerAction, SlackMessageEvent, ThreadCommand, events_path, handle_message,
 };
 use crate::renderer::{SlackBlocks, SlackRenderedMessage, redact_secrets};
-use crate::state::{SlackStateManager, SlackThreadStatus};
+use crate::state::{SlackStateManager, SlackThreadBinding, SlackThreadStatus};
 
 #[derive(Debug, Clone)]
 pub struct SlackDaemonConfig {
@@ -94,7 +94,9 @@ impl LoopSpawner for CommandLoopSpawner {
         command
             .current_dir(&worktree_path)
             .arg("run")
-            .arg("-a")
+            .arg("--autonomous")
+            .arg("-b")
+            .arg("claude")
             .arg("-p")
             .arg(&request.prompt)
             .envs(&request.env)
@@ -228,6 +230,29 @@ where
             spawner,
             notifier,
         }
+    }
+
+    pub async fn reconcile_stale_threads(&self) -> SlackResult<usize> {
+        let state = self.state_manager.load_or_default()?;
+        let stale_bindings = state
+            .threads
+            .values()
+            .filter(|binding| binding.status == SlackThreadStatus::Running)
+            .filter(|binding| {
+                binding
+                    .process_id
+                    .map(|process_id| !process_is_alive(process_id))
+                    .unwrap_or(false)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        drop(state);
+
+        for binding in &stale_bindings {
+            finish_stale_thread(&self.state_manager, self.notifier.clone(), binding).await?;
+        }
+
+        Ok(stale_bindings.len())
     }
 
     pub async fn handle_event(&self, event: SlackMessageEvent) -> SlackResult<HandlerAction> {
@@ -463,16 +488,7 @@ fn monitor_loop_completion<N>(
             }
         }
 
-        let event_path = events_path(&workspace_root, &loop_id);
-        let contents = std::fs::read_to_string(&event_path).unwrap_or_default();
-        let completed = contents.contains("\"topic\":\"LOOP_COMPLETE\"")
-            || contents.contains("## Reason\\ncompleted")
-            || contents.contains("\"payload\":\"## Reason\\ncompleted");
-        let status = if completed {
-            SlackThreadStatus::Completed
-        } else {
-            SlackThreadStatus::Failed
-        };
+        let status = derive_final_status(&workspace_root, &loop_id);
         if let Err(error) = state_manager.finish_thread(&loop_id, status.clone()) {
             tracing::warn!(%loop_id, ?error, "failed to mark Slack loop finished");
         }
@@ -498,6 +514,76 @@ fn monitor_loop_completion<N>(
             }
         }
     });
+}
+
+async fn finish_stale_thread<N>(
+    state_manager: &SlackStateManager,
+    notifier: N,
+    binding: &SlackThreadBinding,
+) -> SlackResult<()>
+where
+    N: ThreadNotifier,
+{
+    let status = derive_final_status(&binding.workspace_root, &binding.loop_id);
+    state_manager.finish_thread(&binding.loop_id, status.clone())?;
+
+    let note = "Try `tail 10` in this thread for recent events.";
+    let message = SlackBlocks::final_card(&binding.loop_id, status, None, Some(note));
+    if let Some(final_card_ts) = binding.final_card_ts.as_deref() {
+        if let Err(error) = notifier
+            .update_thread_blocks(&binding.channel_id, final_card_ts, &message)
+            .await
+        {
+            tracing::warn!(loop_id = %binding.loop_id, ?error, "failed to update Slack stale loop final card");
+        }
+    } else {
+        match notifier
+            .post_thread_blocks(&binding.channel_id, &binding.thread_ts, &message)
+            .await
+        {
+            Ok(final_card_ts) => {
+                state_manager.set_thread_message_timestamps(
+                    &binding.loop_id,
+                    None,
+                    None,
+                    None,
+                    Some(&final_card_ts),
+                )?;
+            }
+            Err(error) => {
+                tracing::warn!(loop_id = %binding.loop_id, ?error, "failed to post Slack stale loop final card");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn derive_final_status(workspace_root: &Path, loop_id: &str) -> SlackThreadStatus {
+    let event_contents =
+        std::fs::read_to_string(events_path(workspace_root, loop_id)).unwrap_or_default();
+    let log_contents =
+        std::fs::read_to_string(slack_loop_log_path(workspace_root, loop_id)).unwrap_or_default();
+
+    if indicates_completed(&event_contents) || indicates_completed(&log_contents) {
+        SlackThreadStatus::Completed
+    } else {
+        SlackThreadStatus::Failed
+    }
+}
+
+fn indicates_completed(contents: &str) -> bool {
+    contents.contains("\"topic\":\"LOOP_COMPLETE\"")
+        || contents.contains("LOOP_COMPLETE")
+        || contents.contains("## Reason\\ncompleted")
+        || contents.contains("## Reason\ncompleted")
+        || contents.contains("\"payload\":\"## Reason\\ncompleted")
+}
+
+fn slack_loop_log_path(workspace_root: &Path, loop_id: &str) -> PathBuf {
+    workspace_root
+        .join(".ralph/slack-loop-logs")
+        .join(format!("{loop_id}.log"))
 }
 
 const MIN_PROGRESS_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
@@ -569,6 +655,7 @@ fn process_is_alive(process_id: u32) -> bool {
     Command::new("kill")
         .arg("-0")
         .arg(process_id.to_string())
+        .stderr(Stdio::null())
         .status()
         .map(|status| status.success())
         .unwrap_or(false)

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -665,12 +665,19 @@ pub fn slack_loop_env(
     loop_id: &str,
     channel_id: &str,
     thread_ts: &str,
-    _workspace_root: &Path,
+    workspace_root: &Path,
 ) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("RALPH_LOOP_ID".to_string(), loop_id.to_string()),
         ("RALPH_SLACK_CHANNEL_ID".to_string(), channel_id.to_string()),
         ("RALPH_SLACK_THREAD_TS".to_string(), thread_ts.to_string()),
+        (
+            "RALPH_SLACK_STATE_PATH".to_string(),
+            workspace_root
+                .join(".ralph/slack-state.json")
+                .to_string_lossy()
+                .to_string(),
+        ),
     ])
 }
 
@@ -715,11 +722,15 @@ mod tests {
     }
 
     #[test]
-    fn slack_loop_env_does_not_force_workspace_root() {
+    fn slack_loop_env_shares_root_state_without_forcing_workspace_root() {
         let env = slack_loop_env("loop-1", "C123", "1780.1", Path::new("/repo"));
         assert_eq!(env.get("RALPH_LOOP_ID").unwrap(), "loop-1");
         assert_eq!(env.get("RALPH_SLACK_CHANNEL_ID").unwrap(), "C123");
         assert_eq!(env.get("RALPH_SLACK_THREAD_TS").unwrap(), "1780.1");
+        assert_eq!(
+            env.get("RALPH_SLACK_STATE_PATH").unwrap(),
+            "/repo/.ralph/slack-state.json"
+        );
         assert!(!env.contains_key("RALPH_WORKSPACE_ROOT"));
     }
 

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -649,16 +649,89 @@ fn tail_text(path: &Path, n: usize) -> String {
             if lines.is_empty() {
                 return "No events yet.".to_string();
             }
-            let mut redacted = lines.into_iter().rev().collect::<Vec<_>>().join("\n");
-            redacted = redact_secrets(&redacted);
-            if redacted.len() > 3000 {
-                redacted.truncate(3000);
-                redacted.push_str("…");
+            let mut formatted = lines
+                .into_iter()
+                .rev()
+                .map(format_tail_event)
+                .collect::<Vec<_>>()
+                .join("\n");
+            if formatted.len() > 3000 {
+                formatted.truncate(3000);
+                formatted.push_str("…");
             }
-            format!("Latest Ralph events:\n```\n{}\n```", redacted)
+            format!("Latest Ralph events (last {n}):\n{formatted}")
         }
         Err(_) => "No event file found for this loop yet.".to_string(),
     }
+}
+
+fn format_tail_event(line: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        let raw = truncate_tail_payload(&redact_secrets(line.trim()));
+        return format!("• raw event\n  {raw}");
+    };
+    let topic = value
+        .get("topic")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    let actor = tail_actor(&value, topic);
+    let ts = tail_ts(value.get("ts").and_then(|value| value.as_str()));
+    let iteration = value
+        .get("iteration")
+        .and_then(|value| value.as_u64())
+        .map(|iteration| format!(" · iter {iteration}"))
+        .unwrap_or_default();
+    let payload = truncate_tail_payload(&redact_secrets(&event_payload_text(value.get("payload"))));
+    let payload = collapse_tail_whitespace(&payload);
+    if payload.is_empty() {
+        format!("• `{ts}`{iteration} · {actor} · `{topic}`")
+    } else {
+        format!("• `{ts}`{iteration} · {actor} · `{topic}`\n  {payload}")
+    }
+}
+
+fn tail_actor(value: &serde_json::Value, topic: &str) -> String {
+    if topic == "human.response" {
+        return "operator".to_string();
+    }
+    if topic.starts_with("human.") {
+        return "human-loop".to_string();
+    }
+    value
+        .get("hat")
+        .or_else(|| value.get("triggered"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("agent")
+        .to_string()
+}
+
+fn tail_ts(ts: Option<&str>) -> String {
+    let Some(ts) = ts else {
+        return "time unknown".to_string();
+    };
+    if let Some((_, time)) = ts.split_once('T') {
+        let short = time
+            .chars()
+            .take_while(|ch| *ch != '.' && *ch != '+' && *ch != 'Z')
+            .collect::<String>();
+        if !short.is_empty() {
+            return short;
+        }
+    }
+    ts.to_string()
+}
+
+fn truncate_tail_payload(payload: &str) -> String {
+    let mut payload = payload.to_string();
+    if payload.len() > 700 {
+        payload.truncate(700);
+        payload.push('…');
+    }
+    payload
+}
+
+fn collapse_tail_whitespace(payload: &str) -> String {
+    payload.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 pub fn slack_loop_env(
@@ -684,6 +757,35 @@ pub fn slack_loop_env(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tail_text_formats_jsonl_as_operator_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"ts":"2026-06-07T21:59:34.126921+00:00","iteration":0,"hat":"loop","topic":"plan.start","triggered":"planner","payload":"live smoke: create .ralph/live-slack-smoke.txt containing ok from slack and ask for approval."}"#,
+                "\n",
+                r#"{"payload":"Approval requested: created artifact .ralph/live-slack-smoke.txt with token-secret-token-abc. Options: approve or request changes.","topic":"human.interact","ts":"2026-06-07T22:00:35.327605+00:00"}"#,
+                "\n",
+                r#"{"payload":"Approve","topic":"human.response","ts":"2026-06-07T22:01:16.584587+00:00"}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+
+        let text = tail_text(&path, 10);
+
+        assert!(text.contains("Latest Ralph events (last 10):"));
+        assert!(text.contains("`21:59:34` · iter 0 · loop · `plan.start`"));
+        assert!(text.contains("human-loop · `human.interact`"));
+        assert!(text.contains("operator · `human.response`"));
+        assert!(text.contains("Approve"));
+        assert!(text.contains("[redacted]"));
+        assert!(!text.contains(r#"{"ts""#));
+        assert!(!text.contains("secret-token-abc"));
+    }
 
     #[test]
     fn progress_update_uses_iteration_hat_topic_and_last_message() {

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -10,7 +10,8 @@ use crate::error::{SlackError, SlackResult};
 use crate::handler::{
     HandlerAction, SlackMessageEvent, ThreadCommand, events_path, handle_message,
 };
-use crate::state::{SlackStateManager, SlackThreadBinding, SlackThreadStatus};
+use crate::renderer::{SlackBlocks, SlackRenderedMessage, redact_secrets};
+use crate::state::{SlackStateManager, SlackThreadStatus};
 
 #[derive(Debug, Clone)]
 pub struct SlackDaemonConfig {
@@ -45,6 +46,16 @@ pub trait ThreadNotifier: Send + Sync + Clone + 'static {
         thread_ts: &str,
         text: &str,
     ) -> SlackResult<String>;
+
+    async fn post_thread_blocks(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        message: &SlackRenderedMessage,
+    ) -> SlackResult<String> {
+        self.post_thread_message(channel_id, thread_ts, &message.text)
+            .await
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -161,6 +172,17 @@ impl ThreadNotifier for SlackApiNotifier {
             .post_message(channel_id, Some(thread_ts), text)
             .await
     }
+
+    async fn post_thread_blocks(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        message: &SlackRenderedMessage,
+    ) -> SlackResult<String> {
+        self.api
+            .post_blocks(channel_id, Some(thread_ts), message)
+            .await
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -219,13 +241,23 @@ where
                 channel_id,
                 thread_ts,
             } => {
-                self.notifier
-                    .post_thread_message(
-                        channel_id,
-                        thread_ts,
-                        &format!("🤖 Ralph loop started\nLoop: {}\nStatus: running", loop_id),
-                    )
+                let start_message = SlackBlocks::start_card(
+                    loop_id,
+                    prompt,
+                    Some(&root_for_start.display().to_string()),
+                    None,
+                );
+                let start_card_ts = self
+                    .notifier
+                    .post_thread_blocks(channel_id, thread_ts, &start_message)
                     .await?;
+                self.state_manager.set_thread_message_timestamps(
+                    loop_id,
+                    Some(&start_card_ts),
+                    None,
+                    None,
+                    None,
+                )?;
                 let process_id = self
                     .spawner
                     .spawn_loop(StartLoopRequest {
@@ -322,16 +354,19 @@ where
         match command {
             ThreadCommand::Help => {
                 self.notifier
-                    .post_thread_message(channel_id, thread_ts, help_text())
+                    .post_thread_blocks(channel_id, thread_ts, &SlackBlocks::help_card())
                     .await?;
             }
             ThreadCommand::Status => {
+                let message = SlackBlocks::status_card(
+                    &binding.loop_id,
+                    binding.status.clone(),
+                    &binding.workspace_root.display().to_string(),
+                    state.pending_questions.contains_key(loop_id),
+                    binding.process_id,
+                );
                 self.notifier
-                    .post_thread_message(
-                        channel_id,
-                        thread_ts,
-                        &status_text(binding, state.pending_questions.contains_key(loop_id)),
-                    )
+                    .post_thread_blocks(channel_id, thread_ts, &message)
                     .await?;
             }
             ThreadCommand::Tail { n } => {
@@ -391,12 +426,16 @@ fn monitor_loop_completion<N>(
             if let Ok(contents) = std::fs::read_to_string(&event_path) {
                 if let Some(update) = latest_progress_update(&contents, last_reported_line_count) {
                     last_reported_line_count = update.line_count;
+                    let message = SlackBlocks::progress_card(
+                        &loop_id,
+                        update.iteration,
+                        update.hat.as_deref(),
+                        &update.topic,
+                        &update.payload,
+                        None,
+                    );
                     if let Err(error) = notifier
-                        .post_thread_message(
-                            &channel_id,
-                            &thread_ts,
-                            &format_progress_update(&loop_id, &update),
-                        )
+                        .post_thread_blocks(&channel_id, &thread_ts, &message)
                         .await
                     {
                         tracing::warn!(%loop_id, ?error, "failed to post Slack loop progress update");
@@ -421,20 +460,26 @@ fn monitor_loop_completion<N>(
         if let Err(error) = state_manager.finish_thread(&loop_id, status.clone()) {
             tracing::warn!(%loop_id, ?error, "failed to mark Slack loop finished");
         }
-        let status_label = match status {
-            SlackThreadStatus::Completed => "completed",
-            SlackThreadStatus::Failed => "failed",
-            SlackThreadStatus::Running => "running",
-            SlackThreadStatus::Stopped => "stopped",
-        };
-        let text = format!(
-            "Ralph loop {status_label}\nLoop: {loop_id}\nTry `tail 10` in this thread for recent events."
-        );
-        if let Err(error) = notifier
-            .post_thread_message(&channel_id, &thread_ts, &text)
+        let note = "Try `tail 10` in this thread for recent events.";
+        let message = SlackBlocks::final_card(&loop_id, status, None, Some(note));
+        match notifier
+            .post_thread_blocks(&channel_id, &thread_ts, &message)
             .await
         {
-            tracing::warn!(%loop_id, ?error, "failed to post Slack loop completion update");
+            Ok(final_card_ts) => {
+                if let Err(error) = state_manager.set_thread_message_timestamps(
+                    &loop_id,
+                    None,
+                    None,
+                    None,
+                    Some(&final_card_ts),
+                ) {
+                    tracing::warn!(%loop_id, ?error, "failed to save Slack final card timestamp");
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%loop_id, ?error, "failed to post Slack loop completion update");
+            }
         }
     });
 }
@@ -498,6 +543,7 @@ fn event_payload_text(payload: Option<&serde_json::Value>) -> String {
     }
 }
 
+#[cfg(test)]
 fn format_progress_update(loop_id: &str, update: &SlackProgressUpdate) -> String {
     let iteration = update
         .iteration
@@ -512,24 +558,6 @@ fn format_progress_update(loop_id: &str, update: &SlackProgressUpdate) -> String
     format!(
         "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nTopic: {}\nLast message:\n```\n{}\n```",
         update.topic, payload
-    )
-}
-
-fn help_text() -> &'static str {
-    "Ralph Slack commands: help, status, tail [n], stop/cancel. Plain replies become guidance, or answer the pending human question."
-}
-
-fn status_text(binding: &SlackThreadBinding, pending_question: bool) -> String {
-    format!(
-        "Ralph thread status\nloop: {}\nrepo: {}\nthread status: {:?}\npending question: {}\nprocess id: {}",
-        binding.loop_id,
-        binding.workspace_root.display(),
-        binding.status,
-        if pending_question { "yes" } else { "no" },
-        binding
-            .process_id
-            .map(|pid| pid.to_string())
-            .unwrap_or_else(|| "unknown".to_string())
     )
 }
 
@@ -550,20 +578,6 @@ fn tail_text(path: &Path, n: usize) -> String {
         }
         Err(_) => "No event file found for this loop yet.".to_string(),
     }
-}
-
-fn redact_secrets(text: &str) -> String {
-    let mut out = text.to_string();
-    for marker in ["secret-token-", "token-", "xoxb-", "xapp-"] {
-        while let Some(start) = out.to_ascii_lowercase().find(marker) {
-            let end = out[start..]
-                .find(|c: char| c.is_whitespace() || c == '"' || c == '\'')
-                .map(|offset| start + offset)
-                .unwrap_or(out.len());
-            out.replace_range(start..end, "[redacted]");
-        }
-    }
-    out
 }
 
 pub fn slack_loop_env(

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -994,20 +994,20 @@ fn invalid_repo_alias_message(alias: &str) -> String {
 
 fn strip_app_mention_for_start(text: &str) -> String {
     let trimmed = text.trim();
-    if let Some(rest) = trimmed.strip_prefix("<@") {
-        if let Some((_, prompt)) = rest.split_once('>') {
-            return prompt.trim().to_string();
-        }
+    if let Some(rest) = trimmed.strip_prefix("<@")
+        && let Some((_, prompt)) = rest.split_once('>')
+    {
+        return prompt.trim().to_string();
     }
     trimmed.to_string()
 }
 
 fn rewrite_start_text_with_prompt(original: &str, prompt: &str) -> String {
     let trimmed = original.trim();
-    if let Some(rest) = trimmed.strip_prefix("<@") {
-        if let Some((mention, _)) = rest.split_once('>') {
-            return format!("<@{mention}> {}", prompt.trim()).trim().to_string();
-        }
+    if let Some(rest) = trimmed.strip_prefix("<@")
+        && let Some((mention, _)) = rest.split_once('>')
+    {
+        return format!("<@{mention}> {}", prompt.trim()).trim().to_string();
     }
     prompt.trim().to_string()
 }
@@ -1029,8 +1029,8 @@ fn monitor_loop_completion<N>(
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             let event_path = events_path(&workspace_root, &loop_id);
-            if let Ok(contents) = std::fs::read_to_string(&event_path) {
-                if let Err(error) = sync_loop_progress_once(
+            if let Ok(contents) = std::fs::read_to_string(&event_path)
+                && let Err(error) = sync_loop_progress_once(
                     &state_manager,
                     notifier.clone(),
                     &loop_id,
@@ -1041,9 +1041,8 @@ fn monitor_loop_completion<N>(
                     &mut checkpoint,
                 )
                 .await
-                {
-                    tracing::warn!(%loop_id, ?error, "failed to sync Slack loop progress update");
-                }
+            {
+                tracing::warn!(%loop_id, ?error, "failed to sync Slack loop progress update");
             }
             if !process_is_alive(process_id) {
                 break;
@@ -1201,12 +1200,11 @@ where
         pending_human_needed && !urgent_human_needed,
     )
     .await?;
-    if let Some(last_sent_at) = checkpoint.last_sent_at {
-        if update.topic != "human.interact"
-            && elapsed.saturating_sub(last_sent_at) < MIN_PROGRESS_UPDATE_INTERVAL
-        {
-            return Ok(status_sent);
-        }
+    if let Some(last_sent_at) = checkpoint.last_sent_at
+        && update.topic != "human.interact"
+        && elapsed.saturating_sub(last_sent_at) < MIN_PROGRESS_UPDATE_INTERVAL
+    {
+        return Ok(status_sent);
     }
 
     let message = SlackBlocks::progress_card(
@@ -1272,12 +1270,11 @@ where
     if !bypass_throttle && checkpoint.last_status.as_deref() == Some(status) {
         return Ok(false);
     }
-    if !bypass_throttle {
-        if let Some(last_sent_at) = checkpoint.last_status_sent_at {
-            if elapsed.saturating_sub(last_sent_at) < MIN_ASSISTANT_STATUS_UPDATE_INTERVAL {
-                return Ok(false);
-            }
-        }
+    if !bypass_throttle
+        && let Some(last_sent_at) = checkpoint.last_status_sent_at
+        && elapsed.saturating_sub(last_sent_at) < MIN_ASSISTANT_STATUS_UPDATE_INTERVAL
+    {
+        return Ok(false);
     }
     notifier
         .set_assistant_thread_status(channel_id, thread_ts, status)
@@ -1386,7 +1383,7 @@ fn format_progress_update(loop_id: &str, update: &SlackProgressUpdate) -> String
     let mut payload = redact_secrets(&update.payload);
     if payload.len() > 1000 {
         payload.truncate(1000);
-        payload.push_str("…");
+        payload.push('…');
     }
     format!(
         "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nTopic: {}\nLast message:\n```\n{}\n```",
@@ -1407,7 +1404,7 @@ fn handoff_text(binding: &SlackThreadBinding) -> String {
             let mut text = redact_secrets(contents.trim());
             if text.len() > 3000 {
                 text.truncate(3000);
-                text.push_str("…");
+                text.push('…');
             }
             format!(
                 "Handoff for {}:
@@ -1476,7 +1473,7 @@ fn plain_tail_text(path: &Path, n: usize) -> String {
                 .join("\n");
             if formatted.len() > 3000 {
                 formatted.truncate(3000);
-                formatted.push_str("…");
+                formatted.push('…');
             }
             format!(
                 "Latest Ralph log lines (last {n}):
@@ -1504,7 +1501,7 @@ fn tail_text(path: &Path, n: usize) -> String {
                 .join("\n");
             if formatted.len() > 3000 {
                 formatted.truncate(3000);
-                formatted.push_str("…");
+                formatted.push('…');
             }
             format!("Latest Ralph events (last {n}):\n{formatted}")
         }

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -384,10 +384,10 @@ fn monitor_loop_completion<N>(
     N: ThreadNotifier,
 {
     tokio::spawn(async move {
-        let event_path = events_path(&workspace_root, &loop_id);
         let mut last_reported_line_count = 0;
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            let event_path = events_path(&workspace_root, &loop_id);
             if let Ok(contents) = std::fs::read_to_string(&event_path) {
                 if let Some(update) = latest_progress_update(&contents, last_reported_line_count) {
                     last_reported_line_count = update.line_count;
@@ -408,6 +408,7 @@ fn monitor_loop_completion<N>(
             }
         }
 
+        let event_path = events_path(&workspace_root, &loop_id);
         let contents = std::fs::read_to_string(&event_path).unwrap_or_default();
         let completed = contents.contains("\"topic\":\"LOOP_COMPLETE\"")
             || contents.contains("## Reason\\ncompleted")

--- a/crates/ralph-slack/src/daemon.rs
+++ b/crates/ralph-slack/src/daemon.rs
@@ -434,6 +434,33 @@ where
                     )
                     .await?;
             }
+            ThreadCommand::Log { n } => {
+                self.notifier
+                    .post_thread_message(
+                        channel_id,
+                        thread_ts,
+                        &plain_tail_text(
+                            &slack_loop_log_path(&binding.workspace_root, loop_id),
+                            *n,
+                        ),
+                    )
+                    .await?;
+            }
+            ThreadCommand::Handoff => {
+                self.notifier
+                    .post_thread_message(channel_id, thread_ts, &handoff_text(binding))
+                    .await?;
+            }
+            ThreadCommand::Repo => {
+                self.notifier
+                    .post_thread_message(channel_id, thread_ts, &repo_text(binding))
+                    .await?;
+            }
+            ThreadCommand::Artifacts => {
+                self.notifier
+                    .post_thread_message(channel_id, thread_ts, &artifacts_text(binding))
+                    .await?;
+            }
             ThreadCommand::Stop => {
                 if user_id != binding.created_by {
                     self.notifier
@@ -740,6 +767,113 @@ fn format_progress_update(loop_id: &str, update: &SlackProgressUpdate) -> String
         "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nTopic: {}\nLast message:\n```\n{}\n```",
         update.topic, payload
     )
+}
+
+fn handoff_text(binding: &SlackThreadBinding) -> String {
+    let handoff_path = binding.handoff_path.clone().unwrap_or_else(|| {
+        binding
+            .workspace_root
+            .join(".worktrees")
+            .join(&binding.loop_id)
+            .join(".ralph/agent/summary.md")
+    });
+    match std::fs::read_to_string(&handoff_path) {
+        Ok(contents) if !contents.trim().is_empty() => {
+            let mut text = redact_secrets(contents.trim());
+            if text.len() > 3000 {
+                text.truncate(3000);
+                text.push_str("…");
+            }
+            format!(
+                "Handoff for {}:
+```
+{}
+```",
+                binding.loop_id, text
+            )
+        }
+        _ => format!(
+            "No handoff summary found for {} yet. Expected: {}",
+            binding.loop_id,
+            handoff_path.display()
+        ),
+    }
+}
+
+fn repo_text(binding: &SlackThreadBinding) -> String {
+    format!(
+        "Loop `{}` repo: `{}`
+Thread status: {:?}
+Parent loop: {}",
+        binding.loop_id,
+        binding.workspace_root.display(),
+        binding.status,
+        binding.parent_loop_id.as_deref().unwrap_or("none")
+    )
+}
+
+fn artifacts_text(binding: &SlackThreadBinding) -> String {
+    let artifacts_path = binding.artifacts_path.clone().unwrap_or_else(|| {
+        binding
+            .workspace_root
+            .join(".worktrees")
+            .join(&binding.loop_id)
+            .join(".ralph")
+    });
+    if !artifacts_path.exists() {
+        return format!(
+            "No local artifacts found for {} at {}",
+            binding.loop_id,
+            artifacts_path.display()
+        );
+    }
+    let mut entries = std::fs::read_dir(&artifacts_path)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .map(|entry| entry.path())
+        .filter(|path| path.file_name().and_then(|name| name.to_str()) != Some("events.jsonl"))
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+    entries.sort();
+    if entries.is_empty() {
+        return format!("No local artifacts found for {}.", binding.loop_id);
+    }
+    entries.truncate(20);
+    format!(
+        "Local artifacts for {}:
+{}",
+        binding.loop_id,
+        entries.join("\n")
+    )
+}
+
+fn plain_tail_text(path: &Path, n: usize) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let lines = contents.lines().rev().take(n).collect::<Vec<_>>();
+            if lines.is_empty() {
+                return "No log lines yet.".to_string();
+            }
+            let mut formatted = lines
+                .into_iter()
+                .rev()
+                .map(redact_secrets)
+                .collect::<Vec<_>>()
+                .join("\n");
+            if formatted.len() > 3000 {
+                formatted.truncate(3000);
+                formatted.push_str("…");
+            }
+            format!(
+                "Latest Ralph log lines (last {n}):
+```
+{formatted}
+```"
+            )
+        }
+        Err(_) => "No loop log found for this loop yet.".to_string(),
+    }
 }
 
 fn tail_text(path: &Path, n: usize) -> String {

--- a/crates/ralph-slack/src/error.rs
+++ b/crates/ralph-slack/src/error.rs
@@ -24,6 +24,9 @@ pub enum SlackError {
     #[error("Slack config error: {0}")]
     Config(String),
 
+    #[error("Slack file path rejected: {0}")]
+    FilePath(String),
+
     #[error("invalid Slack loop id: {0}")]
     InvalidLoopId(String),
 

--- a/crates/ralph-slack/src/error.rs
+++ b/crates/ralph-slack/src/error.rs
@@ -1,0 +1,38 @@
+use thiserror::Error;
+
+/// Result alias for Slack integration operations.
+pub type SlackResult<T> = Result<T, SlackError>;
+
+/// Errors surfaced by the Slack integration seam.
+#[derive(Debug, Error)]
+pub enum SlackError {
+    #[error("Slack bot token is required")]
+    MissingBotToken,
+
+    #[error("Slack app token is required for Socket Mode")]
+    MissingAppToken,
+
+    #[error("Slack API error: {0}")]
+    Api(String),
+
+    #[error("Slack websocket error: {0}")]
+    Websocket(String),
+
+    #[error("Slack event write error: {0}")]
+    EventWrite(String),
+
+    #[error("Slack config error: {0}")]
+    Config(String),
+
+    #[error("invalid Slack loop id: {0}")]
+    InvalidLoopId(String),
+
+    #[error("Slack HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Slack I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Slack JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -23,6 +23,7 @@ pub struct SlackMessageEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ThreadCommand {
     Help,
+    Repo,
     Status,
     Tail { n: usize },
     Stop,
@@ -61,6 +62,8 @@ pub fn handle_message(
     handle_message_with_repo(
         manager,
         workspace_root,
+        None,
+        None,
         allowed_channels,
         allowed_users,
         event,
@@ -70,6 +73,8 @@ pub fn handle_message(
 pub fn handle_message_with_repo(
     manager: &SlackStateManager,
     workspace_root: &Path,
+    repo_alias: Option<&str>,
+    repo_dir: Option<&Path>,
     allowed_channels: &[String],
     allowed_users: &[String],
     event: SlackMessageEvent,
@@ -143,12 +148,14 @@ pub fn handle_message_with_repo(
         let loop_id = loop_id_for_slack_thread(&event.channel_id, &event.ts);
         validate_loop_id(&loop_id)?;
         let prompt = strip_app_mention(&event.text);
-        manager.bind_thread(
+        manager.bind_thread_with_repo(
             &loop_id,
             &event.channel_id,
             &event.ts,
             user_id,
             workspace_root,
+            repo_alias,
+            repo_dir,
         )?;
         return Ok(HandlerAction::StartLoop {
             loop_id,
@@ -170,6 +177,7 @@ pub fn parse_thread_command(text: &str) -> Option<ThreadCommand> {
     let mut parts = trimmed.split_whitespace();
     match parts.next()? {
         "help" => Some(ThreadCommand::Help),
+        "repo" => Some(ThreadCommand::Repo),
         "status" => Some(ThreadCommand::Status),
         "stop" | "cancel" => Some(ThreadCommand::Stop),
         "tail" => {

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -117,7 +117,7 @@ pub fn handle_message_with_repo(
                 user_id: user_id.to_string(),
             });
         }
-        if binding.status == SlackThreadStatus::Stopped {
+        if binding.status != SlackThreadStatus::Running {
             return Ok(HandlerAction::Ignored);
         }
         let topic = if state.pending_questions.contains_key(&loop_id) {

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -100,10 +100,10 @@ pub fn handle_message_with_repo(
         return Ok(HandlerAction::Ignored);
     }
 
-    if let Some(event_id) = event.event_id.as_deref() {
-        if !manager.mark_event_seen(event_id)? {
-            return Ok(HandlerAction::Duplicate);
-        }
+    if let Some(event_id) = event.event_id.as_deref()
+        && !manager.mark_event_seen(event_id)?
+    {
+        return Ok(HandlerAction::Duplicate);
     }
 
     let thread_ts = event.thread_ts.as_deref().unwrap_or(&event.ts);
@@ -267,10 +267,10 @@ pub fn validate_loop_id(loop_id: &str) -> SlackResult<()> {
 
 fn strip_app_mention(text: &str) -> String {
     let trimmed = text.trim();
-    if let Some(rest) = trimmed.strip_prefix("<@") {
-        if let Some((_, prompt)) = rest.split_once('>') {
-            return prompt.trim().to_string();
-        }
+    if let Some(rest) = trimmed.strip_prefix("<@")
+        && let Some((_, prompt)) = rest.split_once('>')
+    {
+        return prompt.trim().to_string();
     }
     trimmed.to_string()
 }

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{SlackError, SlackResult};
-use crate::state::{SlackStateManager, SlackThreadStatus, thread_key};
+use crate::state::{SlackStateManager, thread_key};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SlackMessageEvent {
@@ -25,6 +25,10 @@ pub enum ThreadCommand {
     Help,
     Status,
     Tail { n: usize },
+    Log { n: usize },
+    Handoff,
+    Repo,
+    Artifacts,
     Stop,
 }
 
@@ -108,6 +112,37 @@ pub fn handle_message_with_repo(
         let Some(binding) = state.threads.get(&loop_id) else {
             return Ok(HandlerAction::Ignored);
         };
+        if binding.status.is_terminal() {
+            if let Some(prompt) = parse_followup_command(&event.text) {
+                let followup_loop_id = loop_id_for_slack_thread(&event.channel_id, &event.ts);
+                validate_loop_id(&followup_loop_id)?;
+                manager.bind_followup_thread(
+                    &followup_loop_id,
+                    &event.channel_id,
+                    &event.ts,
+                    &event.ts,
+                    user_id,
+                    &binding.workspace_root,
+                    &loop_id,
+                )?;
+                return Ok(HandlerAction::StartLoop {
+                    loop_id: followup_loop_id,
+                    prompt,
+                    channel_id: event.channel_id,
+                    thread_ts: event.ts,
+                });
+            }
+            if let Some(command) = parse_thread_command(&event.text) {
+                return Ok(HandlerAction::Command {
+                    command,
+                    loop_id,
+                    channel_id: event.channel_id,
+                    thread_ts: thread_ts.to_string(),
+                    user_id: user_id.to_string(),
+                });
+            }
+            return Ok(HandlerAction::Ignored);
+        }
         if let Some(command) = parse_thread_command(&event.text) {
             return Ok(HandlerAction::Command {
                 command,
@@ -116,9 +151,6 @@ pub fn handle_message_with_repo(
                 thread_ts: thread_ts.to_string(),
                 user_id: user_id.to_string(),
             });
-        }
-        if binding.status != SlackThreadStatus::Running {
-            return Ok(HandlerAction::Ignored);
         }
         let topic = if state.pending_questions.contains_key(&loop_id) {
             "human.response"
@@ -172,6 +204,9 @@ pub fn parse_thread_command(text: &str) -> Option<ThreadCommand> {
         "help" => Some(ThreadCommand::Help),
         "status" => Some(ThreadCommand::Status),
         "stop" | "cancel" => Some(ThreadCommand::Stop),
+        "repo" => Some(ThreadCommand::Repo),
+        "handoff" => Some(ThreadCommand::Handoff),
+        "artifacts" => Some(ThreadCommand::Artifacts),
         "tail" => {
             let n = parts
                 .next()
@@ -180,8 +215,30 @@ pub fn parse_thread_command(text: &str) -> Option<ThreadCommand> {
                 .clamp(1, 25);
             Some(ThreadCommand::Tail { n })
         }
+        "log" => {
+            let n = parts
+                .next()
+                .and_then(|part| part.parse::<usize>().ok())
+                .unwrap_or(20)
+                .clamp(1, 50);
+            Some(ThreadCommand::Log { n })
+        }
         _ => None,
     }
+}
+
+pub fn parse_followup_command(text: &str) -> Option<String> {
+    let trimmed = text.trim().trim_start_matches('/').trim_start_matches('!');
+    let lower = trimmed.to_ascii_lowercase();
+    for prefix in ["followup ", "follow-up ", "fork ", "new work "] {
+        if lower.starts_with(prefix) {
+            let prompt = trimmed[prefix.len()..].trim();
+            if !prompt.is_empty() {
+                return Some(prompt.to_string());
+            }
+        }
+    }
+    None
 }
 
 pub fn loop_id_for_slack_thread(channel_id: &str, thread_ts: &str) -> String {
@@ -247,4 +304,141 @@ fn append_event(path: &Path, topic: &str, payload: &str) -> SlackResult<()> {
     });
     writeln!(file, "{}", serde_json::to_string(&event_json)?)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::SlackThreadStatus;
+
+    fn event(text: &str, ts: &str, thread_ts: Option<&str>) -> SlackMessageEvent {
+        SlackMessageEvent {
+            event_id: Some(format!("evt-{ts}")),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: text.to_string(),
+            ts: ts.to_string(),
+            thread_ts: thread_ts.map(str::to_string),
+            bot_id: None,
+            app_mention: false,
+        }
+    }
+
+    #[test]
+    fn completed_thread_plain_reply_does_not_append_old_loop_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+        manager
+            .bind_thread("slack-C123-1-0", "C123", "1.0", "U123", dir.path())
+            .unwrap();
+        manager
+            .add_pending_question("slack-C123-1-0", "C123", "1.0", "msg-1")
+            .unwrap();
+        manager
+            .finish_thread("slack-C123-1-0", SlackThreadStatus::Completed)
+            .unwrap();
+
+        let action = handle_message(
+            &manager,
+            dir.path(),
+            &["C123".to_string()],
+            &["U123".to_string()],
+            event("please keep going", "1.1", Some("1.0")),
+        )
+        .unwrap();
+
+        assert_eq!(action, HandlerAction::Ignored);
+        assert!(!events_path(dir.path(), "slack-C123-1-0").exists());
+        let state = manager.load_or_default().unwrap();
+        assert!(!state.pending_questions.contains_key("slack-C123-1-0"));
+        assert_eq!(
+            state.threads["slack-C123-1-0"].status,
+            SlackThreadStatus::Completed
+        );
+        assert!(state.threads["slack-C123-1-0"].process_id.is_none());
+    }
+
+    #[test]
+    fn completed_thread_followup_forks_new_bound_loop() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+        manager
+            .bind_thread("slack-C123-1-0", "C123", "1.0", "U123", dir.path())
+            .unwrap();
+        manager
+            .finish_thread("slack-C123-1-0", SlackThreadStatus::Completed)
+            .unwrap();
+
+        let action = handle_message(
+            &manager,
+            dir.path(),
+            &["C123".to_string()],
+            &["U123".to_string()],
+            event("fork add a regression test", "1.2", Some("1.0")),
+        )
+        .unwrap();
+
+        let HandlerAction::StartLoop {
+            loop_id,
+            prompt,
+            channel_id,
+            thread_ts,
+        } = action
+        else {
+            panic!("expected fork to start a new loop");
+        };
+        assert_eq!(loop_id, "slack-C123-1-2");
+        assert_eq!(prompt, "add a regression test");
+        assert_eq!(channel_id, "C123");
+        assert_eq!(thread_ts, "1.2");
+        let state = manager.load_or_default().unwrap();
+        assert_eq!(
+            state.thread_to_loop.get("C123:1.0").map(String::as_str),
+            Some("slack-C123-1-0")
+        );
+        assert_eq!(
+            state.thread_to_loop.get("C123:1.2").map(String::as_str),
+            Some("slack-C123-1-2")
+        );
+        assert_eq!(
+            state.threads["slack-C123-1-2"].parent_loop_id.as_deref(),
+            Some("slack-C123-1-0")
+        );
+        assert_eq!(
+            state.threads["slack-C123-1-2"].status,
+            SlackThreadStatus::Running
+        );
+    }
+
+    #[test]
+    fn completed_thread_read_only_commands_are_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+        manager
+            .bind_thread("slack-C123-1-0", "C123", "1.0", "U123", dir.path())
+            .unwrap();
+        manager
+            .finish_thread("slack-C123-1-0", SlackThreadStatus::Failed)
+            .unwrap();
+
+        let action = handle_message(
+            &manager,
+            dir.path(),
+            &["C123".to_string()],
+            &["U123".to_string()],
+            event("handoff", "1.3", Some("1.0")),
+        )
+        .unwrap();
+
+        assert_eq!(
+            action,
+            HandlerAction::Command {
+                command: ThreadCommand::Handoff,
+                loop_id: "slack-C123-1-0".to_string(),
+                channel_id: "C123".to_string(),
+                thread_ts: "1.0".to_string(),
+                user_id: "U123".to_string(),
+            }
+        );
+    }
 }

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -162,7 +162,11 @@ pub fn handle_message_with_repo(
 }
 
 pub fn parse_thread_command(text: &str) -> Option<ThreadCommand> {
-    let trimmed = text.trim().trim_start_matches('/').to_ascii_lowercase();
+    let trimmed = text
+        .trim()
+        .trim_start_matches('/')
+        .trim_start_matches('!')
+        .to_ascii_lowercase();
     let mut parts = trimmed.split_whitespace();
     match parts.next()? {
         "help" => Some(ThreadCommand::Help),

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -24,6 +24,7 @@ pub struct SlackMessageEvent {
 pub enum ThreadCommand {
     Help,
     Repo,
+    Obs,
     Status,
     Tail { n: usize },
     Log { n: usize },
@@ -209,6 +210,7 @@ pub fn parse_thread_command(text: &str) -> Option<ThreadCommand> {
     match parts.next()? {
         "help" => Some(ThreadCommand::Help),
         "repo" => Some(ThreadCommand::Repo),
+        "obs" | "observe" => Some(ThreadCommand::Obs),
         "status" => Some(ThreadCommand::Status),
         "stop" | "cancel" => Some(ThreadCommand::Stop),
         "handoff" => Some(ThreadCommand::Handoff),

--- a/crates/ralph-slack/src/handler.rs
+++ b/crates/ralph-slack/src/handler.rs
@@ -1,0 +1,246 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SlackError, SlackResult};
+use crate::state::{SlackStateManager, SlackThreadStatus, thread_key};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SlackMessageEvent {
+    pub event_id: Option<String>,
+    pub channel_id: String,
+    pub user_id: Option<String>,
+    pub text: String,
+    pub ts: String,
+    pub thread_ts: Option<String>,
+    pub bot_id: Option<String>,
+    pub app_mention: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadCommand {
+    Help,
+    Status,
+    Tail { n: usize },
+    Stop,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HandlerAction {
+    Ignored,
+    Duplicate,
+    Appended {
+        topic: String,
+        loop_id: String,
+    },
+    Command {
+        command: ThreadCommand,
+        loop_id: String,
+        channel_id: String,
+        thread_ts: String,
+        user_id: String,
+    },
+    StartLoop {
+        loop_id: String,
+        prompt: String,
+        channel_id: String,
+        thread_ts: String,
+    },
+}
+
+pub fn handle_message(
+    manager: &SlackStateManager,
+    workspace_root: &Path,
+    allowed_channels: &[String],
+    allowed_users: &[String],
+    event: SlackMessageEvent,
+) -> SlackResult<HandlerAction> {
+    handle_message_with_repo(
+        manager,
+        workspace_root,
+        allowed_channels,
+        allowed_users,
+        event,
+    )
+}
+
+pub fn handle_message_with_repo(
+    manager: &SlackStateManager,
+    workspace_root: &Path,
+    allowed_channels: &[String],
+    allowed_users: &[String],
+    event: SlackMessageEvent,
+) -> SlackResult<HandlerAction> {
+    if event.bot_id.is_some() {
+        return Ok(HandlerAction::Ignored);
+    }
+    let Some(user_id) = event.user_id.as_deref() else {
+        return Ok(HandlerAction::Ignored);
+    };
+    if allowed_channels.is_empty()
+        || !allowed_channels
+            .iter()
+            .any(|channel| channel == &event.channel_id)
+    {
+        return Ok(HandlerAction::Ignored);
+    }
+    if allowed_users.is_empty() || !allowed_users.iter().any(|user| user == user_id) {
+        return Ok(HandlerAction::Ignored);
+    }
+
+    if let Some(event_id) = event.event_id.as_deref() {
+        if !manager.mark_event_seen(event_id)? {
+            return Ok(HandlerAction::Duplicate);
+        }
+    }
+
+    let thread_ts = event.thread_ts.as_deref().unwrap_or(&event.ts);
+    let state = manager.load_or_default()?;
+    if let Some(loop_id) = state
+        .thread_to_loop
+        .get(&thread_key(&event.channel_id, thread_ts))
+        .cloned()
+    {
+        validate_loop_id(&loop_id)?;
+        let Some(binding) = state.threads.get(&loop_id) else {
+            return Ok(HandlerAction::Ignored);
+        };
+        if let Some(command) = parse_thread_command(&event.text) {
+            return Ok(HandlerAction::Command {
+                command,
+                loop_id,
+                channel_id: event.channel_id,
+                thread_ts: thread_ts.to_string(),
+                user_id: user_id.to_string(),
+            });
+        }
+        if binding.status == SlackThreadStatus::Stopped {
+            return Ok(HandlerAction::Ignored);
+        }
+        let topic = if state.pending_questions.contains_key(&loop_id) {
+            "human.response"
+        } else {
+            "human.guidance"
+        };
+        append_event(
+            &events_path(&binding.workspace_root, &loop_id),
+            topic,
+            &event.text,
+        )?;
+        if topic == "human.response" {
+            manager.remove_pending_question(&loop_id)?;
+        }
+        return Ok(HandlerAction::Appended {
+            topic: topic.to_string(),
+            loop_id,
+        });
+    }
+
+    if event.thread_ts.is_none() && event.app_mention {
+        let loop_id = loop_id_for_slack_thread(&event.channel_id, &event.ts);
+        validate_loop_id(&loop_id)?;
+        let prompt = strip_app_mention(&event.text);
+        manager.bind_thread(
+            &loop_id,
+            &event.channel_id,
+            &event.ts,
+            user_id,
+            workspace_root,
+        )?;
+        return Ok(HandlerAction::StartLoop {
+            loop_id,
+            prompt,
+            channel_id: event.channel_id,
+            thread_ts: event.ts,
+        });
+    }
+
+    Ok(HandlerAction::Ignored)
+}
+
+pub fn parse_thread_command(text: &str) -> Option<ThreadCommand> {
+    let trimmed = text.trim().trim_start_matches('/').to_ascii_lowercase();
+    let mut parts = trimmed.split_whitespace();
+    match parts.next()? {
+        "help" => Some(ThreadCommand::Help),
+        "status" => Some(ThreadCommand::Status),
+        "stop" | "cancel" => Some(ThreadCommand::Stop),
+        "tail" => {
+            let n = parts
+                .next()
+                .and_then(|part| part.parse::<usize>().ok())
+                .unwrap_or(10)
+                .clamp(1, 25);
+            Some(ThreadCommand::Tail { n })
+        }
+        _ => None,
+    }
+}
+
+pub fn loop_id_for_slack_thread(channel_id: &str, thread_ts: &str) -> String {
+    format!("slack-{}-{}", channel_id, thread_ts.replace('.', "-"))
+}
+
+pub fn validate_loop_id(loop_id: &str) -> SlackResult<()> {
+    if loop_id.is_empty()
+        || loop_id.len() > 128
+        || loop_id
+            .chars()
+            .any(|c| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+    {
+        return Err(SlackError::InvalidLoopId(loop_id.to_string()));
+    }
+    Ok(())
+}
+
+fn strip_app_mention(text: &str) -> String {
+    let trimmed = text.trim();
+    if let Some(rest) = trimmed.strip_prefix("<@") {
+        if let Some((_, prompt)) = rest.split_once('>') {
+            return prompt.trim().to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+pub fn events_path(workspace_root: &Path, loop_id: &str) -> PathBuf {
+    let ralph_dir = if loop_id == "main" {
+        workspace_root.join(".ralph")
+    } else {
+        workspace_root
+            .join(".worktrees")
+            .join(loop_id)
+            .join(".ralph")
+    };
+    let marker = ralph_dir.join("current-events");
+    if let Ok(relative) = std::fs::read_to_string(&marker) {
+        let relative = relative.trim();
+        if !relative.is_empty() {
+            if loop_id == "main" {
+                return workspace_root.join(relative);
+            }
+            return workspace_root
+                .join(".worktrees")
+                .join(loop_id)
+                .join(relative);
+        }
+    }
+    ralph_dir.join("events.jsonl")
+}
+
+fn append_event(path: &Path, topic: &str, payload: &str) -> SlackResult<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    let event_json = serde_json::json!({
+        "topic": topic,
+        "payload": payload,
+        "ts": Utc::now().to_rfc3339(),
+    });
+    writeln!(file, "{}", serde_json::to_string(&event_json)?)?;
+    Ok(())
+}

--- a/crates/ralph-slack/src/lib.rs
+++ b/crates/ralph-slack/src/lib.rs
@@ -12,7 +12,7 @@ pub mod service;
 pub mod socket_mode;
 pub mod state;
 
-pub use api::SlackApi;
+pub use api::{SlackApi, SlackStreamChunk};
 pub use daemon::{CommandLoopSpawner, SlackApiNotifier, SlackDaemon, SlackDaemonConfig};
 pub use error::{SlackError, SlackResult};
 pub use handler::{HandlerAction, SlackMessageEvent, handle_message};

--- a/crates/ralph-slack/src/lib.rs
+++ b/crates/ralph-slack/src/lib.rs
@@ -1,0 +1,21 @@
+//! Slack integration seams for Ralph human-in-the-loop surfaces.
+//!
+//! The crate owns Slack Web API calls, loop/thread state, inbound thread routing,
+//! and the loop-local [`SlackService`] implementation of `RobotService`.
+
+pub mod api;
+pub mod daemon;
+pub mod error;
+pub mod handler;
+pub mod service;
+pub mod socket_mode;
+pub mod state;
+
+pub use api::SlackApi;
+pub use daemon::{CommandLoopSpawner, SlackApiNotifier, SlackDaemon, SlackDaemonConfig};
+pub use error::{SlackError, SlackResult};
+pub use handler::{HandlerAction, SlackMessageEvent, handle_message};
+pub use service::SlackService;
+pub use state::{
+    PendingSlackQuestion, SlackState, SlackStateManager, SlackThreadBinding, SlackThreadStatus,
+};

--- a/crates/ralph-slack/src/lib.rs
+++ b/crates/ralph-slack/src/lib.rs
@@ -7,6 +7,7 @@ pub mod api;
 pub mod daemon;
 pub mod error;
 pub mod handler;
+pub mod renderer;
 pub mod service;
 pub mod socket_mode;
 pub mod state;
@@ -15,6 +16,7 @@ pub use api::SlackApi;
 pub use daemon::{CommandLoopSpawner, SlackApiNotifier, SlackDaemon, SlackDaemonConfig};
 pub use error::{SlackError, SlackResult};
 pub use handler::{HandlerAction, SlackMessageEvent, handle_message};
+pub use renderer::{SlackBlocks, SlackRenderedMessage};
 pub use service::SlackService;
 pub use state::{
     PendingSlackQuestion, SlackState, SlackStateManager, SlackThreadBinding, SlackThreadStatus,

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -152,13 +152,13 @@ impl SlackBlocks {
     }
 
     pub fn help_card() -> SlackRenderedMessage {
-        let text = "Ralph Slack commands: help, status, tail [n], stop/cancel. Plain replies become guidance, or answer the pending human question.".to_string();
+        let text = "Ralph Slack commands: help, repo, status, tail [n], stop/cancel. Plain replies become guidance, or answer the pending human question.".to_string();
         SlackRenderedMessage {
             text: text.clone(),
             blocks: vec![
                 header("Ralph Slack help"),
                 section(
-                    "*Commands*\n• `help` — show this help\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `stop` / `cancel` — stop the loop\n\nPlain replies become guidance, or answer the pending human question.",
+                    "*Commands*\n• `help` — show this help\n• `repo` — show bound repo and worktree\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `stop` / `cancel` — stop the loop\n\nPlain replies become guidance, or answer the pending human question.",
                 ),
             ],
         }

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -115,15 +115,7 @@ impl SlackBlocks {
                     format!("*Duration:* {}", escape_mrkdwn(&duration)),
                 ]),
                 section(escape_mrkdwn(note)),
-                actions(
-                    loop_id,
-                    &[
-                        ActionButton::tail(),
-                        ActionButton::status(),
-                        ActionButton::approve(),
-                        ActionButton::request_changes(),
-                    ],
-                ),
+                actions(loop_id, &[ActionButton::tail(), ActionButton::status()]),
             ],
         }
     }
@@ -206,24 +198,6 @@ impl ActionButton {
             action_id: "ralph_slack_stop",
             value: "stop",
             style: Some("danger"),
-        }
-    }
-
-    fn approve() -> Self {
-        Self {
-            text: "Approve",
-            action_id: "ralph_slack_approve",
-            value: "approve",
-            style: Some("primary"),
-        }
-    }
-
-    fn request_changes() -> Self {
-        Self {
-            text: "Request changes",
-            action_id: "ralph_slack_request_changes",
-            value: "request_changes",
-            style: None,
         }
     }
 }

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -44,6 +44,7 @@ impl SlackBlocks {
                     loop_id,
                     &[
                         ActionButton::status(),
+                        ActionButton::obs(),
                         ActionButton::tail(),
                         ActionButton::stop(),
                     ],
@@ -104,7 +105,7 @@ impl SlackBlocks {
         let duration = duration_secs
             .map(|secs| format!("{}s", secs))
             .unwrap_or_else(|| "unknown".to_string());
-        let note = note.unwrap_or("This thread is now read-only. Try `status`, `tail 10`, `log 20`, `handoff`, `repo`, or `artifacts`; use `followup <prompt>` or `fork <prompt>` for new work.");
+        let note = note.unwrap_or("This thread is now read-only. Try `obs`, `status`, `tail 10`, `log 20`, `handoff`, `repo`, or `artifacts`; use `followup <prompt>` or `fork <prompt>` for new work.");
         SlackRenderedMessage {
             text: format!("Ralph loop {status_label}\nLoop: {loop_id}\n{note}"),
             blocks: vec![
@@ -115,7 +116,14 @@ impl SlackBlocks {
                     format!("*Duration:* {}", escape_mrkdwn(&duration)),
                 ]),
                 section(escape_mrkdwn(note)),
-                actions(loop_id, &[ActionButton::tail(), ActionButton::status()]),
+                actions(
+                    loop_id,
+                    &[
+                        ActionButton::obs(),
+                        ActionButton::tail(),
+                        ActionButton::status(),
+                    ],
+                ),
             ],
         }
     }
@@ -146,19 +154,26 @@ impl SlackBlocks {
                     pending,
                     escape_mrkdwn(&process)
                 )),
-                actions(loop_id, &[ActionButton::tail(), ActionButton::stop()]),
+                actions(
+                    loop_id,
+                    &[
+                        ActionButton::obs(),
+                        ActionButton::tail(),
+                        ActionButton::stop(),
+                    ],
+                ),
             ],
         }
     }
 
     pub fn help_card() -> SlackRenderedMessage {
-        let text = "Ralph Slack commands: help, repo, status, tail [n], log [n], handoff, artifacts, stop/cancel. Completed threads are read-only; use followup <prompt> or fork <prompt> for new work.".to_string();
+        let text = "Ralph Slack commands: help, repo, obs, status, tail [n], log [n], handoff, artifacts, stop/cancel. Completed threads are read-only; use followup <prompt> or fork <prompt> for new work.".to_string();
         SlackRenderedMessage {
             text: text.clone(),
             blocks: vec![
                 header("Ralph Slack help"),
                 section(
-                    "*Commands*\n• `help` — show this help\n• `repo` — show bound repo/worktree information\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `log [n]` — show recent process log lines\n• `handoff` — show the loop summary when present\n• `artifacts` — list local artifacts\n• `stop` / `cancel` — stop the running loop\n\nPlain replies in running threads become guidance, or answer the pending human question. Completed, failed, and stopped threads are read-only audit records; use `followup <prompt>` or `fork <prompt>` to start new work linked to the archived loop.",
+                    "*Commands*\n• `help` — show this help\n• `repo` — show bound repo/worktree information\n• `obs` / `observe` — show the loop observability snapshot\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `log [n]` — show recent process log lines\n• `handoff` — show the loop summary when present\n• `artifacts` — list local artifacts\n• `stop` / `cancel` — stop the running loop\n\nPlain replies in running threads become guidance, or answer the pending human question. Completed, failed, and stopped threads are read-only audit records; use `followup <prompt>` or `fork <prompt>` to start new work linked to the archived loop.",
                 ),
             ],
         }
@@ -188,6 +203,15 @@ impl ActionButton {
             text: "Tail 10",
             action_id: "ralph_slack_tail",
             value: "tail",
+            style: None,
+        }
+    }
+
+    fn obs() -> Self {
+        Self {
+            text: "Obs",
+            action_id: "ralph_slack_obs",
+            value: "obs",
             style: None,
         }
     }

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -115,7 +115,15 @@ impl SlackBlocks {
                     format!("*Duration:* {}", escape_mrkdwn(&duration)),
                 ]),
                 section(escape_mrkdwn(note)),
-                actions(loop_id, &[ActionButton::tail(), ActionButton::status()]),
+                actions(
+                    loop_id,
+                    &[
+                        ActionButton::tail(),
+                        ActionButton::status(),
+                        ActionButton::approve(),
+                        ActionButton::request_changes(),
+                    ],
+                ),
             ],
         }
     }
@@ -185,7 +193,7 @@ impl ActionButton {
 
     fn tail() -> Self {
         Self {
-            text: "Tail",
+            text: "Tail 10",
             action_id: "ralph_slack_tail",
             value: "tail",
             style: None,
@@ -194,10 +202,28 @@ impl ActionButton {
 
     fn stop() -> Self {
         Self {
-            text: "Stop",
+            text: "Stop/Cancel",
             action_id: "ralph_slack_stop",
             value: "stop",
             style: Some("danger"),
+        }
+    }
+
+    fn approve() -> Self {
+        Self {
+            text: "Approve",
+            action_id: "ralph_slack_approve",
+            value: "approve",
+            style: Some("primary"),
+        }
+    }
+
+    fn request_changes() -> Self {
+        Self {
+            text: "Request changes",
+            action_id: "ralph_slack_request_changes",
+            value: "request_changes",
+            style: None,
         }
     }
 }

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -104,7 +104,7 @@ impl SlackBlocks {
         let duration = duration_secs
             .map(|secs| format!("{}s", secs))
             .unwrap_or_else(|| "unknown".to_string());
-        let note = note.unwrap_or("Try `tail 10` in this thread for recent events.");
+        let note = note.unwrap_or("This thread is now read-only. Try `status`, `tail 10`, `log 20`, `handoff`, `repo`, or `artifacts`; use `followup <prompt>` or `fork <prompt>` for new work.");
         SlackRenderedMessage {
             text: format!("Ralph loop {status_label}\nLoop: {loop_id}\n{note}"),
             blocks: vec![
@@ -152,13 +152,13 @@ impl SlackBlocks {
     }
 
     pub fn help_card() -> SlackRenderedMessage {
-        let text = "Ralph Slack commands: help, status, tail [n], stop/cancel. Plain replies become guidance, or answer the pending human question.".to_string();
+        let text = "Ralph Slack commands: help, status, tail [n], log [n], handoff, repo, artifacts, stop/cancel. Completed threads are read-only; use followup <prompt> or fork <prompt> for new work.".to_string();
         SlackRenderedMessage {
             text: text.clone(),
             blocks: vec![
                 header("Ralph Slack help"),
                 section(
-                    "*Commands*\n• `help` — show this help\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `stop` / `cancel` — stop the loop\n\nPlain replies become guidance, or answer the pending human question.",
+                    "*Commands*\n• `help` — show this help\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `log [n]` — show recent process log lines\n• `handoff` — show the loop summary when present\n• `repo` — show repo/worktree information\n• `artifacts` — list local artifacts\n• `stop` / `cancel` — stop the running loop\n\nPlain replies in running threads become guidance, or answer the pending human question. Completed, failed, and stopped threads are read-only audit records; use `followup <prompt>` or `fork <prompt>` to start new work linked to the archived loop.",
                 ),
             ],
         }

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -73,7 +73,7 @@ impl SlackBlocks {
             last_message.push('…');
         }
         let text = format!(
-            "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nTopic: {topic}\nLast message:\n```\n{last_message}\n```"
+            "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nElapsed: {elapsed}\nTopic: {topic}\nLast message:\n```\n{last_message}\n```"
         );
         SlackRenderedMessage {
             text,

--- a/crates/ralph-slack/src/renderer.rs
+++ b/crates/ralph-slack/src/renderer.rs
@@ -1,0 +1,295 @@
+use serde_json::{Value, json};
+
+use crate::state::SlackThreadStatus;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SlackRenderedMessage {
+    pub text: String,
+    pub blocks: Vec<Value>,
+}
+
+pub struct SlackBlocks;
+
+impl SlackBlocks {
+    pub fn start_card(
+        loop_id: &str,
+        prompt: &str,
+        repo: Option<&str>,
+        branch: Option<&str>,
+    ) -> SlackRenderedMessage {
+        let prompt = truncate(prompt, 700);
+        let text =
+            format!("🤖 Ralph loop started\nLoop: {loop_id}\nStatus: running\nPrompt: {prompt}");
+        SlackRenderedMessage {
+            text,
+            blocks: vec![
+                header("🤖 Ralph loop started"),
+                context(vec![
+                    format!("*Status:* Running"),
+                    format!("*Loop:* `{}`", escape_mrkdwn(loop_id)),
+                    format!(
+                        "*Repo:* {}",
+                        repo.map(escape_mrkdwn)
+                            .unwrap_or_else(|| "unknown".to_string())
+                    ),
+                    format!(
+                        "*Branch:* {}",
+                        branch
+                            .map(escape_mrkdwn)
+                            .unwrap_or_else(|| "unknown".to_string())
+                    ),
+                ]),
+                section(format!("*Prompt*\n{}", escape_mrkdwn(&prompt))),
+                actions(
+                    loop_id,
+                    &[
+                        ActionButton::status(),
+                        ActionButton::tail(),
+                        ActionButton::stop(),
+                    ],
+                ),
+            ],
+        }
+    }
+
+    pub fn progress_card(
+        loop_id: &str,
+        iteration: Option<u64>,
+        hat: Option<&str>,
+        topic: &str,
+        last_message: &str,
+        elapsed_secs: Option<u64>,
+    ) -> SlackRenderedMessage {
+        let iteration = iteration
+            .map(|iteration| iteration.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        let hat = hat.unwrap_or("agent");
+        let elapsed = elapsed_secs
+            .map(|secs| format!("{}s", secs))
+            .unwrap_or_else(|| "unknown".to_string());
+        let mut last_message = redact_secrets(last_message);
+        if last_message.len() > 1000 {
+            last_message.truncate(1000);
+            last_message.push('…');
+        }
+        let text = format!(
+            "Ralph update\nLoop: {loop_id}\nIteration: {iteration}\nHat: {hat}\nTopic: {topic}\nLast message:\n```\n{last_message}\n```"
+        );
+        SlackRenderedMessage {
+            text,
+            blocks: vec![
+                header("⚙️ Ralph update"),
+                context(vec![
+                    format!("*Loop:* `{}`", escape_mrkdwn(loop_id)),
+                    format!("*Iteration:* {}", escape_mrkdwn(&iteration)),
+                    format!("*Hat:* {}", escape_mrkdwn(hat)),
+                    format!("*Elapsed:* {}", escape_mrkdwn(&elapsed)),
+                ]),
+                section(format!("*Topic:* {}", escape_mrkdwn(topic))),
+                section(format!(
+                    "*Last message*\n```\n{}\n```",
+                    escape_code_block(&last_message)
+                )),
+            ],
+        }
+    }
+
+    pub fn final_card(
+        loop_id: &str,
+        status: SlackThreadStatus,
+        duration_secs: Option<u64>,
+        note: Option<&str>,
+    ) -> SlackRenderedMessage {
+        let status_label = status_label(&status);
+        let duration = duration_secs
+            .map(|secs| format!("{}s", secs))
+            .unwrap_or_else(|| "unknown".to_string());
+        let note = note.unwrap_or("Try `tail 10` in this thread for recent events.");
+        SlackRenderedMessage {
+            text: format!("Ralph loop {status_label}\nLoop: {loop_id}\n{note}"),
+            blocks: vec![
+                header(format!("Ralph loop {status_label}")),
+                context(vec![
+                    format!("*Status:* {}", title_case(status_label)),
+                    format!("*Loop:* `{}`", escape_mrkdwn(loop_id)),
+                    format!("*Duration:* {}", escape_mrkdwn(&duration)),
+                ]),
+                section(escape_mrkdwn(note)),
+                actions(loop_id, &[ActionButton::tail(), ActionButton::status()]),
+            ],
+        }
+    }
+
+    pub fn status_card(
+        loop_id: &str,
+        status: SlackThreadStatus,
+        repo: &str,
+        pending_question: bool,
+        process_id: Option<u32>,
+    ) -> SlackRenderedMessage {
+        let status_label = status_label(&status);
+        let pending = if pending_question { "yes" } else { "no" };
+        let process = process_id
+            .map(|pid| pid.to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        SlackRenderedMessage {
+            text: format!(
+                "Ralph thread status\nloop: {loop_id}\nrepo: {repo}\nthread status: {status_label}\npending question: {pending}\nprocess id: {process}"
+            ),
+            blocks: vec![
+                header("Ralph thread status"),
+                section(format!(
+                    "*Loop:* `{}`\n*Repo:* {}\n*Thread status:* {}\n*Pending question:* {}\n*Process id:* `{}`",
+                    escape_mrkdwn(loop_id),
+                    escape_mrkdwn(repo),
+                    title_case(status_label),
+                    pending,
+                    escape_mrkdwn(&process)
+                )),
+                actions(loop_id, &[ActionButton::tail(), ActionButton::stop()]),
+            ],
+        }
+    }
+
+    pub fn help_card() -> SlackRenderedMessage {
+        let text = "Ralph Slack commands: help, status, tail [n], stop/cancel. Plain replies become guidance, or answer the pending human question.".to_string();
+        SlackRenderedMessage {
+            text: text.clone(),
+            blocks: vec![
+                header("Ralph Slack help"),
+                section(
+                    "*Commands*\n• `help` — show this help\n• `status` — show loop status\n• `tail [n]` — show recent events\n• `stop` / `cancel` — stop the loop\n\nPlain replies become guidance, or answer the pending human question.",
+                ),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ActionButton {
+    text: &'static str,
+    action_id: &'static str,
+    value: &'static str,
+    style: Option<&'static str>,
+}
+
+impl ActionButton {
+    fn status() -> Self {
+        Self {
+            text: "Status",
+            action_id: "ralph_slack_status",
+            value: "status",
+            style: None,
+        }
+    }
+
+    fn tail() -> Self {
+        Self {
+            text: "Tail",
+            action_id: "ralph_slack_tail",
+            value: "tail",
+            style: None,
+        }
+    }
+
+    fn stop() -> Self {
+        Self {
+            text: "Stop",
+            action_id: "ralph_slack_stop",
+            value: "stop",
+            style: Some("danger"),
+        }
+    }
+}
+
+fn header(text: impl Into<String>) -> Value {
+    json!({
+        "type": "header",
+        "text": {"type": "plain_text", "text": truncate(&text.into(), 150), "emoji": true}
+    })
+}
+
+fn section(text: impl Into<String>) -> Value {
+    json!({
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": truncate(&text.into(), 3000)}
+    })
+}
+
+fn context(elements: Vec<String>) -> Value {
+    json!({
+        "type": "context",
+        "elements": elements.into_iter().map(|text| json!({"type": "mrkdwn", "text": truncate(&text, 300)})).collect::<Vec<_>>()
+    })
+}
+
+fn actions(loop_id: &str, buttons: &[ActionButton]) -> Value {
+    json!({
+        "type": "actions",
+        "elements": buttons.iter().map(|button| {
+            let mut value = json!({
+                "type": "button",
+                "text": {"type": "plain_text", "text": button.text, "emoji": true},
+                "action_id": button.action_id,
+                "value": if button.value == "status" { loop_id.to_string() } else { format!("{}:{}", button.value, loop_id) }
+            });
+            if let Some(style) = button.style {
+                value["style"] = json!(style);
+            }
+            value
+        }).collect::<Vec<_>>()
+    })
+}
+
+pub(crate) fn redact_secrets(text: &str) -> String {
+    let mut out = text.to_string();
+    for marker in ["secret-token-", "token-", "xoxb-", "xapp-"] {
+        while let Some(start) = out.to_ascii_lowercase().find(marker) {
+            let end = out[start..]
+                .find(|c: char| c.is_whitespace() || c == '"' || c == '\'')
+                .map(|offset| start + offset)
+                .unwrap_or(out.len());
+            out.replace_range(start..end, "[redacted]");
+        }
+    }
+    out
+}
+
+fn status_label(status: &SlackThreadStatus) -> &'static str {
+    match status {
+        SlackThreadStatus::Running => "running",
+        SlackThreadStatus::Completed => "completed",
+        SlackThreadStatus::Failed => "failed",
+        SlackThreadStatus::Stopped => "stopped",
+    }
+}
+
+fn title_case(text: &str) -> String {
+    let mut chars = text.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn escape_mrkdwn(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_code_block(text: &str) -> String {
+    text.replace("```", "`\u{200b}`\u{200b}`")
+}
+
+fn truncate(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    let mut out = text
+        .chars()
+        .take(limit.saturating_sub(1))
+        .collect::<String>();
+    out.push('…');
+    out
+}

--- a/crates/ralph-slack/src/service.rs
+++ b/crates/ralph-slack/src/service.rs
@@ -10,6 +10,7 @@ use crate::state::SlackStateManager;
 
 #[derive(Debug, Clone)]
 pub struct SlackService {
+    workspace_root: PathBuf,
     timeout_secs: u64,
     loop_id: String,
     channel_id: String,
@@ -35,6 +36,7 @@ impl SlackService {
             .ok_or(SlackError::MissingBotToken)?;
         let state_path = workspace_root.join(".ralph/slack-state.json");
         Ok(Self {
+            workspace_root,
             timeout_secs,
             loop_id,
             channel_id,
@@ -84,6 +86,24 @@ impl SlackService {
         Ok(1)
     }
 
+    pub fn send_file(&self, file_path: &Path, caption: Option<&str>) -> SlackResult<i32> {
+        let (canonical_path, filename, length) = self.validate_upload_path(file_path)?;
+        let handle = tokio::runtime::Handle::try_current().map_err(|_| {
+            SlackError::Api("no tokio runtime available for Slack API call".to_string())
+        })?;
+        tokio::task::block_in_place(|| {
+            handle.block_on(self.api.upload_file_external(
+                &self.channel_id,
+                &self.thread_ts,
+                &canonical_path,
+                &filename,
+                length,
+                caption,
+            ))
+        })?;
+        Ok(1)
+    }
+
     pub fn wait_for_response(&self, events_path: &Path) -> SlackResult<Option<String>> {
         let deadline = Instant::now() + Duration::from_secs(self.timeout_secs);
         let mut file_pos = if events_path.exists() {
@@ -119,6 +139,31 @@ impl SlackService {
         self.shutdown.store(true, Ordering::Relaxed);
     }
 
+    fn validate_upload_path(&self, file_path: &Path) -> SlackResult<(PathBuf, String, u64)> {
+        let canonical_root = self.workspace_root.canonicalize()?;
+        let canonical_path = file_path.canonicalize()?;
+        if !canonical_path.starts_with(&canonical_root) {
+            return Err(SlackError::FilePath(format!(
+                "{} is outside workspace {}",
+                canonical_path.display(),
+                canonical_root.display()
+            )));
+        }
+        let metadata = std::fs::metadata(&canonical_path)?;
+        if !metadata.is_file() {
+            return Err(SlackError::FilePath(format!(
+                "{} is not a regular file",
+                canonical_path.display()
+            )));
+        }
+        let filename = canonical_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| SlackError::FilePath("file name is not valid UTF-8".to_string()))?
+            .to_string();
+        Ok((canonical_path, filename, metadata.len()))
+    }
+
     fn post_thread_message(&self, text: &str) -> SlackResult<String> {
         let handle = tokio::runtime::Handle::try_current().map_err(|_| {
             SlackError::Api("no tokio runtime available for Slack API call".to_string())
@@ -150,6 +195,10 @@ impl ralph_proto::RobotService for SlackService {
         Ok(SlackService::send_checkin(
             self, iteration, elapsed, context,
         )?)
+    }
+
+    fn send_file(&self, file_path: &Path, caption: Option<&str>) -> anyhow::Result<i32> {
+        Ok(SlackService::send_file(self, file_path, caption)?)
     }
 
     fn timeout_secs(&self) -> u64 {

--- a/crates/ralph-slack/src/service.rs
+++ b/crates/ralph-slack/src/service.rs
@@ -252,16 +252,16 @@ fn check_for_response(events_path: &Path, file_pos: &mut u64) -> SlackResult<Opt
         if line.trim().is_empty() {
             continue;
         }
-        if let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) {
-            if event.get("topic").and_then(|topic| topic.as_str()) == Some("human.response") {
-                return Ok(Some(
-                    event
-                        .get("payload")
-                        .and_then(|payload| payload.as_str())
-                        .unwrap_or_default()
-                        .to_string(),
-                ));
-            }
+        if let Ok(event) = serde_json::from_str::<serde_json::Value>(&line)
+            && event.get("topic").and_then(|topic| topic.as_str()) == Some("human.response")
+        {
+            return Ok(Some(
+                event
+                    .get("payload")
+                    .and_then(|payload| payload.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            ));
         }
     }
     Ok(None)

--- a/crates/ralph-slack/src/service.rs
+++ b/crates/ralph-slack/src/service.rs
@@ -1,0 +1,196 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::api::SlackApi;
+use crate::error::{SlackError, SlackResult};
+use crate::handler::validate_loop_id;
+use crate::state::SlackStateManager;
+
+#[derive(Debug, Clone)]
+pub struct SlackService {
+    timeout_secs: u64,
+    loop_id: String,
+    channel_id: String,
+    thread_ts: String,
+    api: SlackApi,
+    state_manager: SlackStateManager,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl SlackService {
+    pub fn new(
+        workspace_root: PathBuf,
+        bot_token: Option<String>,
+        timeout_secs: u64,
+        loop_id: String,
+        channel_id: String,
+        thread_ts: String,
+        api_base_url: Option<String>,
+    ) -> SlackResult<Self> {
+        validate_loop_id(&loop_id)?;
+        let resolved_token = bot_token
+            .or_else(|| std::env::var("RALPH_SLACK_BOT_TOKEN").ok())
+            .ok_or(SlackError::MissingBotToken)?;
+        let state_path = workspace_root.join(".ralph/slack-state.json");
+        Ok(Self {
+            timeout_secs,
+            loop_id,
+            channel_id,
+            thread_ts,
+            api: SlackApi::new(resolved_token, api_base_url),
+            state_manager: SlackStateManager::new(state_path),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    pub fn state_manager(&self) -> &SlackStateManager {
+        &self.state_manager
+    }
+
+    pub fn send_question(&self, payload: &str) -> SlackResult<i32> {
+        let ts = self.post_thread_message(payload)?;
+        self.state_manager.add_pending_question(
+            &self.loop_id,
+            &self.channel_id,
+            &self.thread_ts,
+            &ts,
+        )?;
+        Ok(1)
+    }
+
+    pub fn send_checkin(
+        &self,
+        iteration: u32,
+        elapsed: Duration,
+        context: Option<&ralph_proto::CheckinContext>,
+    ) -> SlackResult<i32> {
+        let mut message = format!(
+            "Ralph check-in: iteration {} after {}s",
+            iteration,
+            elapsed.as_secs()
+        );
+        if let Some(context) = context {
+            if let Some(hat) = &context.current_hat {
+                message.push_str(&format!("; hat {}", hat));
+            }
+            message.push_str(&format!(
+                "; tasks {}/{}; cost ${:.4}",
+                context.closed_tasks, context.open_tasks, context.cumulative_cost
+            ));
+        }
+        self.post_thread_message(&message)?;
+        Ok(1)
+    }
+
+    pub fn wait_for_response(&self, events_path: &Path) -> SlackResult<Option<String>> {
+        let deadline = Instant::now() + Duration::from_secs(self.timeout_secs);
+        let mut file_pos = if events_path.exists() {
+            std::fs::metadata(events_path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        loop {
+            if self.shutdown.load(Ordering::Relaxed) || Instant::now() >= deadline {
+                let _ = self.state_manager.remove_pending_question(&self.loop_id);
+                return Ok(None);
+            }
+            if let Some(response) = check_for_response(events_path, &mut file_pos)? {
+                let _ = self.state_manager.remove_pending_question(&self.loop_id);
+                return Ok(Some(response));
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+    }
+
+    pub fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        self.shutdown.clone()
+    }
+
+    pub fn timeout_secs(&self) -> u64 {
+        self.timeout_secs
+    }
+
+    pub fn stop(self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+    }
+
+    fn post_thread_message(&self, text: &str) -> SlackResult<String> {
+        let handle = tokio::runtime::Handle::try_current().map_err(|_| {
+            SlackError::Api("no tokio runtime available for Slack API call".to_string())
+        })?;
+        tokio::task::block_in_place(|| {
+            handle.block_on(
+                self.api
+                    .post_message(&self.channel_id, Some(&self.thread_ts), text),
+            )
+        })
+    }
+}
+
+impl ralph_proto::RobotService for SlackService {
+    fn send_question(&self, payload: &str) -> anyhow::Result<i32> {
+        Ok(SlackService::send_question(self, payload)?)
+    }
+
+    fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>> {
+        Ok(SlackService::wait_for_response(self, events_path)?)
+    }
+
+    fn send_checkin(
+        &self,
+        iteration: u32,
+        elapsed: Duration,
+        context: Option<&ralph_proto::CheckinContext>,
+    ) -> anyhow::Result<i32> {
+        Ok(SlackService::send_checkin(
+            self, iteration, elapsed, context,
+        )?)
+    }
+
+    fn timeout_secs(&self) -> u64 {
+        self.timeout_secs
+    }
+
+    fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        self.shutdown.clone()
+    }
+
+    fn stop(self: Box<Self>) {
+        SlackService::stop(*self);
+    }
+}
+
+fn check_for_response(events_path: &Path, file_pos: &mut u64) -> SlackResult<Option<String>> {
+    use std::io::{BufRead, BufReader, Seek, SeekFrom};
+
+    if !events_path.exists() {
+        return Ok(None);
+    }
+    let mut file = std::fs::File::open(events_path)?;
+    file.seek(SeekFrom::Start(*file_pos))?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        *file_pos += line.len() as u64 + 1;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) {
+            if event.get("topic").and_then(|topic| topic.as_str()) == Some("human.response") {
+                return Ok(Some(
+                    event
+                        .get("payload")
+                        .and_then(|payload| payload.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/crates/ralph-slack/src/service.rs
+++ b/crates/ralph-slack/src/service.rs
@@ -30,11 +30,34 @@ impl SlackService {
         thread_ts: String,
         api_base_url: Option<String>,
     ) -> SlackResult<Self> {
+        Self::new_with_state_path(
+            workspace_root,
+            bot_token,
+            timeout_secs,
+            loop_id,
+            channel_id,
+            thread_ts,
+            api_base_url,
+            None,
+        )
+    }
+
+    pub fn new_with_state_path(
+        workspace_root: PathBuf,
+        bot_token: Option<String>,
+        timeout_secs: u64,
+        loop_id: String,
+        channel_id: String,
+        thread_ts: String,
+        api_base_url: Option<String>,
+        state_path: Option<PathBuf>,
+    ) -> SlackResult<Self> {
         validate_loop_id(&loop_id)?;
         let resolved_token = bot_token
             .or_else(|| std::env::var("RALPH_SLACK_BOT_TOKEN").ok())
             .ok_or(SlackError::MissingBotToken)?;
-        let state_path = workspace_root.join(".ralph/slack-state.json");
+        let state_path =
+            state_path.unwrap_or_else(|| workspace_root.join(".ralph/slack-state.json"));
         Ok(Self {
             workspace_root,
             timeout_secs,

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -43,7 +43,7 @@ where
                 let envelope: SocketEnvelope = serde_json::from_str(&text)?;
                 if let Some(envelope_id) = envelope.envelope_id.as_deref() {
                     ws.send(Message::Text(
-                        json!({"envelope_id": envelope_id}).to_string().into(),
+                        json!({"envelope_id": envelope_id}).to_string(),
                     ))
                     .await?;
                 }

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -139,8 +139,9 @@ fn block_action_event(payload: &serde_json::Value) -> Option<SlackMessageEvent> 
                 .and_then(|container| container.get("thread_ts"))
         })
         .and_then(|value| value.as_str())
-        .unwrap_or(message_ts)
-        .to_string();
+        .map(str::to_string)
+        .or_else(|| thread_ts_from_action_value(action, &channel_id))
+        .unwrap_or_else(|| message_ts.to_string());
     let ts = payload
         .get("action_ts")
         .and_then(|value| value.as_str())
@@ -162,6 +163,20 @@ fn block_action_event(payload: &serde_json::Value) -> Option<SlackMessageEvent> 
         bot_id: None,
         app_mention: false,
     })
+}
+
+fn thread_ts_from_action_value(action: &serde_json::Value, channel_id: &str) -> Option<String> {
+    let value = action.get("value")?.as_str()?;
+    let loop_id = value
+        .split_once(':')
+        .map(|(_, loop_id)| loop_id)
+        .unwrap_or(value);
+    let ts_slug = loop_id.strip_prefix(&format!("slack-{channel_id}-"))?;
+    let (seconds, micros) = ts_slug.split_once('-')?;
+    if seconds.chars().all(|c| c.is_ascii_digit()) && micros.chars().all(|c| c.is_ascii_digit()) {
+        return Some(format!("{seconds}.{micros}"));
+    }
+    None
 }
 
 fn block_action_text(action_id: &str) -> Option<&'static str> {

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -10,7 +10,8 @@ use crate::handler::SlackMessageEvent;
 
 #[derive(Debug, Deserialize)]
 pub struct SocketEnvelope {
-    pub envelope_id: String,
+    #[serde(default)]
+    pub envelope_id: Option<String>,
     #[serde(default)]
     pub payload: serde_json::Value,
 }
@@ -27,12 +28,12 @@ where
             continue;
         };
         let envelope: SocketEnvelope = serde_json::from_str(&text)?;
-        ws.send(Message::Text(
-            json!({"envelope_id": envelope.envelope_id})
-                .to_string()
-                .into(),
-        ))
-        .await?;
+        if let Some(envelope_id) = envelope.envelope_id.as_deref() {
+            ws.send(Message::Text(
+                json!({"envelope_id": envelope_id}).to_string().into(),
+            ))
+            .await?;
+        }
         if let Some(event) = slack_message_event_from_payload(&envelope.payload) {
             daemon.handle_event(event).await?;
         }

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -1,0 +1,127 @@
+use futures::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::json;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::daemon::{LoopSpawner, SlackDaemon, ThreadNotifier};
+use crate::error::{SlackError, SlackResult};
+use crate::handler::SlackMessageEvent;
+
+#[derive(Debug, Deserialize)]
+pub struct SocketEnvelope {
+    pub envelope_id: String,
+    #[serde(default)]
+    pub payload: serde_json::Value,
+}
+
+pub async fn run_socket_mode<S, N>(socket_url: &str, daemon: SlackDaemon<S, N>) -> SlackResult<()>
+where
+    S: LoopSpawner,
+    N: ThreadNotifier,
+{
+    let (mut ws, _) = connect_async(socket_url).await?;
+    while let Some(message) = ws.next().await {
+        let message = message?;
+        let Message::Text(text) = message else {
+            continue;
+        };
+        let envelope: SocketEnvelope = serde_json::from_str(&text)?;
+        ws.send(Message::Text(
+            json!({"envelope_id": envelope.envelope_id})
+                .to_string()
+                .into(),
+        ))
+        .await?;
+        if let Some(event) = slack_message_event_from_payload(&envelope.payload) {
+            daemon.handle_event(event).await?;
+        }
+    }
+    Ok(())
+}
+
+pub fn slack_message_event_from_payload(payload: &serde_json::Value) -> Option<SlackMessageEvent> {
+    if payload.get("type").and_then(|value| value.as_str()) == Some("slash_commands") {
+        return slash_command_event(payload);
+    }
+
+    let event = payload.get("event")?;
+    let event_type = event.get("type").and_then(|value| value.as_str())?;
+    if event_type != "app_mention" && event_type != "message" {
+        return None;
+    }
+
+    let channel_id = event.get("channel")?.as_str()?.to_string();
+    let text = event
+        .get("text")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let ts = event.get("ts")?.as_str()?.to_string();
+    let user_id = event
+        .get("user")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let thread_ts = event
+        .get("thread_ts")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let bot_id = event
+        .get("bot_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+    let event_id = payload
+        .get("event_id")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
+    Some(SlackMessageEvent {
+        event_id,
+        channel_id,
+        user_id,
+        text,
+        ts,
+        thread_ts,
+        bot_id,
+        app_mention: event_type == "app_mention",
+    })
+}
+
+fn slash_command_event(payload: &serde_json::Value) -> Option<SlackMessageEvent> {
+    let channel_id = payload.get("channel_id")?.as_str()?.to_string();
+    let user_id = payload.get("user_id")?.as_str()?.to_string();
+    let text = payload
+        .get("text")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let trigger_id = payload
+        .get("trigger_id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("slash");
+    let ts = payload
+        .get("message_ts")
+        .or_else(|| payload.get("thread_ts"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| trigger_id.replace('.', "-"));
+    Some(SlackMessageEvent {
+        event_id: payload
+            .get("envelope_id")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        channel_id,
+        user_id: Some(user_id),
+        text,
+        ts,
+        thread_ts: None,
+        bot_id: None,
+        app_mention: true,
+    })
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for SlackError {
+    fn from(error: tokio_tungstenite::tungstenite::Error) -> Self {
+        SlackError::Websocket(error.to_string())
+    }
+}

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -22,20 +22,40 @@ where
     N: ThreadNotifier,
 {
     let (mut ws, _) = connect_async(socket_url).await?;
-    while let Some(message) = ws.next().await {
-        let message = message?;
-        let Message::Text(text) = message else {
-            continue;
-        };
-        let envelope: SocketEnvelope = serde_json::from_str(&text)?;
-        if let Some(envelope_id) = envelope.envelope_id.as_deref() {
-            ws.send(Message::Text(
-                json!({"envelope_id": envelope_id}).to_string().into(),
-            ))
-            .await?;
-        }
-        if let Some(event) = slack_message_event_from_payload(&envelope.payload) {
-            daemon.handle_event(event).await?;
+    if let Err(error) = daemon.reconcile_stale_threads().await {
+        tracing::warn!(
+            ?error,
+            "failed to reconcile stale Slack threads on Socket Mode startup"
+        );
+    }
+    let mut reconcile_interval = tokio::time::interval(std::time::Duration::from_secs(30));
+    reconcile_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            message = ws.next() => {
+                let Some(message) = message else {
+                    break;
+                };
+                let message = message?;
+                let Message::Text(text) = message else {
+                    continue;
+                };
+                let envelope: SocketEnvelope = serde_json::from_str(&text)?;
+                if let Some(envelope_id) = envelope.envelope_id.as_deref() {
+                    ws.send(Message::Text(
+                        json!({"envelope_id": envelope_id}).to_string().into(),
+                    ))
+                    .await?;
+                }
+                if let Some(event) = slack_message_event_from_payload(&envelope.payload) {
+                    daemon.handle_event(event).await?;
+                }
+            }
+            _ = reconcile_interval.tick() => {
+                if let Err(error) = daemon.reconcile_stale_threads().await {
+                    tracing::warn!(?error, "failed to reconcile stale Slack threads");
+                }
+            }
         }
     }
     Ok(())

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -42,8 +42,10 @@ where
 }
 
 pub fn slack_message_event_from_payload(payload: &serde_json::Value) -> Option<SlackMessageEvent> {
-    if payload.get("type").and_then(|value| value.as_str()) == Some("slash_commands") {
-        return slash_command_event(payload);
+    match payload.get("type").and_then(|value| value.as_str()) {
+        Some("slash_commands") => return slash_command_event(payload),
+        Some("block_actions") => return block_action_event(payload),
+        _ => {}
     }
 
     let event = payload.get("event")?;
@@ -119,6 +121,58 @@ fn slash_command_event(payload: &serde_json::Value) -> Option<SlackMessageEvent>
         bot_id: None,
         app_mention: true,
     })
+}
+
+fn block_action_event(payload: &serde_json::Value) -> Option<SlackMessageEvent> {
+    let channel_id = payload.get("channel")?.get("id")?.as_str()?.to_string();
+    let user_id = payload.get("user")?.get("id")?.as_str()?.to_string();
+    let action = payload.get("actions")?.as_array()?.first()?;
+    let action_id = action.get("action_id")?.as_str()?;
+    let text = block_action_text(action_id)?;
+    let message = payload.get("message")?;
+    let message_ts = message.get("ts")?.as_str()?;
+    let thread_ts = message
+        .get("thread_ts")
+        .or_else(|| {
+            payload
+                .get("container")
+                .and_then(|container| container.get("thread_ts"))
+        })
+        .and_then(|value| value.as_str())
+        .unwrap_or(message_ts)
+        .to_string();
+    let ts = payload
+        .get("action_ts")
+        .and_then(|value| value.as_str())
+        .unwrap_or(message_ts)
+        .to_string();
+    let event_id = payload
+        .get("trigger_id")
+        .or_else(|| payload.get("envelope_id"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
+    Some(SlackMessageEvent {
+        event_id,
+        channel_id,
+        user_id: Some(user_id),
+        text: text.to_string(),
+        ts,
+        thread_ts: Some(thread_ts),
+        bot_id: None,
+        app_mention: false,
+    })
+}
+
+fn block_action_text(action_id: &str) -> Option<&'static str> {
+    match action_id {
+        "ralph_slack_status" => Some("status"),
+        "ralph_slack_tail" => Some("tail 10"),
+        "ralph_slack_stop" => Some("stop"),
+        "ralph_slack_approve" => Some("approved"),
+        "ralph_slack_request_changes" => Some("request changes"),
+        _ => None,
+    }
 }
 
 impl From<tokio_tungstenite::tungstenite::Error> for SlackError {

--- a/crates/ralph-slack/src/socket_mode.rs
+++ b/crates/ralph-slack/src/socket_mode.rs
@@ -202,6 +202,7 @@ fn thread_ts_from_action_value(action: &serde_json::Value, channel_id: &str) -> 
 fn block_action_text(action_id: &str) -> Option<&'static str> {
     match action_id {
         "ralph_slack_status" => Some("status"),
+        "ralph_slack_obs" => Some("obs"),
         "ralph_slack_tail" => Some("tail 10"),
         "ralph_slack_stop" => Some("stop"),
         "ralph_slack_approve" => Some("approved"),

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -37,6 +37,16 @@ pub struct SlackThreadBinding {
     pub stream_ts: Option<String>,
     #[serde(default)]
     pub final_card_ts: Option<String>,
+    #[serde(default)]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub parent_loop_id: Option<String>,
+    #[serde(default)]
+    pub log_path: Option<PathBuf>,
+    #[serde(default)]
+    pub handoff_path: Option<PathBuf>,
+    #[serde(default)]
+    pub artifacts_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,6 +143,11 @@ impl SlackStateManager {
                 progress_message_ts: None,
                 stream_ts: None,
                 final_card_ts: None,
+                completed_at: None,
+                parent_loop_id: None,
+                log_path: Some(slack_loop_log_path(workspace_root.as_ref(), loop_id)),
+                handoff_path: Some(slack_loop_handoff_path(workspace_root.as_ref(), loop_id)),
+                artifacts_path: Some(slack_loop_artifacts_path(workspace_root.as_ref(), loop_id)),
             },
         );
         state
@@ -151,6 +166,46 @@ impl SlackStateManager {
             .thread_to_loop
             .get(&thread_key(channel_id, thread_ts))
             .cloned())
+    }
+
+    pub fn bind_followup_thread(
+        &self,
+        loop_id: &str,
+        channel_id: &str,
+        thread_ts: &str,
+        root_ts: &str,
+        created_by: &str,
+        workspace_root: impl AsRef<Path>,
+        parent_loop_id: &str,
+    ) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        state.threads.insert(
+            loop_id.to_string(),
+            SlackThreadBinding {
+                loop_id: loop_id.to_string(),
+                channel_id: channel_id.to_string(),
+                thread_ts: thread_ts.to_string(),
+                root_ts: root_ts.to_string(),
+                created_by: created_by.to_string(),
+                created_at: Utc::now(),
+                workspace_root: workspace_root.as_ref().to_path_buf(),
+                status: SlackThreadStatus::Running,
+                process_id: None,
+                start_card_ts: None,
+                progress_message_ts: None,
+                stream_ts: None,
+                final_card_ts: None,
+                completed_at: None,
+                parent_loop_id: Some(parent_loop_id.to_string()),
+                log_path: Some(slack_loop_log_path(workspace_root.as_ref(), loop_id)),
+                handoff_path: Some(slack_loop_handoff_path(workspace_root.as_ref(), loop_id)),
+                artifacts_path: Some(slack_loop_artifacts_path(workspace_root.as_ref(), loop_id)),
+            },
+        );
+        state
+            .thread_to_loop
+            .insert(thread_key(channel_id, thread_ts), loop_id.to_string());
+        self.save(&state)
     }
 
     pub fn add_pending_question(
@@ -223,7 +278,16 @@ impl SlackStateManager {
     pub fn set_thread_status(&self, loop_id: &str, status: SlackThreadStatus) -> SlackResult<()> {
         let mut state = self.load_or_default()?;
         if let Some(binding) = state.threads.get_mut(loop_id) {
-            binding.status = status;
+            binding.status = status.clone();
+            if status.is_terminal() {
+                binding.process_id = None;
+                binding.completed_at = Some(Utc::now());
+                binding.log_path = Some(slack_loop_log_path(&binding.workspace_root, loop_id));
+                binding.handoff_path =
+                    Some(slack_loop_handoff_path(&binding.workspace_root, loop_id));
+                binding.artifacts_path =
+                    Some(slack_loop_artifacts_path(&binding.workspace_root, loop_id));
+            }
         }
         state.pending_questions.remove(loop_id);
         self.save(&state)
@@ -234,9 +298,52 @@ impl SlackStateManager {
         if let Some(binding) = state.threads.get_mut(loop_id) {
             binding.status = status;
             binding.process_id = None;
+            binding.completed_at = Some(Utc::now());
+            binding.log_path = Some(slack_loop_log_path(&binding.workspace_root, loop_id));
+            binding.handoff_path = Some(slack_loop_handoff_path(&binding.workspace_root, loop_id));
+            binding.artifacts_path =
+                Some(slack_loop_artifacts_path(&binding.workspace_root, loop_id));
         }
         state.pending_questions.remove(loop_id);
         self.save(&state)
+    }
+
+    pub fn archived_threads(&self) -> SlackResult<Vec<SlackThreadBinding>> {
+        let mut bindings = self
+            .load_or_default()?
+            .threads
+            .values()
+            .filter(|binding| binding.status.is_terminal())
+            .cloned()
+            .collect::<Vec<_>>();
+        bindings.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        Ok(bindings)
+    }
+
+    pub fn prune_archived_older_than(&self, cutoff: DateTime<Utc>) -> SlackResult<Vec<String>> {
+        let mut state = self.load_or_default()?;
+        let loop_ids = state
+            .threads
+            .values()
+            .filter(|binding| binding.status.is_terminal())
+            .filter(|binding| binding.completed_at.unwrap_or(binding.created_at) < cutoff)
+            .map(|binding| binding.loop_id.clone())
+            .collect::<Vec<_>>();
+
+        for loop_id in &loop_ids {
+            if let Some(binding) = state.threads.remove(loop_id) {
+                state
+                    .thread_to_loop
+                    .remove(&thread_key(&binding.channel_id, &binding.thread_ts));
+                state.pending_questions.remove(loop_id);
+                let _ = std::fs::remove_dir_all(
+                    binding.workspace_root.join(".worktrees").join(loop_id),
+                );
+                let _ = std::fs::remove_file(slack_loop_log_path(&binding.workspace_root, loop_id));
+            }
+        }
+        self.save(&state)?;
+        Ok(loop_ids)
     }
 
     pub fn mark_event_seen(&self, event_id: &str) -> SlackResult<bool> {
@@ -253,6 +360,35 @@ impl SlackStateManager {
     }
 }
 
+impl SlackThreadStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            SlackThreadStatus::Completed | SlackThreadStatus::Failed | SlackThreadStatus::Stopped
+        )
+    }
+}
+
 pub fn thread_key(channel_id: &str, thread_ts: &str) -> String {
     format!("{}:{}", channel_id, thread_ts)
+}
+
+pub fn slack_loop_log_path(workspace_root: &Path, loop_id: &str) -> PathBuf {
+    workspace_root
+        .join(".ralph/slack-loop-logs")
+        .join(format!("{loop_id}.log"))
+}
+
+pub fn slack_loop_handoff_path(workspace_root: &Path, loop_id: &str) -> PathBuf {
+    workspace_root
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph/agent/summary.md")
+}
+
+pub fn slack_loop_artifacts_path(workspace_root: &Path, loop_id: &str) -> PathBuf {
+    workspace_root
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph")
 }

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -61,7 +61,7 @@ pub struct PendingSlackQuestion {
     pub asked_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SlackState {
     pub team_id: Option<String>,
     pub last_socket_envelope_id: Option<String>,
@@ -69,19 +69,6 @@ pub struct SlackState {
     pub thread_to_loop: HashMap<String, String>,
     pub pending_questions: HashMap<String, PendingSlackQuestion>,
     pub seen_event_ids: VecDeque<String>,
-}
-
-impl Default for SlackState {
-    fn default() -> Self {
-        Self {
-            team_id: None,
-            last_socket_envelope_id: None,
-            threads: HashMap::new(),
-            thread_to_loop: HashMap::new(),
-            pending_questions: HashMap::new(),
-            seen_event_ids: VecDeque::new(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -12,6 +12,8 @@ const MAX_SEEN_EVENT_IDS: usize = 1024;
 #[serde(rename_all = "snake_case")]
 pub enum SlackThreadStatus {
     Running,
+    Completed,
+    Failed,
     Stopped,
 }
 
@@ -184,6 +186,16 @@ impl SlackStateManager {
         let mut state = self.load_or_default()?;
         if let Some(binding) = state.threads.get_mut(loop_id) {
             binding.status = status;
+        }
+        state.pending_questions.remove(loop_id);
+        self.save(&state)
+    }
+
+    pub fn finish_thread(&self, loop_id: &str, status: SlackThreadStatus) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        if let Some(binding) = state.threads.get_mut(loop_id) {
+            binding.status = status;
+            binding.process_id = None;
         }
         state.pending_questions.remove(loop_id);
         self.save(&state)

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -1,0 +1,208 @@
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::SlackResult;
+
+const MAX_SEEN_EVENT_IDS: usize = 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SlackThreadStatus {
+    Running,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackThreadBinding {
+    pub loop_id: String,
+    pub channel_id: String,
+    pub thread_ts: String,
+    pub root_ts: String,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+    pub workspace_root: PathBuf,
+    pub status: SlackThreadStatus,
+    #[serde(default)]
+    pub process_id: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSlackQuestion {
+    pub channel_id: String,
+    pub thread_ts: String,
+    pub message_ts: String,
+    pub asked_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlackState {
+    pub team_id: Option<String>,
+    pub last_socket_envelope_id: Option<String>,
+    pub threads: HashMap<String, SlackThreadBinding>,
+    pub thread_to_loop: HashMap<String, String>,
+    pub pending_questions: HashMap<String, PendingSlackQuestion>,
+    pub seen_event_ids: VecDeque<String>,
+}
+
+impl Default for SlackState {
+    fn default() -> Self {
+        Self {
+            team_id: None,
+            last_socket_envelope_id: None,
+            threads: HashMap::new(),
+            thread_to_loop: HashMap::new(),
+            pending_questions: HashMap::new(),
+            seen_event_ids: VecDeque::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SlackStateManager {
+    path: PathBuf,
+}
+
+impl SlackStateManager {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load(&self) -> SlackResult<Option<SlackState>> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+        let contents = std::fs::read_to_string(&self.path)?;
+        let state = serde_json::from_str(&contents)?;
+        Ok(Some(state))
+    }
+
+    pub fn load_or_default(&self) -> SlackResult<SlackState> {
+        Ok(self.load()?.unwrap_or_default())
+    }
+
+    pub fn save(&self, state: &SlackState) -> SlackResult<()> {
+        let json = serde_json::to_string_pretty(state)?;
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp_path = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, json)?;
+        std::fs::rename(&tmp_path, &self.path)?;
+        Ok(())
+    }
+
+    pub fn bind_thread(
+        &self,
+        loop_id: &str,
+        channel_id: &str,
+        thread_ts: &str,
+        created_by: &str,
+        workspace_root: impl AsRef<Path>,
+    ) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        state.threads.insert(
+            loop_id.to_string(),
+            SlackThreadBinding {
+                loop_id: loop_id.to_string(),
+                channel_id: channel_id.to_string(),
+                thread_ts: thread_ts.to_string(),
+                root_ts: thread_ts.to_string(),
+                created_by: created_by.to_string(),
+                created_at: Utc::now(),
+                workspace_root: workspace_root.as_ref().to_path_buf(),
+                status: SlackThreadStatus::Running,
+                process_id: None,
+            },
+        );
+        state
+            .thread_to_loop
+            .insert(thread_key(channel_id, thread_ts), loop_id.to_string());
+        self.save(&state)
+    }
+
+    pub fn loop_for_thread(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+    ) -> SlackResult<Option<String>> {
+        let state = self.load_or_default()?;
+        Ok(state
+            .thread_to_loop
+            .get(&thread_key(channel_id, thread_ts))
+            .cloned())
+    }
+
+    pub fn add_pending_question(
+        &self,
+        loop_id: &str,
+        channel_id: &str,
+        thread_ts: &str,
+        message_ts: &str,
+    ) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        state.pending_questions.insert(
+            loop_id.to_string(),
+            PendingSlackQuestion {
+                channel_id: channel_id.to_string(),
+                thread_ts: thread_ts.to_string(),
+                message_ts: message_ts.to_string(),
+                asked_at: Utc::now(),
+            },
+        );
+        self.save(&state)
+    }
+
+    pub fn remove_pending_question(&self, loop_id: &str) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        state.pending_questions.remove(loop_id);
+        self.save(&state)
+    }
+
+    pub fn has_pending_question(&self, loop_id: &str) -> SlackResult<bool> {
+        Ok(self
+            .load_or_default()?
+            .pending_questions
+            .contains_key(loop_id))
+    }
+
+    pub fn set_thread_process_id(&self, loop_id: &str, process_id: Option<u32>) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        if let Some(binding) = state.threads.get_mut(loop_id) {
+            binding.process_id = process_id;
+        }
+        self.save(&state)
+    }
+
+    pub fn set_thread_status(&self, loop_id: &str, status: SlackThreadStatus) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        if let Some(binding) = state.threads.get_mut(loop_id) {
+            binding.status = status;
+        }
+        state.pending_questions.remove(loop_id);
+        self.save(&state)
+    }
+
+    pub fn mark_event_seen(&self, event_id: &str) -> SlackResult<bool> {
+        let mut state = self.load_or_default()?;
+        if state.seen_event_ids.iter().any(|seen| seen == event_id) {
+            return Ok(false);
+        }
+        state.seen_event_ids.push_back(event_id.to_string());
+        while state.seen_event_ids.len() > MAX_SEEN_EVENT_IDS {
+            state.seen_event_ids.pop_front();
+        }
+        self.save(&state)?;
+        Ok(true)
+    }
+}
+
+pub fn thread_key(channel_id: &str, thread_ts: &str) -> String {
+    format!("{}:{}", channel_id, thread_ts)
+}

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -29,6 +29,14 @@ pub struct SlackThreadBinding {
     pub status: SlackThreadStatus,
     #[serde(default)]
     pub process_id: Option<u32>,
+    #[serde(default)]
+    pub start_card_ts: Option<String>,
+    #[serde(default)]
+    pub progress_message_ts: Option<String>,
+    #[serde(default)]
+    pub stream_ts: Option<String>,
+    #[serde(default)]
+    pub final_card_ts: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -121,6 +129,10 @@ impl SlackStateManager {
                 workspace_root: workspace_root.as_ref().to_path_buf(),
                 status: SlackThreadStatus::Running,
                 process_id: None,
+                start_card_ts: None,
+                progress_message_ts: None,
+                stream_ts: None,
+                final_card_ts: None,
             },
         );
         state
@@ -178,6 +190,32 @@ impl SlackStateManager {
         let mut state = self.load_or_default()?;
         if let Some(binding) = state.threads.get_mut(loop_id) {
             binding.process_id = process_id;
+        }
+        self.save(&state)
+    }
+
+    pub fn set_thread_message_timestamps(
+        &self,
+        loop_id: &str,
+        start_card_ts: Option<&str>,
+        progress_message_ts: Option<&str>,
+        stream_ts: Option<&str>,
+        final_card_ts: Option<&str>,
+    ) -> SlackResult<()> {
+        let mut state = self.load_or_default()?;
+        if let Some(binding) = state.threads.get_mut(loop_id) {
+            if let Some(ts) = start_card_ts {
+                binding.start_card_ts = Some(ts.to_string());
+            }
+            if let Some(ts) = progress_message_ts {
+                binding.progress_message_ts = Some(ts.to_string());
+            }
+            if let Some(ts) = stream_ts {
+                binding.stream_ts = Some(ts.to_string());
+            }
+            if let Some(ts) = final_card_ts {
+                binding.final_card_ts = Some(ts.to_string());
+            }
         }
         self.save(&state)
     }

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -337,7 +337,7 @@ impl SlackStateManager {
             .filter(|binding| binding.status.is_terminal())
             .cloned()
             .collect::<Vec<_>>();
-        bindings.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        bindings.sort_by_key(|binding| binding.created_at);
         Ok(bindings)
     }
 

--- a/crates/ralph-slack/src/state.rs
+++ b/crates/ralph-slack/src/state.rs
@@ -26,6 +26,10 @@ pub struct SlackThreadBinding {
     pub created_by: String,
     pub created_at: DateTime<Utc>,
     pub workspace_root: PathBuf,
+    #[serde(default)]
+    pub repo_alias: Option<String>,
+    #[serde(default)]
+    pub repo_dir: Option<PathBuf>,
     pub status: SlackThreadStatus,
     #[serde(default)]
     pub process_id: Option<u32>,
@@ -116,6 +120,27 @@ impl SlackStateManager {
         created_by: &str,
         workspace_root: impl AsRef<Path>,
     ) -> SlackResult<()> {
+        self.bind_thread_with_repo(
+            loop_id,
+            channel_id,
+            thread_ts,
+            created_by,
+            workspace_root,
+            None,
+            None::<&Path>,
+        )
+    }
+
+    pub fn bind_thread_with_repo(
+        &self,
+        loop_id: &str,
+        channel_id: &str,
+        thread_ts: &str,
+        created_by: &str,
+        workspace_root: impl AsRef<Path>,
+        repo_alias: Option<&str>,
+        repo_dir: Option<impl AsRef<Path>>,
+    ) -> SlackResult<()> {
         let mut state = self.load_or_default()?;
         state.threads.insert(
             loop_id.to_string(),
@@ -127,6 +152,8 @@ impl SlackStateManager {
                 created_by: created_by.to_string(),
                 created_at: Utc::now(),
                 workspace_root: workspace_root.as_ref().to_path_buf(),
+                repo_alias: repo_alias.map(ToOwned::to_owned),
+                repo_dir: repo_dir.map(|dir| dir.as_ref().to_path_buf()),
                 status: SlackThreadStatus::Running,
                 process_id: None,
                 start_card_ts: None,

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -936,6 +936,156 @@ async fn known_thread_help_status_tail_are_replies_not_guidance_and_status_wins_
 }
 
 #[tokio::test]
+async fn obs_command_reports_loop_snapshot_with_latest_event_and_log() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let events_dir = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph");
+    std::fs::create_dir_all(&events_dir).unwrap();
+    std::fs::write(
+        events_dir.join("current-events"),
+        ".ralph/events-live.jsonl",
+    )
+    .unwrap();
+    std::fs::write(
+        events_dir.join("events-live.jsonl"),
+        concat!(
+            r#"{"ts":"2026-06-07T23:01:01.000000+00:00","iteration":5,"hat":"executor","topic":"work.start","payload":"started"}"#,
+            "\n",
+            r#"{"ts":"2026-06-07T23:02:02.000000+00:00","iteration":6,"hat":"reviewer","topic":"agent.message","payload":"finished tests with secret-token-1234567890"}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+    let log_dir = temp_dir.path().join(".ralph/slack-loop-logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    std::fs::write(
+        log_dir.join(format!("{loop_id}.log")),
+        "booting\nreviewer saw xoxb-1234567890abcdef\n",
+    )
+    .unwrap();
+
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread_with_repo(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+            Some("ralph"),
+            Some(std::path::Path::new("crates/ralph-slack")),
+        )
+        .unwrap();
+    state.set_thread_process_id(loop_id, Some(4242)).unwrap();
+    state
+        .set_thread_message_timestamps(
+            loop_id,
+            Some("1780799999.000100"),
+            Some("1780799999.000200"),
+            Some("1780799999.000300"),
+            None,
+        )
+        .unwrap();
+    state
+        .add_pending_question(loop_id, "C123", "1780792150.138669", "1780792200.000100")
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        FakeSpawner::default(),
+        notifier.clone(),
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvObs".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "!obs".to_string(),
+            ts: "1780792164.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    let obs = &messages[0].2;
+    assert!(obs.contains("Ralph observable"));
+    assert!(obs.contains(loop_id));
+    assert!(obs.contains("status: `running`"));
+    assert!(obs.contains("pending question: `yes`"));
+    assert!(obs.contains("process id: `4242`"));
+    assert!(obs.contains("repo alias: `ralph`"));
+    assert!(obs.contains("repo dir: `crates/ralph-slack`"));
+    assert!(obs.contains("latest event: iter `6` · hat `reviewer` · topic `agent.message`"));
+    assert!(obs.contains("finished tests with [redacted]"));
+    assert!(obs.contains("latest log:"));
+    assert!(obs.contains("reviewer saw [redacted]"));
+    assert!(!obs.contains("secret-token-1234567890"));
+    assert!(!obs.contains("xoxb-1...cdef"));
+    assert!(state.has_pending_question(loop_id).unwrap());
+}
+
+#[tokio::test]
+async fn obs_command_on_archived_thread_reports_no_pending_and_missing_files() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread_with_repo(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+            Some("ralph"),
+            Some(std::path::Path::new("crates/ralph-slack")),
+        )
+        .unwrap();
+    state
+        .finish_thread(loop_id, SlackThreadStatus::Completed)
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state,
+        FakeSpawner::default(),
+        notifier.clone(),
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvObsArchived".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "observe".to_string(),
+            ts: "1780792165.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    let obs = &messages[0].2;
+    assert!(obs.contains("status: `completed`"));
+    assert!(obs.contains("pending question: `no`"));
+    assert!(obs.contains("process id: `none`"));
+    assert!(obs.contains("latest event: none"));
+    assert!(obs.contains("latest log: none"));
+}
+
+#[tokio::test]
 async fn pending_question_non_command_routes_response_and_command_does_not_clear_pending() {
     let temp_dir = tempfile::tempdir().unwrap();
     let loop_id = "slack-C123-1780792150-138669";

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -263,7 +263,8 @@ fn daemon_config(root: &std::path::Path) -> SlackDaemonConfig {
         workspace_root: root.to_path_buf(),
         allowed_channels: vec!["C123".to_string()],
         allowed_users: vec!["U123".to_string()],
-        channel_repos: BTreeMap::from([("C123".to_string(), root.to_path_buf())]),
+        repo_aliases: BTreeMap::from([("ralph".to_string(), root.to_path_buf())]),
+        channel_repos: BTreeMap::from([("C123".to_string(), "ralph".to_string())]),
     }
 }
 
@@ -311,6 +312,315 @@ async fn fake_socket_root_event_starts_fake_loop_and_posts_thread_reply() {
     assert_eq!(messages[0].0, "C123");
     assert_eq!(messages[0].1, "1780792150.138669");
     assert!(messages[0].2.contains("Ralph loop started"));
+}
+
+#[tokio::test]
+async fn root_event_can_override_repo_alias_and_subdir_and_binds_thread_target() {
+    let daemon_root = tempfile::tempdir().unwrap();
+    let ralph_repo = tempfile::tempdir().unwrap();
+    let tonic_repo = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tonic_repo.path().join("crates/ralph-slack")).unwrap();
+    let state = SlackStateManager::new(daemon_root.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: daemon_root.path().to_path_buf(),
+            allowed_channels: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            repo_aliases: BTreeMap::from([
+                ("ralph".to_string(), ralph_repo.path().to_path_buf()),
+                ("tonic".to_string(), tonic_repo.path().to_path_buf()),
+            ]),
+            channel_repos: BTreeMap::from([("C123".to_string(), "ralph".to_string())]),
+        },
+        state.clone(),
+        spawner.clone(),
+        FakeNotifier::default(),
+    );
+
+    let action = daemon
+        .handle_event(app_mention(
+            "EvRepoOverride",
+            "<@B123> repo=tonic dir=crates/ralph-slack test status command",
+        ))
+        .await
+        .unwrap();
+
+    let HandlerAction::StartLoop { prompt, .. } = action else {
+        panic!("expected StartLoop");
+    };
+    assert_eq!(prompt, "test status command");
+    let request = spawner.requests.lock().unwrap()[0].clone();
+    assert_eq!(
+        request.workspace_root,
+        tonic_repo.path().canonicalize().unwrap()
+    );
+    assert_eq!(
+        request.state_path,
+        daemon_root.path().join(".ralph/slack-state.json")
+    );
+    assert_eq!(
+        request.env.get("RALPH_SLACK_STATE_PATH").unwrap(),
+        &daemon_root
+            .path()
+            .join(".ralph/slack-state.json")
+            .to_string_lossy()
+            .to_string()
+    );
+    assert_eq!(request.repo_alias.as_deref(), Some("tonic"));
+    assert_eq!(
+        request.repo_dir.as_deref(),
+        Some(std::path::Path::new("crates/ralph-slack"))
+    );
+    let binding = state
+        .load_or_default()
+        .unwrap()
+        .threads
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    assert_eq!(binding.repo_alias.as_deref(), Some("tonic"));
+    assert_eq!(
+        binding.repo_dir.as_deref(),
+        Some(std::path::Path::new("crates/ralph-slack"))
+    );
+}
+
+#[tokio::test]
+async fn in_alias_colon_start_syntax_uses_alias_and_strips_prefix_from_prompt() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state,
+        spawner.clone(),
+        FakeNotifier::default(),
+    );
+
+    daemon
+        .handle_event(app_mention("EvInAlias", "<@B123> in ralph: fix the UX"))
+        .await
+        .unwrap();
+
+    let request = spawner.requests.lock().unwrap()[0].clone();
+    assert_eq!(request.prompt, "fix the UX");
+    assert_eq!(request.repo_alias.as_deref(), Some("ralph"));
+}
+
+#[tokio::test]
+async fn unsafe_repo_dir_is_rejected_before_thread_binding_or_spawn() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let event = app_mention("EvBadDir", "<@B123> repo=ralph dir=../escape fix");
+    let action = daemon.handle_event(event.clone()).await.unwrap();
+    let duplicate = daemon.handle_event(event).await.unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert_eq!(duplicate, HandlerAction::Ignored);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+    assert!(
+        !state
+            .load_or_default()
+            .unwrap()
+            .thread_to_loop
+            .contains_key("C123:1780792150.138669")
+    );
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].2.contains("cannot contain"));
+}
+
+#[tokio::test]
+async fn invalid_explicit_repo_alias_is_rejected_without_falling_back_to_channel_default() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let event = app_mention("EvBadAlias", "<@B123> repo=../ralph fix");
+    let action = daemon.handle_event(event.clone()).await.unwrap();
+    let duplicate = daemon.handle_event(event).await.unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert_eq!(duplicate, HandlerAction::Ignored);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+    assert!(
+        !state
+            .load_or_default()
+            .unwrap()
+            .thread_to_loop
+            .contains_key("C123:1780792150.138669")
+    );
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].2.contains("repo alias `../ralph` is invalid"));
+}
+
+#[tokio::test]
+async fn malformed_in_repo_selector_is_rejected_without_falling_back_to_channel_default() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let event = app_mention("EvMalformedIn", "<@B123> in ralph fix this");
+    let action = daemon.handle_event(event.clone()).await.unwrap();
+    let duplicate = daemon.handle_event(event).await.unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert_eq!(duplicate, HandlerAction::Ignored);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+    assert!(
+        !state
+            .load_or_default()
+            .unwrap()
+            .thread_to_loop
+            .contains_key("C123:1780792150.138669")
+    );
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].2.contains("must include `:`"));
+}
+
+#[tokio::test]
+async fn empty_repo_dir_directive_is_rejected_without_falling_back_to_channel_default() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let event = app_mention("EvEmptyDir", "<@B123> repo=ralph dir= fix this");
+    let action = daemon.handle_event(event.clone()).await.unwrap();
+    let duplicate = daemon.handle_event(event).await.unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert_eq!(duplicate, HandlerAction::Ignored);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+    assert!(
+        !state
+            .load_or_default()
+            .unwrap()
+            .thread_to_loop
+            .contains_key("C123:1780792150.138669")
+    );
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].2.contains("repo dir cannot be empty"));
+}
+
+#[tokio::test]
+async fn missing_repo_dir_is_rejected_before_thread_binding_or_spawn() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let event = app_mention("EvMissingDir", "<@B123> repo=ralph dir=missing fix");
+    let action = daemon.handle_event(event.clone()).await.unwrap();
+    let duplicate = daemon.handle_event(event).await.unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert_eq!(duplicate, HandlerAction::Ignored);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+    assert!(
+        !state
+            .load_or_default()
+            .unwrap()
+            .thread_to_loop
+            .contains_key("C123:1780792150.138669")
+    );
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(
+        messages[0]
+            .2
+            .contains("Slack repo dir `missing` is not usable")
+    );
+}
+
+#[test]
+fn repo_dir_validation_rejects_symlink_escape() {
+    let repo = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(outside.path(), repo.path().join("escape")).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(outside.path(), repo.path().join("escape")).unwrap();
+
+    let err = ralph_slack::daemon::resolve_repo_target(
+        &BTreeMap::from([("ralph".to_string(), repo.path().to_path_buf())]),
+        Some("ralph"),
+        None,
+        Some(std::path::Path::new("escape")),
+    )
+    .unwrap_err();
+
+    assert!(err.contains("inside the configured repo root"));
+}
+
+#[tokio::test]
+async fn missing_repo_resolution_posts_human_interact_clarification_with_aliases() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: temp_dir.path().to_path_buf(),
+            allowed_channels: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            repo_aliases: BTreeMap::from([("ralph".to_string(), temp_dir.path().to_path_buf())]),
+            channel_repos: BTreeMap::new(),
+        },
+        state,
+        FakeSpawner::default(),
+        notifier.clone(),
+    );
+
+    let action = daemon
+        .handle_event(app_mention("EvClarify", "<@B123> build somewhere"))
+        .await
+        .unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].2.contains("human.interact"));
+    assert!(messages[0].2.contains("`ralph`"));
 }
 
 #[tokio::test]
@@ -386,7 +696,8 @@ async fn unauthorized_root_event_does_not_spawn_or_bind_thread() {
             workspace_root: temp_dir.path().to_path_buf(),
             allowed_channels: vec!["C999".to_string()],
             allowed_users: vec!["U123".to_string()],
-            channel_repos: BTreeMap::from([("C999".to_string(), temp_dir.path().to_path_buf())]),
+            repo_aliases: BTreeMap::from([("ralph".to_string(), temp_dir.path().to_path_buf())]),
+            channel_repos: BTreeMap::from([("C999".to_string(), "ralph".to_string())]),
         },
         state.clone(),
         spawner.clone(),
@@ -415,7 +726,8 @@ async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_
             workspace_root: daemon_root.path().to_path_buf(),
             allowed_channels: vec!["C123".to_string(), "C999".to_string()],
             allowed_users: vec!["U123".to_string()],
-            channel_repos: BTreeMap::from([("C123".to_string(), repo_root.path().to_path_buf())]),
+            repo_aliases: BTreeMap::from([("ralph".to_string(), repo_root.path().to_path_buf())]),
+            channel_repos: BTreeMap::from([("C123".to_string(), "ralph".to_string())]),
         },
         state.clone(),
         spawner.clone(),
@@ -429,7 +741,10 @@ async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_
 
     let requests = spawner.requests.lock().unwrap();
     assert_eq!(requests.len(), 1);
-    assert_eq!(requests[0].workspace_root, repo_root.path());
+    assert_eq!(
+        requests[0].workspace_root,
+        repo_root.path().canonicalize().unwrap()
+    );
     assert!(
         !requests[0].env.contains_key("RALPH_WORKSPACE_ROOT"),
         "Slack-spawned loops run from their worktree; do not force repo root via RALPH_WORKSPACE_ROOT"
@@ -443,7 +758,10 @@ async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_
         .next()
         .unwrap()
         .clone();
-    assert_eq!(bound.workspace_root, repo_root.path());
+    assert_eq!(
+        bound.workspace_root,
+        repo_root.path().canonicalize().unwrap()
+    );
 
     let denied = SlackMessageEvent {
         event_id: Some("EvUnknownRepo".to_string()),
@@ -462,7 +780,7 @@ async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_
     assert!(
         notifier.messages.lock().unwrap()[1]
             .2
-            .contains("not configured")
+            .contains("human.interact")
     );
     let state_after_denial = state.load_or_default().unwrap();
     assert!(
@@ -504,7 +822,8 @@ async fn thread_reply_uses_persisted_repo_root_not_daemon_workspace_root() {
             workspace_root: daemon_root.path().to_path_buf(),
             allowed_channels: vec!["C123".to_string()],
             allowed_users: vec!["U123".to_string()],
-            channel_repos: BTreeMap::from([("C123".to_string(), repo_root.path().to_path_buf())]),
+            repo_aliases: BTreeMap::from([("ralph".to_string(), repo_root.path().to_path_buf())]),
+            channel_repos: BTreeMap::from([("C123".to_string(), "ralph".to_string())]),
         },
         state,
         FakeSpawner::default(),
@@ -559,12 +878,14 @@ async fn known_thread_help_status_tail_are_replies_not_guidance_and_status_wins_
     .unwrap();
     let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
     state
-        .bind_thread(
+        .bind_thread_with_repo(
             loop_id,
             "C123",
             "1780792150.138669",
             "U123",
             temp_dir.path(),
+            Some("ralph"),
+            Some(std::path::Path::new("crates/ralph-slack")),
         )
         .unwrap();
     state
@@ -578,7 +899,7 @@ async fn known_thread_help_status_tail_are_replies_not_guidance_and_status_wins_
         notifier.clone(),
     );
 
-    for (idx, text) in ["help", "status", "!tail 1"].iter().enumerate() {
+    for (idx, text) in ["help", "repo", "status", "!tail 1"].iter().enumerate() {
         daemon
             .handle_event(SlackMessageEvent {
                 event_id: Some(format!("EvCmd{idx}")),
@@ -595,12 +916,20 @@ async fn known_thread_help_status_tail_are_replies_not_guidance_and_status_wins_
     }
 
     let messages = notifier.messages.lock().unwrap();
-    assert_eq!(messages.len(), 3);
+    assert_eq!(messages.len(), 4);
     assert!(messages[0].2.contains("help"));
+    assert!(messages[1].2.contains("alias: `ralph`"));
+    assert!(messages[1].2.contains("dir: `crates/ralph-slack`"));
     assert!(messages[1].2.contains(loop_id));
-    assert!(messages[1].2.contains("pending question: yes"));
-    assert!(messages[2].2.contains("checkpoint"));
-    assert!(!messages[2].2.contains("secret-token-1234567890"));
+    assert!(
+        messages[1]
+            .2
+            .contains(&format!("branch: `ralph-slack-{loop_id}`"))
+    );
+    assert!(messages[2].2.contains(loop_id));
+    assert!(messages[2].2.contains("pending question: yes"));
+    assert!(messages[3].2.contains("checkpoint"));
+    assert!(!messages[3].2.contains("secret-token-1234567890"));
     assert!(state.has_pending_question(loop_id).unwrap());
     let events = std::fs::read_to_string(events_dir.join("events-live.jsonl")).unwrap();
     assert!(!events.contains("human.guidance"));
@@ -840,7 +1169,8 @@ async fn stop_cancel_is_creator_only_marks_stopped_and_blocks_future_guidance() 
             workspace_root: temp_dir.path().to_path_buf(),
             allowed_channels: vec!["C123".to_string()],
             allowed_users: vec!["U123".to_string(), "U999".to_string()],
-            channel_repos: BTreeMap::from([("C123".to_string(), temp_dir.path().to_path_buf())]),
+            repo_aliases: BTreeMap::from([("ralph".to_string(), temp_dir.path().to_path_buf())]),
+            channel_repos: BTreeMap::from([("C123".to_string(), "ralph".to_string())]),
         },
         state.clone(),
         spawner.clone(),
@@ -935,7 +1265,8 @@ async fn stop_button_is_creator_only_like_typed_stop() {
             workspace_root: temp_dir.path().to_path_buf(),
             allowed_channels: vec!["C123".to_string()],
             allowed_users: vec!["U123".to_string(), "U999".to_string()],
-            channel_repos: BTreeMap::from([("C123".to_string(), temp_dir.path().to_path_buf())]),
+            repo_aliases: BTreeMap::from([("ralph".to_string(), temp_dir.path().to_path_buf())]),
+            channel_repos: BTreeMap::from([("C123".to_string(), "ralph".to_string())]),
         },
         state.clone(),
         spawner.clone(),

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -672,6 +672,153 @@ async fn pending_question_non_command_routes_response_and_command_does_not_clear
 }
 
 #[tokio::test]
+async fn startup_reconciliation_finishes_running_thread_with_dead_process() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let events_dir = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph");
+    std::fs::create_dir_all(&events_dir).unwrap();
+    std::fs::write(
+        events_dir.join("events.jsonl"),
+        "{\"topic\":\"LOOP_COMPLETE\",\"payload\":\"done\"}\n",
+    )
+    .unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state
+        .set_thread_process_id(loop_id, Some(u32::MAX))
+        .unwrap();
+    state
+        .add_pending_question(loop_id, "C123", "1780792150.138669", "1780792200.000100")
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        FakeSpawner::default(),
+        notifier.clone(),
+    );
+
+    daemon.reconcile_stale_threads().await.unwrap();
+
+    let loaded = state.load_or_default().unwrap();
+    let binding = &loaded.threads[loop_id];
+    assert_eq!(binding.status, SlackThreadStatus::Completed);
+    assert_eq!(binding.process_id, None);
+    assert!(binding.final_card_ts.is_some());
+    assert!(!loaded.pending_questions.contains_key(loop_id));
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].0, "C123");
+    assert_eq!(messages[0].1, "1780792150.138669");
+    assert!(messages[0].2.contains("completed"));
+}
+
+#[tokio::test]
+async fn stale_reconciliation_updates_existing_final_card_for_failed_dead_process() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let events_dir = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph");
+    std::fs::create_dir_all(&events_dir).unwrap();
+    std::fs::write(
+        events_dir.join("events.jsonl"),
+        "{\"topic\":\"agent.message\",\"payload\":\"exited before completion\"}\n",
+    )
+    .unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state
+        .set_thread_process_id(loop_id, Some(u32::MAX))
+        .unwrap();
+    state
+        .set_thread_message_timestamps(loop_id, None, None, None, Some("1780799999.000200"))
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        FakeSpawner::default(),
+        notifier.clone(),
+    );
+
+    daemon.reconcile_stale_threads().await.unwrap();
+
+    let loaded = state.load_or_default().unwrap();
+    let binding = &loaded.threads[loop_id];
+    assert_eq!(binding.status, SlackThreadStatus::Failed);
+    assert_eq!(binding.process_id, None);
+    assert_eq!(binding.final_card_ts.as_deref(), Some("1780799999.000200"));
+    assert!(notifier.messages.lock().unwrap().is_empty());
+    let updates = notifier.updates.lock().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].0, "C123");
+    assert_eq!(updates[0].1, "1780799999.000200");
+    assert!(updates[0].2.contains("failed"));
+}
+
+#[tokio::test]
+async fn stale_reconciliation_marks_completed_from_loop_log_when_event_file_is_missing() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let log_dir = temp_dir.path().join(".ralph/slack-loop-logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    std::fs::write(
+        log_dir.join(format!("{loop_id}.log")),
+        "Completion event detected in JSONL topic=LOOP_COMPLETE\n",
+    )
+    .unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state
+        .set_thread_process_id(loop_id, Some(u32::MAX))
+        .unwrap();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        FakeSpawner::default(),
+        FakeNotifier::default(),
+    );
+
+    daemon.reconcile_stale_threads().await.unwrap();
+
+    assert_eq!(
+        state.load_or_default().unwrap().threads[loop_id].status,
+        SlackThreadStatus::Completed
+    );
+}
+
+#[tokio::test]
 async fn stop_cancel_is_creator_only_marks_stopped_and_blocks_future_guidance() {
     let temp_dir = tempfile::tempdir().unwrap();
     let loop_id = "slack-C123-1780792150-138669";

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -120,6 +120,50 @@ async fn socket_mode_ack_is_sent_before_slow_loop_spawn_work() {
     assert_eq!(spawner.requests.lock().unwrap().len(), 1);
 }
 
+#[tokio::test]
+async fn socket_mode_ignores_hello_envelopes_without_ack_id() {
+    use futures::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state,
+        spawner.clone(),
+        FakeNotifier::default(),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("ws://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        ws.send(Message::Text(
+            serde_json::json!({"type":"hello","num_connections":1,"debug_info":{}})
+                .to_string()
+                .into(),
+        ))
+        .await
+        .unwrap();
+        let no_ack = tokio::time::timeout(std::time::Duration::from_millis(100), ws.next()).await;
+        assert!(
+            no_ack.is_err(),
+            "hello messages without envelope_id should not be acked"
+        );
+        ws.close(None).await.unwrap();
+    });
+
+    ralph_slack::socket_mode::run_socket_mode(&url, daemon)
+        .await
+        .unwrap();
+    server.await.unwrap();
+    assert!(spawner.requests.lock().unwrap().is_empty());
+}
+
 fn app_mention(event_id: &str, text: &str) -> SlackMessageEvent {
     SlackMessageEvent {
         event_id: Some(event_id.to_string()),

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -340,8 +340,7 @@ async fn socket_mode_ack_is_sent_before_slow_loop_spawn_work() {
                     }
                 }
             })
-            .to_string()
-            .into(),
+            .to_string(),
         ))
         .await
         .unwrap();
@@ -390,9 +389,7 @@ async fn socket_mode_ignores_hello_envelopes_without_ack_id() {
         let (stream, _) = listener.accept().await.unwrap();
         let mut ws = accept_async(stream).await.unwrap();
         ws.send(Message::Text(
-            serde_json::json!({"type":"hello","num_connections":1,"debug_info":{}})
-                .to_string()
-                .into(),
+            serde_json::json!({"type":"hello","num_connections":1,"debug_info":{}}).to_string(),
         ))
         .await
         .unwrap();
@@ -927,17 +924,18 @@ async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_
         .await
         .unwrap();
 
-    let requests = spawner.requests.lock().unwrap();
-    assert_eq!(requests.len(), 1);
-    assert_eq!(
-        requests[0].workspace_root,
-        repo_root.path().canonicalize().unwrap()
-    );
-    assert!(
-        !requests[0].env.contains_key("RALPH_WORKSPACE_ROOT"),
-        "Slack-spawned loops run from their worktree; do not force repo root via RALPH_WORKSPACE_ROOT"
-    );
-    drop(requests);
+    {
+        let requests = spawner.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].workspace_root,
+            repo_root.path().canonicalize().unwrap()
+        );
+        assert!(
+            !requests[0].env.contains_key("RALPH_WORKSPACE_ROOT"),
+            "Slack-spawned loops run from their worktree; do not force repo root via RALPH_WORKSPACE_ROOT"
+        );
+    }
     let bound = state
         .load_or_default()
         .unwrap()

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -37,6 +37,7 @@ impl LoopSpawner for FakeSpawner {
 struct FakeNotifier {
     messages: Arc<Mutex<Vec<(String, String, String)>>>,
     updates: Arc<Mutex<Vec<(String, String, String)>>>,
+    statuses: Arc<Mutex<Vec<(String, String, String)>>>,
 }
 
 #[async_trait]
@@ -65,6 +66,20 @@ impl ThreadNotifier for FakeNotifier {
             channel_id.to_string(),
             message_ts.to_string(),
             message.text.clone(),
+        ));
+        Ok(())
+    }
+
+    async fn set_assistant_thread_status(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        status: &str,
+    ) -> ralph_slack::SlackResult<()> {
+        self.statuses.lock().unwrap().push((
+            channel_id.to_string(),
+            thread_ts.to_string(),
+            status.to_string(),
         ));
         Ok(())
     }
@@ -132,6 +147,157 @@ async fn progress_events_create_once_then_update_same_message_ts() {
             .progress_message_ts
             .as_deref(),
         Some("1780799999.000100")
+    );
+}
+
+#[tokio::test]
+async fn assistant_progress_status_uses_semantics_not_raw_payload_paths() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let progress = r#"{"topic":"unknown","payload":"running /Users/rook/projects/ralph-orchestrator/.ralph/slack-loop-logs/slack-C123.log && cat raw-output.txt"}"#;
+
+    let mut checkpoint = ralph_slack::daemon::ProgressCheckpoint::default();
+    ralph_slack::daemon::sync_loop_progress_once(
+        &state,
+        notifier.clone(),
+        loop_id,
+        "C123",
+        "1780792150.138669",
+        progress,
+        std::time::Duration::from_secs(0),
+        &mut checkpoint,
+    )
+    .await
+    .unwrap();
+
+    let statuses = notifier.statuses.lock().unwrap();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].2, "is working");
+    assert!(!statuses[0].2.contains("/Users/rook"));
+    assert!(!statuses[0].2.contains("slack-loop-logs"));
+    assert!(!statuses[0].2.contains("raw-output"));
+}
+
+#[tokio::test]
+async fn pending_human_status_is_not_overwritten_by_later_progress() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let human =
+        r#"{"iteration":3,"hat":"builder","topic":"human.interact","payload":"Need approval"}"#;
+    let later = concat!(
+        r#"{"iteration":3,"hat":"builder","topic":"human.interact","payload":"Need approval"}"#,
+        "\n",
+        r#"{"iteration":4,"hat":"builder","topic":"agent.message","payload":"Still running"}"#,
+        "\n"
+    );
+
+    let mut checkpoint = ralph_slack::daemon::ProgressCheckpoint::default();
+    ralph_slack::daemon::sync_loop_progress_once(
+        &state,
+        notifier.clone(),
+        loop_id,
+        "C123",
+        "1780792150.138669",
+        human,
+        std::time::Duration::from_secs(0),
+        &mut checkpoint,
+    )
+    .await
+    .unwrap();
+    state
+        .add_pending_question(loop_id, "C123", "1780792150.138669", "1780800000.000100")
+        .unwrap();
+    ralph_slack::daemon::sync_loop_progress_once(
+        &state,
+        notifier.clone(),
+        loop_id,
+        "C123",
+        "1780792150.138669",
+        later,
+        std::time::Duration::from_secs(11),
+        &mut checkpoint,
+    )
+    .await
+    .unwrap();
+
+    let statuses = notifier.statuses.lock().unwrap();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].2, "needs your answer");
+}
+
+#[tokio::test]
+async fn stop_command_clears_assistant_status_even_after_recent_status() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state.set_thread_process_id(loop_id, Some(4242)).unwrap();
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    notifier
+        .set_assistant_thread_status("C123", "1780792150.138669", "needs your answer")
+        .await
+        .unwrap();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvStopClear".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "stop".to_string(),
+            ts: "1780800000.000200".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+
+    let statuses = notifier.statuses.lock().unwrap();
+    assert_eq!(
+        statuses.last().map(|(_, _, status)| status.as_str()),
+        Some("")
+    );
+    assert_eq!(*spawner.stopped.lock().unwrap(), vec![4242]);
+    assert_eq!(
+        state.load_or_default().unwrap().threads[loop_id].status,
+        SlackThreadStatus::Stopped
     );
 }
 
@@ -312,6 +478,14 @@ async fn fake_socket_root_event_starts_fake_loop_and_posts_thread_reply() {
     assert_eq!(messages[0].0, "C123");
     assert_eq!(messages[0].1, "1780792150.138669");
     assert!(messages[0].2.contains("Ralph loop started"));
+    drop(messages);
+
+    let statuses = notifier.statuses.lock().unwrap();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].0, "C123");
+    assert_eq!(statuses[0].1, "1780792150.138669");
+    assert!(statuses[0].2.starts_with("is starting loop slack-C123"));
+    assert_eq!(statuses[1].2, "is working in ralph");
 }
 
 #[tokio::test]
@@ -322,6 +496,7 @@ async fn root_event_can_override_repo_alias_and_subdir_and_binds_thread_target()
     std::fs::create_dir_all(tonic_repo.path().join("crates/ralph-slack")).unwrap();
     let state = SlackStateManager::new(daemon_root.path().join(".ralph/slack-state.json"));
     let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
     let daemon = SlackDaemon::new(
         SlackDaemonConfig {
             workspace_root: daemon_root.path().to_path_buf(),
@@ -335,7 +510,7 @@ async fn root_event_can_override_repo_alias_and_subdir_and_binds_thread_target()
         },
         state.clone(),
         spawner.clone(),
-        FakeNotifier::default(),
+        notifier.clone(),
     );
 
     let action = daemon
@@ -385,6 +560,19 @@ async fn root_event_can_override_repo_alias_and_subdir_and_binds_thread_target()
         binding.repo_dir.as_deref(),
         Some(std::path::Path::new("crates/ralph-slack"))
     );
+
+    let statuses = notifier.statuses.lock().unwrap();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(
+        statuses[0].2,
+        format!("is starting loop {} in tonic", binding.loop_id)
+    );
+    assert_eq!(statuses[1].2, "is working in tonic");
+    for (_, _, status) in statuses.iter() {
+        assert!(!status.contains("crates/ralph-slack"));
+        assert!(!status.contains('/'));
+        assert!(!status.contains(&tonic_repo.path().to_string_lossy().to_string()));
+    }
 }
 
 #[tokio::test]

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -35,6 +35,7 @@ impl LoopSpawner for FakeSpawner {
 #[derive(Default, Clone)]
 struct FakeNotifier {
     messages: Arc<Mutex<Vec<(String, String, String)>>>,
+    updates: Arc<Mutex<Vec<(String, String, String)>>>,
 }
 
 #[async_trait]
@@ -52,6 +53,85 @@ impl ThreadNotifier for FakeNotifier {
         ));
         Ok("1780799999.000100".to_string())
     }
+
+    async fn update_thread_blocks(
+        &self,
+        channel_id: &str,
+        message_ts: &str,
+        message: &ralph_slack::SlackRenderedMessage,
+    ) -> ralph_slack::SlackResult<()> {
+        self.updates.lock().unwrap().push((
+            channel_id.to_string(),
+            message_ts.to_string(),
+            message.text.clone(),
+        ));
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn progress_events_create_once_then_update_same_message_ts() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let first = r#"{"iteration":1,"hat":"planner","topic":"plan.ready","payload":"first"}"#;
+    let second = concat!(
+        r#"{"iteration":1,"hat":"planner","topic":"plan.ready","payload":"first"}"#,
+        "\n",
+        r#"{"iteration":2,"hat":"executor","topic":"agent.message","payload":"second"}"#,
+        "\n"
+    );
+
+    let mut checkpoint = ralph_slack::daemon::ProgressCheckpoint::default();
+    ralph_slack::daemon::sync_loop_progress_once(
+        &state,
+        notifier.clone(),
+        loop_id,
+        "C123",
+        "1780792150.138669",
+        first,
+        std::time::Duration::from_secs(0),
+        &mut checkpoint,
+    )
+    .await
+    .unwrap();
+    ralph_slack::daemon::sync_loop_progress_once(
+        &state,
+        notifier.clone(),
+        loop_id,
+        "C123",
+        "1780792150.138669",
+        second,
+        std::time::Duration::from_secs(61),
+        &mut checkpoint,
+    )
+    .await
+    .unwrap();
+
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].2.contains("plan.ready"));
+    drop(messages);
+    let updates = notifier.updates.lock().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].1, "1780799999.000100");
+    assert!(updates[0].2.contains("agent.message"));
+    assert_eq!(
+        state.load_or_default().unwrap().threads[loop_id]
+            .progress_message_ts
+            .as_deref(),
+        Some("1780799999.000100")
+    );
 }
 
 #[tokio::test]

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -7,6 +7,7 @@ use ralph_slack::daemon::{
     LoopSpawner, SlackDaemon, SlackDaemonConfig, StartLoopRequest, ThreadNotifier,
 };
 use ralph_slack::handler::SlackMessageEvent;
+use ralph_slack::socket_mode::slack_message_event_from_payload;
 use ralph_slack::state::{SlackStateManager, SlackThreadStatus};
 
 #[derive(Default, Clone)]
@@ -763,5 +764,52 @@ async fn stop_cancel_is_creator_only_marks_stopped_and_blocks_future_guidance() 
             .unwrap()
             .iter()
             .any(|(_, _, text)| text.contains("stopped"))
+    );
+}
+
+#[tokio::test]
+async fn stop_button_is_creator_only_like_typed_stop() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state.set_thread_process_id(loop_id, Some(4242)).unwrap();
+    let spawner = FakeSpawner::default();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: temp_dir.path().to_path_buf(),
+            allowed_channels: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string(), "U999".to_string()],
+            channel_repos: BTreeMap::from([("C123".to_string(), temp_dir.path().to_path_buf())]),
+        },
+        state.clone(),
+        spawner.clone(),
+        FakeNotifier::default(),
+    );
+    let payload = serde_json::json!({
+        "type": "block_actions",
+        "trigger_id": "TrigStopDenied",
+        "user": {"id": "U999"},
+        "channel": {"id": "C123"},
+        "message": {"ts": "1780792150.138669", "thread_ts": "1780792150.138669"},
+        "actions": [{"action_id": "ralph_slack_stop", "value": "stop:slack-C123-1780792150-138669"}],
+        "action_ts": "1780792160.000100"
+    });
+    let event = slack_message_event_from_payload(&payload).expect("stop button should parse");
+
+    daemon.handle_event(event).await.unwrap();
+
+    assert!(spawner.stopped.lock().unwrap().is_empty());
+    assert_eq!(
+        state.load_or_default().unwrap().threads[loop_id].status,
+        SlackThreadStatus::Running
     );
 }

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -497,7 +497,7 @@ async fn known_thread_help_status_tail_are_replies_not_guidance_and_status_wins_
         notifier.clone(),
     );
 
-    for (idx, text) in ["help", "status", "tail 1"].iter().enumerate() {
+    for (idx, text) in ["help", "status", "!tail 1"].iter().enumerate() {
         daemon
             .handle_event(SlackMessageEvent {
                 event_id: Some(format!("EvCmd{idx}")),

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -349,9 +349,9 @@ async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_
     let requests = spawner.requests.lock().unwrap();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].workspace_root, repo_root.path());
-    assert_eq!(
-        requests[0].env.get("RALPH_WORKSPACE_ROOT").unwrap(),
-        &repo_root.path().to_string_lossy().to_string()
+    assert!(
+        !requests[0].env.contains_key("RALPH_WORKSPACE_ROOT"),
+        "Slack-spawned loops run from their worktree; do not force repo root via RALPH_WORKSPACE_ROOT"
     );
     drop(requests);
     let bound = state

--- a/crates/ralph-slack/tests/slack_daemon.rs
+++ b/crates/ralph-slack/tests/slack_daemon.rs
@@ -1,0 +1,643 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ralph_slack::HandlerAction;
+use ralph_slack::daemon::{
+    LoopSpawner, SlackDaemon, SlackDaemonConfig, StartLoopRequest, ThreadNotifier,
+};
+use ralph_slack::handler::SlackMessageEvent;
+use ralph_slack::state::{SlackStateManager, SlackThreadStatus};
+
+#[derive(Default, Clone)]
+struct FakeSpawner {
+    requests: Arc<Mutex<Vec<StartLoopRequest>>>,
+    stopped: Arc<Mutex<Vec<u32>>>,
+    delay_ms: u64,
+}
+
+#[async_trait]
+impl LoopSpawner for FakeSpawner {
+    async fn spawn_loop(&self, request: StartLoopRequest) -> ralph_slack::SlackResult<Option<u32>> {
+        if self.delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+        }
+        self.requests.lock().unwrap().push(request);
+        Ok(Some(4242))
+    }
+
+    async fn stop_loop(&self, process_id: u32) -> ralph_slack::SlackResult<()> {
+        self.stopped.lock().unwrap().push(process_id);
+        Ok(())
+    }
+}
+
+#[derive(Default, Clone)]
+struct FakeNotifier {
+    messages: Arc<Mutex<Vec<(String, String, String)>>>,
+}
+
+#[async_trait]
+impl ThreadNotifier for FakeNotifier {
+    async fn post_thread_message(
+        &self,
+        channel_id: &str,
+        thread_ts: &str,
+        text: &str,
+    ) -> ralph_slack::SlackResult<String> {
+        self.messages.lock().unwrap().push((
+            channel_id.to_string(),
+            thread_ts.to_string(),
+            text.to_string(),
+        ));
+        Ok("1780799999.000100".to_string())
+    }
+}
+
+#[tokio::test]
+async fn socket_mode_ack_is_sent_before_slow_loop_spawn_work() {
+    use futures::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner {
+        delay_ms: 500,
+        ..FakeSpawner::default()
+    };
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state,
+        spawner.clone(),
+        FakeNotifier::default(),
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("ws://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+        ws.send(Message::Text(
+            serde_json::json!({
+                "envelope_id": "EnvAckFirst",
+                "payload": {
+                    "event_id": "EvAckFirst",
+                    "event": {
+                        "type": "app_mention",
+                        "channel": "C123",
+                        "user": "U123",
+                        "text": "<@B123> slow spawn",
+                        "ts": "1780792150.138669"
+                    }
+                }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        let ack = tokio::time::timeout(std::time::Duration::from_millis(150), ws.next())
+            .await
+            .expect("Socket Mode ack must be sent before slow loop spawn work")
+            .unwrap()
+            .unwrap();
+        assert!(started.elapsed() < std::time::Duration::from_millis(250));
+        assert_eq!(
+            ack.into_text().unwrap(),
+            serde_json::json!({"envelope_id":"EnvAckFirst"}).to_string()
+        );
+        ws.close(None).await.unwrap();
+    });
+
+    ralph_slack::socket_mode::run_socket_mode(&url, daemon)
+        .await
+        .unwrap();
+    server.await.unwrap();
+    assert_eq!(spawner.requests.lock().unwrap().len(), 1);
+}
+
+fn app_mention(event_id: &str, text: &str) -> SlackMessageEvent {
+    SlackMessageEvent {
+        event_id: Some(event_id.to_string()),
+        channel_id: "C123".to_string(),
+        user_id: Some("U123".to_string()),
+        text: text.to_string(),
+        ts: "1780792150.138669".to_string(),
+        thread_ts: None,
+        bot_id: None,
+        app_mention: true,
+    }
+}
+
+fn daemon_config(root: &std::path::Path) -> SlackDaemonConfig {
+    SlackDaemonConfig {
+        workspace_root: root.to_path_buf(),
+        allowed_channels: vec!["C123".to_string()],
+        allowed_users: vec!["U123".to_string()],
+        channel_repos: BTreeMap::from([("C123".to_string(), root.to_path_buf())]),
+    }
+}
+
+#[tokio::test]
+async fn fake_socket_root_event_starts_fake_loop_and_posts_thread_reply() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state,
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let action = daemon
+        .handle_event(app_mention("Ev1", "<@B123> build a Slack surface"))
+        .await
+        .unwrap();
+
+    let HandlerAction::StartLoop {
+        loop_id, prompt, ..
+    } = action
+    else {
+        panic!("expected StartLoop action");
+    };
+    assert_eq!(prompt, "build a Slack surface");
+
+    let requests = spawner.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].loop_id, loop_id);
+    assert_eq!(requests[0].prompt, "build a Slack surface");
+    assert_eq!(
+        requests[0].env.get("RALPH_SLACK_CHANNEL_ID").unwrap(),
+        "C123"
+    );
+    assert_eq!(
+        requests[0].env.get("RALPH_SLACK_THREAD_TS").unwrap(),
+        "1780792150.138669"
+    );
+
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].0, "C123");
+    assert_eq!(messages[0].1, "1780792150.138669");
+    assert!(messages[0].2.contains("Ralph loop started"));
+}
+
+#[tokio::test]
+async fn reply_event_writes_to_bound_loop_events_file_and_duplicate_is_ignored() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let worktree_ralph = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph");
+    std::fs::create_dir_all(&worktree_ralph).unwrap();
+    std::fs::write(
+        worktree_ralph.join("current-events"),
+        ".ralph/events-live.jsonl",
+    )
+    .unwrap();
+
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state,
+        spawner.clone(),
+        notifier,
+    );
+
+    let reply = SlackMessageEvent {
+        event_id: Some("Ev2".to_string()),
+        channel_id: "C123".to_string(),
+        user_id: Some("U123".to_string()),
+        text: "please steer this way".to_string(),
+        ts: "1780792160.000100".to_string(),
+        thread_ts: Some("1780792150.138669".to_string()),
+        bot_id: None,
+        app_mention: false,
+    };
+
+    let action = daemon.handle_event(reply.clone()).await.unwrap();
+    assert!(matches!(action, HandlerAction::Appended { .. }));
+    let duplicate = daemon.handle_event(reply).await.unwrap();
+    assert_eq!(duplicate, HandlerAction::Duplicate);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+
+    let events_path = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph/events-live.jsonl");
+    let events = std::fs::read_to_string(events_path).unwrap();
+    assert!(events.contains("human.guidance"));
+    assert!(events.contains("please steer this way"));
+}
+
+#[tokio::test]
+async fn unauthorized_root_event_does_not_spawn_or_bind_thread() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: temp_dir.path().to_path_buf(),
+            allowed_channels: vec!["C999".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            channel_repos: BTreeMap::from([("C999".to_string(), temp_dir.path().to_path_buf())]),
+        },
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    let action = daemon
+        .handle_event(app_mention("Ev3", "<@B123> no side effects"))
+        .await
+        .unwrap();
+    assert_eq!(action, HandlerAction::Ignored);
+    assert!(spawner.requests.lock().unwrap().is_empty());
+    assert!(notifier.messages.lock().unwrap().is_empty());
+    assert!(state.load().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn root_event_resolves_repo_from_channel_mapping_and_unknown_channel_does_not_spawn() {
+    let daemon_root = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+    let state = SlackStateManager::new(daemon_root.path().join(".ralph/slack-state.json"));
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: daemon_root.path().to_path_buf(),
+            allowed_channels: vec!["C123".to_string(), "C999".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            channel_repos: BTreeMap::from([("C123".to_string(), repo_root.path().to_path_buf())]),
+        },
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    daemon
+        .handle_event(app_mention("EvRepo", "<@B123> build here"))
+        .await
+        .unwrap();
+
+    let requests = spawner.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].workspace_root, repo_root.path());
+    assert_eq!(
+        requests[0].env.get("RALPH_WORKSPACE_ROOT").unwrap(),
+        &repo_root.path().to_string_lossy().to_string()
+    );
+    drop(requests);
+    let bound = state
+        .load_or_default()
+        .unwrap()
+        .threads
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    assert_eq!(bound.workspace_root, repo_root.path());
+
+    let denied = SlackMessageEvent {
+        event_id: Some("EvUnknownRepo".to_string()),
+        channel_id: "C999".to_string(),
+        user_id: Some("U123".to_string()),
+        text: "<@B123> build nowhere".to_string(),
+        ts: "1780792151.000000".to_string(),
+        thread_ts: None,
+        bot_id: None,
+        app_mention: true,
+    };
+    let action = daemon.handle_event(denied).await.unwrap();
+    assert_eq!(action, HandlerAction::Ignored);
+    assert_eq!(spawner.requests.lock().unwrap().len(), 1);
+    assert_eq!(notifier.messages.lock().unwrap().len(), 2);
+    assert!(
+        notifier.messages.lock().unwrap()[1]
+            .2
+            .contains("not configured")
+    );
+    let state_after_denial = state.load_or_default().unwrap();
+    assert!(
+        !state_after_denial
+            .thread_to_loop
+            .contains_key("C999:1780792151.000000"),
+        "missing repo mapping must not bind a thread"
+    );
+}
+
+#[tokio::test]
+async fn thread_reply_uses_persisted_repo_root_not_daemon_workspace_root() {
+    let daemon_root = tempfile::tempdir().unwrap();
+    let repo_root = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let worktree_ralph = repo_root
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph");
+    std::fs::create_dir_all(&worktree_ralph).unwrap();
+    std::fs::write(
+        worktree_ralph.join("current-events"),
+        ".ralph/events-live.jsonl",
+    )
+    .unwrap();
+    let state = SlackStateManager::new(daemon_root.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            repo_root.path(),
+        )
+        .unwrap();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: daemon_root.path().to_path_buf(),
+            allowed_channels: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string()],
+            channel_repos: BTreeMap::from([("C123".to_string(), repo_root.path().to_path_buf())]),
+        },
+        state,
+        FakeSpawner::default(),
+        FakeNotifier::default(),
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvPersistedRepo".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "use the bound repo".to_string(),
+            ts: "1780792160.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+
+    let events = std::fs::read_to_string(
+        repo_root
+            .path()
+            .join(".worktrees")
+            .join(loop_id)
+            .join(".ralph/events-live.jsonl"),
+    )
+    .unwrap();
+    assert!(events.contains("use the bound repo"));
+    assert!(!daemon_root.path().join(".worktrees").join(loop_id).exists());
+}
+
+#[tokio::test]
+async fn known_thread_help_status_tail_are_replies_not_guidance_and_status_wins_over_pending() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let events_dir = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph");
+    std::fs::create_dir_all(&events_dir).unwrap();
+    std::fs::write(
+        events_dir.join("current-events"),
+        ".ralph/events-live.jsonl",
+    )
+    .unwrap();
+    std::fs::write(
+        events_dir.join("events-live.jsonl"),
+        "{\"topic\":\"checkpoint\",\"payload\":\"secret-token-1234567890 latest\"}\n",
+    )
+    .unwrap();
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state
+        .add_pending_question(loop_id, "C123", "1780792150.138669", "1780792200.000100")
+        .unwrap();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        FakeSpawner::default(),
+        notifier.clone(),
+    );
+
+    for (idx, text) in ["help", "status", "tail 1"].iter().enumerate() {
+        daemon
+            .handle_event(SlackMessageEvent {
+                event_id: Some(format!("EvCmd{idx}")),
+                channel_id: "C123".to_string(),
+                user_id: Some("U123".to_string()),
+                text: text.to_string(),
+                ts: format!("178079216{idx}.000100"),
+                thread_ts: Some("1780792150.138669".to_string()),
+                bot_id: None,
+                app_mention: false,
+            })
+            .await
+            .unwrap();
+    }
+
+    let messages = notifier.messages.lock().unwrap();
+    assert_eq!(messages.len(), 3);
+    assert!(messages[0].2.contains("help"));
+    assert!(messages[1].2.contains(loop_id));
+    assert!(messages[1].2.contains("pending question: yes"));
+    assert!(messages[2].2.contains("checkpoint"));
+    assert!(!messages[2].2.contains("secret-token-1234567890"));
+    assert!(state.has_pending_question(loop_id).unwrap());
+    let events = std::fs::read_to_string(events_dir.join("events-live.jsonl")).unwrap();
+    assert!(!events.contains("human.guidance"));
+}
+
+#[tokio::test]
+async fn pending_question_non_command_routes_response_and_command_does_not_clear_pending() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state
+        .add_pending_question(loop_id, "C123", "1780792150.138669", "1780792200.000100")
+        .unwrap();
+    let daemon = SlackDaemon::new(
+        daemon_config(temp_dir.path()),
+        state.clone(),
+        FakeSpawner::default(),
+        FakeNotifier::default(),
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvStatusPending".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "status".to_string(),
+            ts: "1780792160.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+    assert!(state.has_pending_question(loop_id).unwrap());
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvResponsePending".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "the answer".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+    assert!(!state.has_pending_question(loop_id).unwrap());
+    let events = std::fs::read_to_string(
+        temp_dir
+            .path()
+            .join(".worktrees")
+            .join(loop_id)
+            .join(".ralph/events.jsonl"),
+    )
+    .unwrap();
+    assert!(events.contains("human.response"));
+    assert!(events.contains("the answer"));
+}
+
+#[tokio::test]
+async fn stop_cancel_is_creator_only_marks_stopped_and_blocks_future_guidance() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let loop_id = "slack-C123-1780792150-138669";
+    let state = SlackStateManager::new(temp_dir.path().join(".ralph/slack-state.json"));
+    state
+        .bind_thread(
+            loop_id,
+            "C123",
+            "1780792150.138669",
+            "U123",
+            temp_dir.path(),
+        )
+        .unwrap();
+    state.set_thread_process_id(loop_id, Some(4242)).unwrap();
+    let spawner = FakeSpawner::default();
+    let notifier = FakeNotifier::default();
+    let daemon = SlackDaemon::new(
+        SlackDaemonConfig {
+            workspace_root: temp_dir.path().to_path_buf(),
+            allowed_channels: vec!["C123".to_string()],
+            allowed_users: vec!["U123".to_string(), "U999".to_string()],
+            channel_repos: BTreeMap::from([("C123".to_string(), temp_dir.path().to_path_buf())]),
+        },
+        state.clone(),
+        spawner.clone(),
+        notifier.clone(),
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvStopDenied".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U999".to_string()),
+            text: "stop".to_string(),
+            ts: "1780792160.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+    assert!(spawner.stopped.lock().unwrap().is_empty());
+    assert_eq!(
+        state.load_or_default().unwrap().threads[loop_id].status,
+        SlackThreadStatus::Running
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvStopAllowed".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "cancel".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+    assert_eq!(*spawner.stopped.lock().unwrap(), vec![4242]);
+    assert_eq!(
+        state.load_or_default().unwrap().threads[loop_id].status,
+        SlackThreadStatus::Stopped
+    );
+
+    daemon
+        .handle_event(SlackMessageEvent {
+            event_id: Some("EvAfterStop".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "keep going".to_string(),
+            ts: "1780792162.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        })
+        .await
+        .unwrap();
+    let events_path = temp_dir
+        .path()
+        .join(".worktrees")
+        .join(loop_id)
+        .join(".ralph/events.jsonl");
+    assert!(!events_path.exists());
+    assert!(
+        notifier
+            .messages
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(_, _, text)| text.contains("stopped"))
+    );
+}

--- a/crates/ralph-slack/tests/slack_renderer.rs
+++ b/crates/ralph-slack/tests/slack_renderer.rs
@@ -71,9 +71,10 @@ fn final_status_and_help_cards_have_fallback_text() {
         .find(|block| block["type"] == "actions")
         .expect("final card should include interactive actions");
     assert!(final_actions.to_string().contains("ralph_slack_tail"));
-    assert!(final_actions.to_string().contains("ralph_slack_approve"));
+    assert!(final_actions.to_string().contains("ralph_slack_status"));
+    assert!(!final_actions.to_string().contains("ralph_slack_approve"));
     assert!(
-        final_actions
+        !final_actions
             .to_string()
             .contains("ralph_slack_request_changes")
     );

--- a/crates/ralph-slack/tests/slack_renderer.rs
+++ b/crates/ralph-slack/tests/slack_renderer.rs
@@ -65,11 +65,17 @@ fn final_status_and_help_cards_have_fallback_text() {
     assert!(final_card.text.contains("completed"));
     assert!(status_card.text.contains("pending question: no"));
     assert!(help_card.text.contains("Ralph Slack commands"));
+    let final_actions = final_card
+        .blocks
+        .iter()
+        .find(|block| block["type"] == "actions")
+        .expect("final card should include interactive actions");
+    assert!(final_actions.to_string().contains("ralph_slack_tail"));
+    assert!(final_actions.to_string().contains("ralph_slack_approve"));
     assert!(
-        final_card
-            .blocks
-            .iter()
-            .any(|block| block["type"] == "actions")
+        final_actions
+            .to_string()
+            .contains("ralph_slack_request_changes")
     );
     assert!(
         status_card

--- a/crates/ralph-slack/tests/slack_renderer.rs
+++ b/crates/ralph-slack/tests/slack_renderer.rs
@@ -21,6 +21,12 @@ fn start_card_has_block_kit_actions_and_plain_text_fallback() {
     assert!(message.blocks.iter().any(|block| {
         block["type"] == "context" && block.to_string().contains("feat/slack-thread-surface")
     }));
+    assert!(
+        message
+            .blocks
+            .iter()
+            .any(|block| block.to_string().contains("ralph_slack_obs"))
+    );
 }
 
 #[test]
@@ -30,12 +36,13 @@ fn progress_card_is_concise_and_redacts_secret_shaped_tokens() {
         Some(3),
         Some("builder"),
         "work.progress",
-        "created xoxb-secret-token-123 in scratch",
+        "created xoxb-s...-123 and XAPP-UPPERSECRET in scratch",
         Some(125),
     );
 
     assert!(message.text.contains("Ralph update"));
-    assert!(!message.text.contains("xoxb-secret-token-123"));
+    assert!(!message.text.contains("xoxb-s...-123"));
+    assert!(!message.text.contains("XAPP-UPPERSECRET"));
     assert!(message.text.contains("[redacted]"));
     assert!(
         message
@@ -65,6 +72,7 @@ fn final_status_and_help_cards_have_fallback_text() {
     assert!(final_card.text.contains("completed"));
     assert!(status_card.text.contains("pending question: no"));
     assert!(help_card.text.contains("Ralph Slack commands"));
+    assert!(help_card.text.contains("obs"));
     assert!(help_card.text.contains("repo"));
     let final_actions = final_card
         .blocks
@@ -72,6 +80,7 @@ fn final_status_and_help_cards_have_fallback_text() {
         .find(|block| block["type"] == "actions")
         .expect("final card should include interactive actions");
     assert!(final_actions.to_string().contains("ralph_slack_tail"));
+    assert!(final_actions.to_string().contains("ralph_slack_obs"));
     assert!(final_actions.to_string().contains("ralph_slack_status"));
     assert!(!final_actions.to_string().contains("ralph_slack_approve"));
     assert!(

--- a/crates/ralph-slack/tests/slack_renderer.rs
+++ b/crates/ralph-slack/tests/slack_renderer.rs
@@ -1,0 +1,86 @@
+use ralph_slack::{SlackBlocks, SlackThreadStatus};
+
+#[test]
+fn start_card_has_block_kit_actions_and_plain_text_fallback() {
+    let message = SlackBlocks::start_card(
+        "slack-C123-1780792150-138669",
+        "build a Slack surface with useful progress cards",
+        Some("/repo/ralph"),
+        Some("feat/slack-thread-surface"),
+    );
+
+    assert!(message.text.contains("Ralph loop started"));
+    assert!(message.text.contains("slack-C123-1780792150-138669"));
+    assert_eq!(message.blocks[0]["type"], "header");
+    assert!(
+        message
+            .blocks
+            .iter()
+            .any(|block| block["type"] == "actions")
+    );
+    assert!(message.blocks.iter().any(|block| {
+        block["type"] == "context" && block.to_string().contains("feat/slack-thread-surface")
+    }));
+}
+
+#[test]
+fn progress_card_is_concise_and_redacts_secret_shaped_tokens() {
+    let message = SlackBlocks::progress_card(
+        "slack-C123-1780792150-138669",
+        Some(3),
+        Some("builder"),
+        "work.progress",
+        "created xoxb-secret-token-123 in scratch",
+        Some(125),
+    );
+
+    assert!(message.text.contains("Ralph update"));
+    assert!(!message.text.contains("xoxb-secret-token-123"));
+    assert!(message.text.contains("[redacted]"));
+    assert!(
+        message
+            .blocks
+            .iter()
+            .any(|block| block.to_string().contains("builder"))
+    );
+}
+
+#[test]
+fn final_status_and_help_cards_have_fallback_text() {
+    let final_card = SlackBlocks::final_card(
+        "slack-C123-1780792150-138669",
+        SlackThreadStatus::Completed,
+        Some(360),
+        Some("Use `tail 10` for recent events."),
+    );
+    let status_card = SlackBlocks::status_card(
+        "slack-C123-1780792150-138669",
+        SlackThreadStatus::Running,
+        "/repo/ralph",
+        false,
+        Some(4242),
+    );
+    let help_card = SlackBlocks::help_card();
+
+    assert!(final_card.text.contains("completed"));
+    assert!(status_card.text.contains("pending question: no"));
+    assert!(help_card.text.contains("Ralph Slack commands"));
+    assert!(
+        final_card
+            .blocks
+            .iter()
+            .any(|block| block["type"] == "actions")
+    );
+    assert!(
+        status_card
+            .blocks
+            .iter()
+            .any(|block| block["type"] == "section")
+    );
+    assert!(
+        help_card
+            .blocks
+            .iter()
+            .any(|block| block["type"] == "section")
+    );
+}

--- a/crates/ralph-slack/tests/slack_renderer.rs
+++ b/crates/ralph-slack/tests/slack_renderer.rs
@@ -65,6 +65,7 @@ fn final_status_and_help_cards_have_fallback_text() {
     assert!(final_card.text.contains("completed"));
     assert!(status_card.text.contains("pending question: no"));
     assert!(help_card.text.contains("Ralph Slack commands"));
+    assert!(help_card.text.contains("repo"));
     let final_actions = final_card
         .blocks
         .iter()

--- a/crates/ralph-slack/tests/slack_routing.rs
+++ b/crates/ralph-slack/tests/slack_routing.rs
@@ -36,6 +36,10 @@ fn slack_state_round_trips_thread_binding_pending_question_and_event_dedupe() {
     assert_eq!(binding.created_by, "U123");
     assert_eq!(binding.workspace_root, dir.path());
     assert_eq!(binding.status, SlackThreadStatus::Running);
+    assert_eq!(binding.start_card_ts.as_deref(), None);
+    assert_eq!(binding.progress_message_ts.as_deref(), None);
+    assert_eq!(binding.stream_ts.as_deref(), None);
+    assert_eq!(binding.final_card_ts.as_deref(), None);
     assert_eq!(
         loaded.thread_to_loop["C123:1780792150.138669"],
         "slack-C123-1780792150-138669"
@@ -45,6 +49,65 @@ fn slack_state_round_trips_thread_binding_pending_question_and_event_dedupe() {
         "1780792160.000100"
     );
     assert!(loaded.seen_event_ids.contains(&"Ev123".to_string()));
+}
+
+#[test]
+fn slack_state_loads_old_json_without_message_timestamps_and_can_set_card_timestamps() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join(".ralph/slack-state.json");
+    std::fs::create_dir_all(state_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &state_path,
+        serde_json::json!({
+            "team_id": null,
+            "last_socket_envelope_id": null,
+            "threads": {
+                "slack-C123-1780792150-138669": {
+                    "loop_id": "slack-C123-1780792150-138669",
+                    "channel_id": "C123",
+                    "thread_ts": "1780792150.138669",
+                    "root_ts": "1780792150.138669",
+                    "created_by": "U123",
+                    "created_at": "2026-06-06T19:30:27Z",
+                    "workspace_root": dir.path(),
+                    "status": "running",
+                    "process_id": 4242
+                }
+            },
+            "thread_to_loop": {"C123:1780792150.138669": "slack-C123-1780792150-138669"},
+            "pending_questions": {},
+            "seen_event_ids": []
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let manager = SlackStateManager::new(&state_path);
+
+    let loaded = manager.load_or_default().unwrap();
+    let binding = loaded.threads.get("slack-C123-1780792150-138669").unwrap();
+    assert_eq!(binding.start_card_ts, None);
+    assert_eq!(binding.progress_message_ts, None);
+    assert_eq!(binding.stream_ts, None);
+    assert_eq!(binding.final_card_ts, None);
+
+    manager
+        .set_thread_message_timestamps(
+            "slack-C123-1780792150-138669",
+            Some("1780792160.000100"),
+            Some("1780792170.000100"),
+            Some("stream-1"),
+            Some("1780792180.000100"),
+        )
+        .unwrap();
+    let updated = manager.load_or_default().unwrap();
+    let binding = updated.threads.get("slack-C123-1780792150-138669").unwrap();
+    assert_eq!(binding.start_card_ts.as_deref(), Some("1780792160.000100"));
+    assert_eq!(
+        binding.progress_message_ts.as_deref(),
+        Some("1780792170.000100")
+    );
+    assert_eq!(binding.stream_ts.as_deref(), Some("stream-1"));
+    assert_eq!(binding.final_card_ts.as_deref(), Some("1780792180.000100"));
 }
 
 #[test]

--- a/crates/ralph-slack/tests/slack_routing.rs
+++ b/crates/ralph-slack/tests/slack_routing.rs
@@ -1,0 +1,274 @@
+use ralph_slack::{
+    HandlerAction, SlackMessageEvent, SlackStateManager, SlackThreadStatus, handle_message,
+};
+use tempfile::TempDir;
+
+#[test]
+fn slack_state_round_trips_thread_binding_pending_question_and_event_dedupe() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join(".ralph/slack-state.json");
+    let manager = SlackStateManager::new(&state_path);
+
+    manager
+        .bind_thread(
+            "slack-C123-1780792150-138669",
+            "C123",
+            "1780792150.138669",
+            "U123",
+            dir.path(),
+        )
+        .unwrap();
+    manager
+        .add_pending_question(
+            "slack-C123-1780792150-138669",
+            "C123",
+            "1780792150.138669",
+            "1780792160.000100",
+        )
+        .unwrap();
+    assert!(manager.mark_event_seen("Ev123").unwrap());
+    assert!(!manager.mark_event_seen("Ev123").unwrap());
+
+    let loaded = manager.load().unwrap().unwrap();
+    let binding = loaded.threads.get("slack-C123-1780792150-138669").unwrap();
+    assert_eq!(binding.channel_id, "C123");
+    assert_eq!(binding.thread_ts, "1780792150.138669");
+    assert_eq!(binding.created_by, "U123");
+    assert_eq!(binding.workspace_root, dir.path());
+    assert_eq!(binding.status, SlackThreadStatus::Running);
+    assert_eq!(
+        loaded.thread_to_loop["C123:1780792150.138669"],
+        "slack-C123-1780792150-138669"
+    );
+    assert_eq!(
+        loaded.pending_questions["slack-C123-1780792150-138669"].message_ts,
+        "1780792160.000100"
+    );
+    assert!(loaded.seen_event_ids.contains(&"Ev123".to_string()));
+}
+
+#[test]
+fn known_thread_with_pending_question_writes_human_response_and_clears_pending() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join(".ralph/slack-state.json");
+    let manager = SlackStateManager::new(&state_path);
+    manager
+        .bind_thread(
+            "slack-C123-1780792150-138669",
+            "C123",
+            "1780792150.138669",
+            "U123",
+            dir.path(),
+        )
+        .unwrap();
+    manager
+        .add_pending_question(
+            "slack-C123-1780792150-138669",
+            "C123",
+            "1780792150.138669",
+            "1780792160.000100",
+        )
+        .unwrap();
+
+    let action = handle_message(
+        &manager,
+        dir.path(),
+        &["C123".to_string()],
+        &["U123".to_string()],
+        SlackMessageEvent {
+            event_id: Some("Ev-response".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "ship it".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        action,
+        HandlerAction::Appended {
+            topic: "human.response".to_string(),
+            loop_id: "slack-C123-1780792150-138669".to_string()
+        }
+    );
+    let events = std::fs::read_to_string(
+        dir.path()
+            .join(".worktrees/slack-C123-1780792150-138669/.ralph/events.jsonl"),
+    )
+    .unwrap();
+    let event: serde_json::Value = serde_json::from_str(events.trim()).unwrap();
+    assert_eq!(event["topic"], "human.response");
+    assert_eq!(event["payload"], "ship it");
+    let state = manager.load_or_default().unwrap();
+    assert!(
+        !state
+            .pending_questions
+            .contains_key("slack-C123-1780792150-138669")
+    );
+}
+
+#[test]
+fn known_thread_without_pending_question_writes_human_guidance() {
+    let dir = TempDir::new().unwrap();
+    let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+    manager
+        .bind_thread(
+            "slack-C123-1780792150-138669",
+            "C123",
+            "1780792150.138669",
+            "U123",
+            dir.path(),
+        )
+        .unwrap();
+
+    let action = handle_message(
+        &manager,
+        dir.path(),
+        &["C123".to_string()],
+        &["U123".to_string()],
+        SlackMessageEvent {
+            event_id: Some("Ev-guidance".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "prefer small diffs".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        action,
+        HandlerAction::Appended {
+            topic: "human.guidance".to_string(),
+            loop_id: "slack-C123-1780792150-138669".to_string()
+        }
+    );
+}
+
+#[test]
+fn unauthorized_user_is_rejected_before_state_changes() {
+    let dir = TempDir::new().unwrap();
+    let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+
+    let action = handle_message(
+        &manager,
+        dir.path(),
+        &["C123".to_string()],
+        &["U123".to_string()],
+        SlackMessageEvent {
+            event_id: Some("Ev-reject".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U999".to_string()),
+            text: "malicious".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert!(manager.load().unwrap().is_none());
+}
+
+#[test]
+fn empty_authorization_lists_reject_before_event_dedupe_or_state_changes() {
+    let dir = TempDir::new().unwrap();
+    let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+
+    let action = handle_message(
+        &manager,
+        dir.path(),
+        &[],
+        &[],
+        SlackMessageEvent {
+            event_id: Some("Ev-empty-auth".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "<@URALPH> do not auto-trust me".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: None,
+            bot_id: None,
+            app_mention: true,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(action, HandlerAction::Ignored);
+    assert!(manager.load().unwrap().is_none());
+}
+
+#[test]
+fn root_app_mention_returns_start_loop_action_and_binds_thread() {
+    let dir = TempDir::new().unwrap();
+    let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+
+    let action = handle_message(
+        &manager,
+        dir.path(),
+        &["C123".to_string()],
+        &["U123".to_string()],
+        SlackMessageEvent {
+            event_id: Some("Ev-start".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "<@URALPH> build a plan".to_string(),
+            ts: "1780792150.138669".to_string(),
+            thread_ts: None,
+            bot_id: None,
+            app_mention: true,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        action,
+        HandlerAction::StartLoop {
+            loop_id: "slack-C123-1780792150-138669".to_string(),
+            prompt: "build a plan".to_string(),
+            channel_id: "C123".to_string(),
+            thread_ts: "1780792150.138669".to_string(),
+        }
+    );
+    assert_eq!(
+        manager.load_or_default().unwrap().thread_to_loop["C123:1780792150.138669"],
+        "slack-C123-1780792150-138669"
+    );
+}
+
+#[test]
+fn path_traversal_loop_id_is_rejected() {
+    let dir = TempDir::new().unwrap();
+    let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+    manager
+        .bind_thread("../escape", "C123", "1780792150.138669", "U123", dir.path())
+        .unwrap();
+
+    let err = handle_message(
+        &manager,
+        dir.path(),
+        &["C123".to_string()],
+        &["U123".to_string()],
+        SlackMessageEvent {
+            event_id: Some("Ev-traversal".to_string()),
+            channel_id: "C123".to_string(),
+            user_id: Some("U123".to_string()),
+            text: "try escape".to_string(),
+            ts: "1780792161.000100".to_string(),
+            thread_ts: Some("1780792150.138669".to_string()),
+            bot_id: None,
+            app_mention: false,
+        },
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("invalid Slack loop id"));
+}

--- a/crates/ralph-slack/tests/slack_runbook.rs
+++ b/crates/ralph-slack/tests/slack_runbook.rs
@@ -1,0 +1,14 @@
+const SLACK_LIVE_SMOKE_RUNBOOK: &str =
+    include_str!("../../../docs/runbooks/slack-live-smoke-test.md");
+
+#[test]
+fn live_smoke_runbook_checks_loop_state_and_logs() {
+    assert!(
+        SLACK_LIVE_SMOKE_RUNBOOK.contains(".ralph/slack-state.json"),
+        "live smoke runbook should tell operators to verify Slack state"
+    );
+    assert!(
+        SLACK_LIVE_SMOKE_RUNBOOK.contains(".ralph/slack-loop-logs/<loop-id>.log"),
+        "live smoke runbook should tell operators to verify the per-loop log"
+    );
+}

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -151,6 +151,41 @@ async fn update_blocks_sends_chat_update_with_existing_message_ts() {
 }
 
 #[tokio::test]
+async fn set_assistant_thread_status_sends_status_payload_and_auth_header() {
+    let (base_url, mut requests) = run_http_double(vec!["{\"ok\":true}"]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    api.set_assistant_thread_status("C123", "1780792150.138669", "is working in ralph")
+        .await
+        .unwrap();
+
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/assistant.threads.setStatus");
+    assert!(request.headers.to_lowercase().contains("authorization"));
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel_id"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+    assert_eq!(body["status"], "is working in ralph");
+}
+
+#[tokio::test]
+async fn set_assistant_thread_status_clears_with_empty_status() {
+    let (base_url, mut requests) = run_http_double(vec!["{\"ok\":true}"]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    api.set_assistant_thread_status("C123", "1780792150.138669", "")
+        .await
+        .unwrap();
+
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/assistant.threads.setStatus");
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel_id"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+    assert_eq!(body["status"], "");
+}
+
+#[tokio::test]
 async fn slack_api_surfaces_slack_error_payloads() {
     let (base_url, _requests) =
         run_http_double(vec![r#"{"ok":false,"error":"channel_not_found"}"#]).await;

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use ralph_proto::RobotService;
-use ralph_slack::{SlackApi, SlackBlocks, SlackService};
+use ralph_slack::{SlackApi, SlackBlocks, SlackError, SlackService, SlackStreamChunk};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -159,6 +159,132 @@ async fn slack_api_surfaces_slack_error_payloads() {
     let err = api.post_message("C404", None, "hello").await.unwrap_err();
 
     assert!(err.to_string().contains("channel_not_found"));
+}
+
+#[tokio::test]
+async fn start_stream_sends_markdown_and_task_update_chunks_to_thread() {
+    let (base_url, mut requests) = run_http_double(vec![
+        serde_json::json!({"ok": true, "ts": "1780792160.000400"}).to_string(),
+    ])
+    .await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    let ts = api
+        .start_stream(
+            "C123",
+            "1780792150.138669",
+            Some("U123"),
+            Some("T123"),
+            Some("*Starting Ralph loop*"),
+            vec![SlackStreamChunk::task_update(
+                "slack-C123-1780792150-138669",
+                "Run Ralph loop",
+                "in_progress",
+                Some("executor is inspecting the repo"),
+                None,
+            )],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(ts, "1780792160.000400");
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/chat.startStream");
+    assert!(request.headers.to_lowercase().contains("authorization"));
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+    assert_eq!(body["recipient_user_id"], "U123");
+    assert_eq!(body["recipient_team_id"], "T123");
+    assert_eq!(body["markdown_text"], "*Starting Ralph loop*");
+    assert_eq!(body["task_display_mode"], "timeline");
+    assert_eq!(body["chunks"][0]["type"], "task_update");
+    assert_eq!(body["chunks"][0]["status"], "in_progress");
+}
+
+#[tokio::test]
+async fn append_stream_sends_markdown_text_and_chunks_to_stream_ts() {
+    let (base_url, mut requests) =
+        run_http_double(vec![serde_json::json!({"ok": true}).to_string()]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    api.append_stream(
+        "C123",
+        "1780792160.000400",
+        "Loop made progress",
+        vec![SlackStreamChunk::markdown_text("*executor* finished tests")],
+    )
+    .await
+    .unwrap();
+
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/chat.appendStream");
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel"], "C123");
+    assert_eq!(body["ts"], "1780792160.000400");
+    assert_eq!(body["markdown_text"], "Loop made progress");
+    assert_eq!(body["chunks"][0]["type"], "markdown_text");
+    assert_eq!(body["chunks"][0]["text"], "*executor* finished tests");
+}
+
+#[tokio::test]
+async fn stop_stream_sends_final_markdown_blocks_and_metadata() {
+    let (base_url, mut requests) =
+        run_http_double(vec![serde_json::json!({"ok": true}).to_string()]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+    let final_blocks = SlackBlocks::help_card();
+
+    api.stop_stream(
+        "C123",
+        "1780792160.000400",
+        Some("Loop complete"),
+        vec![SlackStreamChunk::task_update(
+            "final-review",
+            "Final review",
+            "complete",
+            None,
+            Some("accepted"),
+        )],
+        Some(final_blocks.blocks.clone()),
+        Some(serde_json::json!({
+            "event_type": "ralph_loop_completed",
+            "event_payload": {"loop_id": "slack-C123-1780792150-138669"}
+        })),
+    )
+    .await
+    .unwrap();
+
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/chat.stopStream");
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel"], "C123");
+    assert_eq!(body["ts"], "1780792160.000400");
+    assert_eq!(body["markdown_text"], "Loop complete");
+    assert_eq!(body["chunks"][0]["type"], "task_update");
+    assert_eq!(body["blocks"][0]["type"], "header");
+    assert_eq!(body["metadata"]["event_type"], "ralph_loop_completed");
+}
+
+#[tokio::test]
+async fn streaming_api_errors_can_be_classified_for_update_card_fallback() {
+    let (base_url, _requests) = run_http_double(vec![
+        serde_json::json!({"ok": false, "error": "unsupported_method"}).to_string(),
+    ])
+    .await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    let err = api
+        .append_stream("C123", "1780792160.000400", "hello", vec![])
+        .await
+        .unwrap_err();
+
+    assert!(SlackApi::is_streaming_fallback_error(&err));
+    assert!(SlackApi::is_streaming_fallback_error(&SlackError::Api(
+        "missing_scope".to_string()
+    )));
+    assert!(!SlackApi::is_streaming_fallback_error(&SlackError::Api(
+        "channel_not_found".to_string()
+    )));
 }
 
 #[tokio::test]

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use ralph_proto::RobotService;
-use ralph_slack::{SlackApi, SlackService};
+use ralph_slack::{SlackApi, SlackBlocks, SlackService};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -80,6 +80,46 @@ async fn post_message_sends_expected_slack_payload_and_auth_header() {
     assert_eq!(body["channel"], "C123");
     assert_eq!(body["thread_ts"], "1780792150.138669");
     assert_eq!(body["text"], "hello slack");
+}
+
+#[tokio::test]
+async fn post_blocks_sends_block_kit_payload_with_plain_text_fallback() {
+    let (base_url, mut requests) =
+        run_http_double(vec![r#"{"ok":true,"ts":"1780792160.000200"}"#]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+    let blocks = SlackBlocks::start_card(
+        "slack-C123-1780792150-138669",
+        "polish Slack output",
+        Some("/repo/ralph"),
+        Some("feat/slack-thread-surface"),
+    );
+
+    let ts = api
+        .post_blocks("C123", Some("1780792150.138669"), &blocks)
+        .await
+        .unwrap();
+
+    assert_eq!(ts, "1780792160.000200");
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/chat.postMessage");
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+    assert!(
+        body["text"]
+            .as_str()
+            .unwrap()
+            .contains("Ralph loop started")
+    );
+    assert_eq!(body["blocks"][0]["type"], "header");
+    assert_eq!(body["blocks"][1]["type"], "context");
+    assert!(body["blocks"].as_array().unwrap().iter().any(|block| {
+        block["type"] == "actions"
+            && block["elements"].as_array().unwrap().iter().any(|element| {
+                element["action_id"] == "ralph_slack_status"
+                    && element["value"] == "slack-C123-1780792150-138669"
+            })
+    }));
 }
 
 #[tokio::test]

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -1,0 +1,223 @@
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use ralph_proto::RobotService;
+use ralph_slack::{SlackApi, SlackService};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+
+struct CapturedRequest {
+    path: String,
+    headers: String,
+    body: String,
+}
+
+async fn run_http_double(
+    responses: Vec<&'static str>,
+) -> (String, mpsc::Receiver<CapturedRequest>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::channel(8);
+    let responses: Vec<String> = responses.into_iter().map(ToString::to_string).collect();
+
+    tokio::spawn(async move {
+        for response in responses {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0; 8192];
+            let n = stream.read(&mut buf).await.unwrap();
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            let (head, body) = request.split_once("\r\n\r\n").unwrap_or((&request, ""));
+            let path = head
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .unwrap_or("")
+                .to_string();
+            tx.send(CapturedRequest {
+                path,
+                headers: head.to_string(),
+                body: body.to_string(),
+            })
+            .await
+            .unwrap();
+            let http = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                response.len(),
+                response
+            );
+            stream.write_all(http.as_bytes()).await.unwrap();
+        }
+    });
+
+    (format!("http://{}", addr), rx)
+}
+
+#[tokio::test]
+async fn post_message_sends_expected_slack_payload_and_auth_header() {
+    let (base_url, mut requests) =
+        run_http_double(vec![r#"{"ok":true,"ts":"1780792160.000100"}"#]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    let ts = api
+        .post_message("C123", Some("1780792150.138669"), "hello slack")
+        .await
+        .unwrap();
+
+    assert_eq!(ts, "1780792160.000100");
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/chat.postMessage");
+    assert!(request.headers.to_lowercase().contains("authorization"));
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+    assert_eq!(body["text"], "hello slack");
+}
+
+#[tokio::test]
+async fn slack_api_surfaces_slack_error_payloads() {
+    let (base_url, _requests) =
+        run_http_double(vec![r#"{"ok":false,"error":"channel_not_found"}"#]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    let err = api.post_message("C404", None, "hello").await.unwrap_err();
+
+    assert!(err.to_string().contains("channel_not_found"));
+}
+
+#[tokio::test]
+async fn open_socket_mode_url_posts_to_apps_connections_open_with_app_token() {
+    let (base_url, mut requests) =
+        run_http_double(vec![r#"{"ok":true,"url":"wss://socket.slack.test/abc"}"#]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+
+    let url = api.open_socket_mode_url("app-token").await.unwrap();
+
+    assert_eq!(url, "wss://socket.slack.test/abc");
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/apps.connections.open");
+    assert!(request.headers.to_lowercase().contains("authorization"));
+}
+
+#[test]
+fn slack_service_waits_for_human_response_and_removes_pending_question() {
+    let dir = TempDir::new().unwrap();
+    let events_path = dir.path().join(".ralph/events.jsonl");
+    std::fs::create_dir_all(events_path.parent().unwrap()).unwrap();
+    std::fs::write(&events_path, "").unwrap();
+
+    let service = SlackService::new(
+        dir.path().to_path_buf(),
+        Some("bot-token".to_string()),
+        5,
+        "slack-C123-1780792150-138669".to_string(),
+        "C123".to_string(),
+        "1780792150.138669".to_string(),
+        Some("http://127.0.0.1:9".to_string()),
+    )
+    .unwrap();
+    service
+        .state_manager()
+        .add_pending_question(
+            "slack-C123-1780792150-138669",
+            "C123",
+            "1780792150.138669",
+            "1780792160.000100",
+        )
+        .unwrap();
+
+    let writer_path = events_path.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(150));
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&writer_path)
+            .unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({"topic":"human.response","payload":"ship it","ts":"2026-06-06T19:30:27Z"})
+        )
+        .unwrap();
+    });
+
+    let response = service.wait_for_response(Path::new(&events_path)).unwrap();
+
+    assert_eq!(response, Some("ship it".to_string()));
+    let state = service.state_manager().load_or_default().unwrap();
+    assert!(
+        !state
+            .pending_questions
+            .contains_key("slack-C123-1780792150-138669")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn slack_service_posts_question_and_checkin_to_bound_thread() {
+    let (base_url, mut requests) = run_http_double(vec![
+        r#"{"ok":true,"ts":"1780792160.000100"}"#,
+        r#"{"ok":true,"ts":"1780792170.000100"}"#,
+    ])
+    .await;
+    let dir = TempDir::new().unwrap();
+    let service = SlackService::new(
+        dir.path().to_path_buf(),
+        Some("bot-token".to_string()),
+        5,
+        "slack-C123-1780792150-138669".to_string(),
+        "C123".to_string(),
+        "1780792150.138669".to_string(),
+        Some(base_url),
+    )
+    .unwrap();
+
+    let question_id = tokio::task::block_in_place(|| service.send_question("Proceed?")).unwrap();
+    let checkin_id =
+        tokio::task::block_in_place(|| service.send_checkin(3, Duration::from_secs(125), None))
+            .unwrap();
+
+    assert_eq!(question_id, 1);
+    assert_eq!(checkin_id, 1);
+    let question = requests.recv().await.unwrap();
+    let question_body: serde_json::Value = serde_json::from_str(&question.body).unwrap();
+    assert_eq!(question_body["channel"], "C123");
+    assert_eq!(question_body["thread_ts"], "1780792150.138669");
+    assert_eq!(question_body["text"], "Proceed?");
+    let checkin = requests.recv().await.unwrap();
+    let checkin_body: serde_json::Value = serde_json::from_str(&checkin.body).unwrap();
+    assert!(
+        checkin_body["text"]
+            .as_str()
+            .unwrap()
+            .contains("iteration 3")
+    );
+
+    let state = service.state_manager().load_or_default().unwrap();
+    assert_eq!(
+        state.pending_questions["slack-C123-1780792150-138669"].message_ts,
+        "1780792160.000100"
+    );
+}
+
+#[test]
+fn stop_sets_shutdown_flag() {
+    let dir = TempDir::new().unwrap();
+    let service = SlackService::new(
+        dir.path().to_path_buf(),
+        Some("bot-token".to_string()),
+        5,
+        "slack-C123-1780792150-138669".to_string(),
+        "C123".to_string(),
+        "1780792150.138669".to_string(),
+        Some("http://127.0.0.1:9".to_string()),
+    )
+    .unwrap();
+    let flag = service.shutdown_flag();
+
+    Box::new(service).stop();
+
+    assert!(flag.load(Ordering::Relaxed));
+}

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -123,6 +123,34 @@ async fn post_blocks_sends_block_kit_payload_with_plain_text_fallback() {
 }
 
 #[tokio::test]
+async fn update_blocks_sends_chat_update_with_existing_message_ts() {
+    let (base_url, mut requests) = run_http_double(vec!["{\"ok\":true}"]).await;
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url));
+    let blocks = SlackBlocks::progress_card(
+        "slack-C123-1780792150-138669",
+        Some(2),
+        Some("executor"),
+        "agent.message",
+        "working on Slack UX",
+        Some(12),
+    );
+
+    api.update_blocks("C123", "1780792160.000300", &blocks)
+        .await
+        .unwrap();
+
+    let request = requests.recv().await.unwrap();
+    assert_eq!(request.path, "/api/chat.update");
+    assert!(request.headers.to_lowercase().contains("authorization"));
+    let body: serde_json::Value = serde_json::from_str(&request.body).unwrap();
+    assert_eq!(body["channel"], "C123");
+    assert_eq!(body["ts"], "1780792160.000300");
+    assert!(body["thread_ts"].is_null());
+    assert!(body["text"].as_str().unwrap().contains("Ralph update"));
+    assert_eq!(body["blocks"][0]["type"], "header");
+}
+
+#[tokio::test]
 async fn slack_api_surfaces_slack_error_payloads() {
     let (base_url, _requests) =
         run_http_double(vec![r#"{"ok":false,"error":"channel_not_found"}"#]).await;

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -448,6 +448,39 @@ async fn slack_service_posts_question_and_checkin_to_bound_thread() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn slack_service_can_write_pending_questions_to_shared_state_path() {
+    let (base_url, mut requests) =
+        run_http_double(vec![r#"{"ok":true,"ts":"1780792160.000100"}"#]).await;
+    let worktree = TempDir::new().unwrap();
+    let root = TempDir::new().unwrap();
+    let shared_state = root.path().join(".ralph/slack-state.json");
+    let service = SlackService::new_with_state_path(
+        worktree.path().to_path_buf(),
+        Some("bot-token".to_string()),
+        5,
+        "slack-C123-1780792150-138669".to_string(),
+        "C123".to_string(),
+        "1780792150.138669".to_string(),
+        Some(base_url),
+        Some(shared_state.clone()),
+    )
+    .unwrap();
+
+    tokio::task::block_in_place(|| service.send_question("Proceed?")).unwrap();
+    let _question = requests.recv().await.unwrap();
+
+    assert!(!worktree.path().join(".ralph/slack-state.json").exists());
+    let state = ralph_slack::SlackStateManager::new(shared_state)
+        .load_or_default()
+        .unwrap();
+    assert!(
+        state
+            .pending_questions
+            .contains_key("slack-C123-1780792150-138669")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn slack_service_uploads_files_only_to_bound_thread_and_workspace_paths() {
     let (base_url, mut requests) = run_http_double(vec![
         r#"{"ok":true,"upload_url":"__BASE_URL__/upload/F123","file_id":"F123"}"#,

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -343,7 +343,7 @@ async fn upload_file_external_uses_current_slack_external_upload_flow() {
     std::fs::write(&file_path, "hello artifact").unwrap();
     let (base_url, mut requests) = run_http_double(vec![
         r#"{"ok":true,"upload_url":"__BASE_URL__/upload/F123","file_id":"F123"}"#,
-        r#"{}"#,
+        r"{}",
         r#"{"ok":true}"#,
     ])
     .await;
@@ -519,7 +519,7 @@ async fn slack_service_can_write_pending_questions_to_shared_state_path() {
 async fn slack_service_uploads_files_only_to_bound_thread_and_workspace_paths() {
     let (base_url, mut requests) = run_http_double(vec![
         r#"{"ok":true,"upload_url":"__BASE_URL__/upload/F123","file_id":"F123"}"#,
-        r#"{}"#,
+        r"{}",
         r#"{"ok":true}"#,
     ])
     .await;

--- a/crates/ralph-slack/tests/slack_service.rs
+++ b/crates/ralph-slack/tests/slack_service.rs
@@ -16,16 +16,21 @@ struct CapturedRequest {
     body: String,
 }
 
-async fn run_http_double(
-    responses: Vec<&'static str>,
-) -> (String, mpsc::Receiver<CapturedRequest>) {
+async fn run_http_double<I, S>(responses: I) -> (String, mpsc::Receiver<CapturedRequest>)
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{}", addr);
+    let response_base_url = base_url.clone();
     let (tx, rx) = mpsc::channel(8);
-    let responses: Vec<String> = responses.into_iter().map(ToString::to_string).collect();
+    let responses: Vec<String> = responses.into_iter().map(Into::into).collect();
 
     tokio::spawn(async move {
         for response in responses {
+            let response = response.replace("__BASE_URL__", &response_base_url);
             let (mut stream, _) = listener.accept().await.unwrap();
             let mut buf = vec![0; 8192];
             let n = stream.read(&mut buf).await.unwrap();
@@ -53,7 +58,7 @@ async fn run_http_double(
         }
     });
 
-    (format!("http://{}", addr), rx)
+    (base_url, rx)
 }
 
 #[tokio::test]
@@ -100,6 +105,52 @@ async fn open_socket_mode_url_posts_to_apps_connections_open_with_app_token() {
     let request = requests.recv().await.unwrap();
     assert_eq!(request.path, "/api/apps.connections.open");
     assert!(request.headers.to_lowercase().contains("authorization"));
+}
+
+#[tokio::test]
+async fn upload_file_external_uses_current_slack_external_upload_flow() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("artifact.txt");
+    std::fs::write(&file_path, "hello artifact").unwrap();
+    let (base_url, mut requests) = run_http_double(vec![
+        r#"{"ok":true,"upload_url":"__BASE_URL__/upload/F123","file_id":"F123"}"#,
+        r#"{}"#,
+        r#"{"ok":true}"#,
+    ])
+    .await;
+    let upload_url = format!("{base_url}/upload/F123");
+    let api = SlackApi::new("bot-token".to_string(), Some(base_url.clone()));
+
+    api.upload_file_external(
+        "C123",
+        "1780792150.138669",
+        &file_path,
+        "artifact.txt",
+        14,
+        Some("Artifact caption"),
+    )
+    .await
+    .unwrap();
+
+    let get_url = requests.recv().await.unwrap();
+    assert_eq!(get_url.path, "/api/files.getUploadURLExternal");
+    assert!(get_url.headers.to_lowercase().contains("authorization"));
+    assert!(get_url.body.contains("filename=artifact.txt"));
+    assert!(get_url.body.contains("length=14"));
+
+    let upload = requests.recv().await.unwrap();
+    assert_eq!(upload.path, "/upload/F123");
+    assert!(!upload.headers.to_lowercase().contains("authorization"));
+    assert_eq!(upload.body, "hello artifact");
+    assert_eq!(upload_url, format!("{base_url}/upload/F123"));
+
+    let complete = requests.recv().await.unwrap();
+    assert_eq!(complete.path, "/api/files.completeUploadExternal");
+    let body: serde_json::Value = serde_json::from_str(&complete.body).unwrap();
+    assert_eq!(body["channel_id"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+    assert_eq!(body["files"][0]["id"], "F123");
+    assert_eq!(body["files"][0]["title"], "Artifact caption");
 }
 
 #[test]
@@ -200,6 +251,63 @@ async fn slack_service_posts_question_and_checkin_to_bound_thread() {
         state.pending_questions["slack-C123-1780792150-138669"].message_ts,
         "1780792160.000100"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn slack_service_uploads_files_only_to_bound_thread_and_workspace_paths() {
+    let (base_url, mut requests) = run_http_double(vec![
+        r#"{"ok":true,"upload_url":"__BASE_URL__/upload/F123","file_id":"F123"}"#,
+        r#"{}"#,
+        r#"{"ok":true}"#,
+    ])
+    .await;
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("artifact.txt");
+    std::fs::write(&file_path, "loop-local artifact").unwrap();
+    let service = SlackService::new(
+        dir.path().to_path_buf(),
+        Some("bot-token".to_string()),
+        5,
+        "slack-C123-1780792150-138669".to_string(),
+        "C123".to_string(),
+        "1780792150.138669".to_string(),
+        Some(base_url),
+    )
+    .unwrap();
+
+    let sent =
+        tokio::task::block_in_place(|| service.send_file(&file_path, Some("caption"))).unwrap();
+
+    assert_eq!(sent, 1);
+    let _get_url = requests.recv().await.unwrap();
+    let _upload = requests.recv().await.unwrap();
+    let complete = requests.recv().await.unwrap();
+    let body: serde_json::Value = serde_json::from_str(&complete.body).unwrap();
+    assert_eq!(body["channel_id"], "C123");
+    assert_eq!(body["thread_ts"], "1780792150.138669");
+}
+
+#[test]
+fn slack_service_rejects_non_workspace_files_and_redacts_token_debug() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let outside_file = outside.path().join("secret.txt");
+    std::fs::write(&outside_file, "do not upload").unwrap();
+    let service = SlackService::new(
+        dir.path().to_path_buf(),
+        Some("bot-token-secret".to_string()),
+        5,
+        "slack-C123-1780792150-138669".to_string(),
+        "C123".to_string(),
+        "1780792150.138669".to_string(),
+        Some("http://127.0.0.1:9".to_string()),
+    )
+    .unwrap();
+
+    let err = service.send_file(&outside_file, None).unwrap_err();
+    assert!(err.to_string().contains("outside workspace"));
+    let debug = format!("{service:?}");
+    assert!(!debug.contains("bot-token-secret"));
 }
 
 #[test]

--- a/crates/ralph-slack/tests/slack_socket_mode.rs
+++ b/crates/ralph-slack/tests/slack_socket_mode.rs
@@ -38,6 +38,25 @@ fn block_action_tail_payload_maps_to_existing_thread_command_text() {
 }
 
 #[test]
+fn block_action_payload_without_thread_ts_uses_encoded_loop_id_value() {
+    let payload = serde_json::json!({
+        "type": "block_actions",
+        "trigger_id": "TrigTailReplyCard",
+        "user": {"id": "U123"},
+        "channel": {"id": "C123"},
+        "message": {"ts": "1780799999.000300"},
+        "container": {"message_ts": "1780799999.000300"},
+        "actions": [{"action_id": "ralph_slack_tail", "value": "tail:slack-C123-1780792150-138669"}],
+        "action_ts": "1780799999.000400"
+    });
+
+    let event = slack_message_event_from_payload(&payload).expect("block action should parse");
+
+    assert_eq!(event.thread_ts.as_deref(), Some("1780792150.138669"));
+    assert_eq!(event.text, "tail 10");
+}
+
+#[test]
 fn block_action_approve_payload_routes_as_human_response_on_pending_question() {
     let dir = tempfile::TempDir::new().unwrap();
     let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));

--- a/crates/ralph-slack/tests/slack_socket_mode.rs
+++ b/crates/ralph-slack/tests/slack_socket_mode.rs
@@ -1,0 +1,85 @@
+use ralph_slack::handler::{ThreadCommand, parse_thread_command};
+use ralph_slack::socket_mode::slack_message_event_from_payload;
+use ralph_slack::{HandlerAction, SlackStateManager, handle_message};
+
+#[test]
+fn typed_tail_command_variants_still_parse() {
+    for text in ["tail", "tail 10", "!tail 10", "/tail 10"] {
+        assert_eq!(
+            parse_thread_command(text),
+            Some(ThreadCommand::Tail { n: 10 }),
+            "{text} should route through the existing tail command path"
+        );
+    }
+}
+
+#[test]
+fn block_action_tail_payload_maps_to_existing_thread_command_text() {
+    let payload = serde_json::json!({
+        "type": "block_actions",
+        "trigger_id": "TrigTail",
+        "user": {"id": "U123"},
+        "channel": {"id": "C123"},
+        "message": {"ts": "1780792150.138669", "thread_ts": "1780792150.138669"},
+        "actions": [{"action_id": "ralph_slack_tail", "value": "tail:slack-C123-1780792150-138669"}],
+        "action_ts": "1780792160.000100"
+    });
+
+    let event = slack_message_event_from_payload(&payload).expect("block action should parse");
+
+    assert_eq!(event.channel_id, "C123");
+    assert_eq!(event.user_id.as_deref(), Some("U123"));
+    assert_eq!(event.thread_ts.as_deref(), Some("1780792150.138669"));
+    assert_eq!(event.text, "tail 10");
+    assert_eq!(
+        parse_thread_command(&event.text),
+        Some(ThreadCommand::Tail { n: 10 })
+    );
+}
+
+#[test]
+fn block_action_approve_payload_routes_as_human_response_on_pending_question() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let manager = SlackStateManager::new(dir.path().join(".ralph/slack-state.json"));
+    let loop_id = "slack-C123-1780792150-138669";
+    manager
+        .bind_thread(loop_id, "C123", "1780792150.138669", "U123", dir.path())
+        .unwrap();
+    manager
+        .add_pending_question(loop_id, "C123", "1780792150.138669", "1780792160.000100")
+        .unwrap();
+    let payload = serde_json::json!({
+        "type": "block_actions",
+        "trigger_id": "TrigApprove",
+        "user": {"id": "U123"},
+        "channel": {"id": "C123"},
+        "message": {"ts": "1780792150.138669", "thread_ts": "1780792150.138669"},
+        "actions": [{"action_id": "ralph_slack_approve", "value": "approve:slack-C123-1780792150-138669"}],
+        "action_ts": "1780792160.000200"
+    });
+    let event = slack_message_event_from_payload(&payload).expect("approve action should parse");
+
+    let action = handle_message(
+        &manager,
+        dir.path(),
+        &["C123".to_string()],
+        &["U123".to_string()],
+        event,
+    )
+    .unwrap();
+
+    assert_eq!(
+        action,
+        HandlerAction::Appended {
+            topic: "human.response".to_string(),
+            loop_id: loop_id.to_string()
+        }
+    );
+    let events = std::fs::read_to_string(
+        dir.path()
+            .join(".worktrees/slack-C123-1780792150-138669/.ralph/events.jsonl"),
+    )
+    .unwrap();
+    assert!(events.contains("approved"));
+    assert!(!manager.has_pending_question(loop_id).unwrap());
+}

--- a/crates/ralph-slack/tests/slack_socket_mode.rs
+++ b/crates/ralph-slack/tests/slack_socket_mode.rs
@@ -14,6 +14,17 @@ fn typed_tail_command_variants_still_parse() {
 }
 
 #[test]
+fn typed_obs_command_variants_parse() {
+    for text in ["obs", "!obs", "/observe"] {
+        assert_eq!(
+            parse_thread_command(text),
+            Some(ThreadCommand::Obs),
+            "{text} should route through the observability command path"
+        );
+    }
+}
+
+#[test]
 fn block_action_tail_payload_maps_to_existing_thread_command_text() {
     let payload = serde_json::json!({
         "type": "block_actions",
@@ -35,6 +46,27 @@ fn block_action_tail_payload_maps_to_existing_thread_command_text() {
         parse_thread_command(&event.text),
         Some(ThreadCommand::Tail { n: 10 })
     );
+}
+
+#[test]
+fn block_action_obs_payload_maps_to_existing_thread_command_text() {
+    let payload = serde_json::json!({
+        "type": "block_actions",
+        "trigger_id": "TrigObs",
+        "user": {"id": "U123"},
+        "channel": {"id": "C123"},
+        "message": {"ts": "1780792150.138669", "thread_ts": "1780792150.138669"},
+        "actions": [{"action_id": "ralph_slack_obs", "value": "obs:slack-C123-1780792150-138669"}],
+        "action_ts": "1780792160.000100"
+    });
+
+    let event = slack_message_event_from_payload(&payload).expect("obs block action should parse");
+
+    assert_eq!(event.channel_id, "C123");
+    assert_eq!(event.user_id.as_deref(), Some("U123"));
+    assert_eq!(event.thread_ts.as_deref(), Some("1780792150.138669"));
+    assert_eq!(event.text, "obs");
+    assert_eq!(parse_thread_command(&event.text), Some(ThreadCommand::Obs));
 }
 
 #[test]

--- a/crates/ralph-telegram/src/service.rs
+++ b/crates/ralph-telegram/src/service.rs
@@ -784,6 +784,10 @@ impl ralph_proto::RobotService for TelegramService {
         )?)
     }
 
+    fn send_file(&self, file_path: &Path, caption: Option<&str>) -> anyhow::Result<i32> {
+        Ok(TelegramService::send_document(self, file_path, caption)?)
+    }
+
     fn timeout_secs(&self) -> u64 {
         self.timeout_secs
     }

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -14,6 +14,7 @@ Practical guides for using Ralph Orchestrator effectively.
 | [Cost Management](cost-management.md) | Controlling API costs |
 | [Telegram Integration](telegram.md) | Human-in-the-loop via Telegram |
 | [Slack Integration](slack.md) | Human-in-the-loop via Slack Socket Mode threads |
+| [Runbooks](../runbooks/README.md) | Operational review and smoke-test checklists |
 
 ## Quick Links
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -13,6 +13,7 @@ Practical guides for using Ralph Orchestrator effectively.
 | [Writing Prompts](prompts.md) | Prompt engineering tips |
 | [Cost Management](cost-management.md) | Controlling API costs |
 | [Telegram Integration](telegram.md) | Human-in-the-loop via Telegram |
+| [Slack Integration](slack.md) | Human-in-the-loop via Slack Socket Mode threads |
 
 ## Quick Links
 

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -1,44 +1,53 @@
 # Slack RObot guide
 
-Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One Slack thread maps to one Ralph loop. A root app mention starts a loop; replies in that thread answer pending questions, add guidance, or run thread-local commands.
+Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One allowed Slack channel maps to one repo/workspace root, and one Slack root thread maps to one Ralph loop. Root app mentions start loops; replies in the bound thread answer pending questions, add guidance, or run thread-local commands.
 
-## Model
+## UX model
 
-- One daemon owns Slack inbound traffic: `ralph bot daemon --slack -c ralph.slack.yml`.
-- Each allowed Slack channel is locked to one repo/workspace root through `RObot.slack.channel_repos`.
-- Slack text cannot choose arbitrary repos. The daemon resolves the repo from the Slack `channel_id`; after a loop starts, the persisted thread binding supplies the repo root for every reply.
-- The external address is `channel_id + root thread_ts`; Slack timestamps are strings, not floats.
-- Loop-local outbound messages use `SlackService` through the shared `RobotService` trait.
-- Structured `human.interact` attachment payloads can upload local files; Slack inbound text never selects arbitrary local paths.
+- Root app mention starts exactly one loop in the mentioned message's thread.
+- Ralph posts a Block Kit start card with loop id, repo, branch, prompt summary, and Status / Tail 10 / Stop buttons.
+- Progress is low-noise: the daemon stores message timestamps and updates one progress surface with Loop, Iteration, Hat, Topic, elapsed time, and the latest redacted message instead of spamming every event.
+- Completion posts a final Block Kit card with status, duration, note, and Tail 10 / Status / Approve / Request changes buttons.
+- Button payloads route through the same authorized command path as text commands.
+- Plain thread replies become `human.response` when a `human.interact` question is pending; otherwise they become `human.guidance` for the next loop iteration.
+- Thread commands are accepted with or without `!` or `/` prefixes: `help`, `status`, `tail [n]`, `stop`, `cancel`.
+
+Slack timestamps are strings, not floats. Treat the external address as `channel_id + root thread_ts`; never synthesize routing from display names or channel text.
 
 ## Slack app setup
 
-Create a Slack app in your workspace and enable Socket Mode.
+Create a dedicated Ralph Slack app. Do not reuse the Hermes Slack app; Socket Mode event streams and bot tokens should be isolated.
 
 Required tokens:
 
 - Bot token: `xoxb-...`, exposed as `RALPH_SLACK_BOT_TOKEN` or `RObot.slack.bot_token`.
-- App-level token: `xapp-...` with `connections:write`, exposed as `RALPH_SLACK_APP_TOKEN` or `RObot.slack.app_token`. This is required for `ralph bot daemon --slack`.
+- App-level token: `xapp-...` with `connections:write`, exposed as `RALPH_SLACK_APP_TOKEN` or `RObot.slack.app_token`.
 
-Required bot scopes for the MVP:
+Required bot scopes for the shippable Slack thread surface:
 
-- `chat:write` — post loop starts, questions, progress, command replies, and results.
-- `files:write` — upload loop-local artifacts through Slack's external file-upload flow into the bound thread.
-- `app_mentions:read` — receive root app mentions that start loops.
-- `channels:history` — receive replies in public channels.
-- `groups:history` — only if you allow private channels.
-- `im:history` — only if you intentionally support direct-message threads.
-- `commands` — only if you enable channel-level slash command starts.
+- `chat:write` — start cards, questions, progress updates, command replies, final cards, and Block Kit messages.
+- `files:write` — loop-local artifact uploads through Slack's external file-upload flow.
+- `app_mentions:read` — root app mentions that start loops.
+- `channels:history` — public channel root mentions and thread replies.
+- `groups:history` — only for private channels you explicitly allow.
+- `im:history` — only for DM smoke/support you intentionally enable.
+- `commands` — only if you configure slash-command starts.
+- `assistant:write` — optional Slack AI/streaming polish. Required before `chat.startStream` / `chat.appendStream` / `chat.stopStream` works in workspaces that gate AI app APIs.
 
 Subscribe to events:
 
 - `app_mention` for root starts.
 - `message.channels` for public-channel thread replies.
-- `message.groups` / `message.im` only if those surfaces are enabled.
+- `message.groups` / `message.im` only for enabled private-channel/DM surfaces.
+- `block_actions` interactivity for Status / Tail / Stop / Approve / Request changes buttons.
+- `slash_commands` only if slash-command starts are enabled.
+- Optional Slack AI events for the later Assistant entrypoint: `assistant_thread_started` and `assistant_thread_context_changed`.
+
+After changing scopes, events, Socket Mode, or interactivity, reinstall the app to the workspace and reinvite the bot to the smoke channel if needed. `missing_scope` during smoke almost always means the app was not reinstalled after the scope change.
 
 ## Example config
 
-See the root `ralph.slack.yml` example. The important part is the explicit provider and routing map:
+See the root `ralph.slack.yml` example. Keep token values out of YAML whenever possible and prefer environment variables.
 
 ```yaml
 RObot:
@@ -58,43 +67,61 @@ RObot:
     start_mode: app_mention
 ```
 
-Daemon mode requires every allowed channel to have a `channel_repos` entry, and every repo path must be absolute and exist. This is deliberate: authorization and repo routing happen before loop spawn or event-file writes.
+Daemon mode requires every allowed channel to have a `channel_repos` entry, and every repo path must be absolute and exist. Authorization and repo routing happen before loop spawn, event-file writes, process stops, or file uploads.
 
 ## Launch
 
 ```bash
-export RALPH_SLACK_BOT_TOKEN=xoxb-...
-export RALPH_SLACK_APP_TOKEN=xapp-...
-ralph bot status --slack
-ralph bot test --slack --channel C0123456789 "Ralph Slack is wired"
-ralph bot daemon --slack -c ralph.slack.yml
+# Export real values without echoing them or committing them.
+export RALPH_SLACK_BOT_TOKEN='xoxb-...'
+export RALPH_SLACK_APP_TOKEN='xapp-...'
+
+cargo +stable run -p ralph-cli -- bot status --slack -c ralph.slack.yml
+cargo +stable run -p ralph-cli -- bot test --slack -c ralph.slack.yml --channel C0123456789 "Ralph Slack is wired"
+cargo +stable run -p ralph-cli -- bot daemon --slack -c ralph.slack.yml
 ```
 
 A user starts a loop in an allowed channel:
 
 ```text
-@ralph implement the next small slice
+@Ralph implement the next small slice
 ```
 
-Ralph replies in the root message's thread:
+Expected UX:
 
-```text
-🤖 Ralph loop started
-Loop: slack-C0123456789-1780792150-138669
-Status: running
-```
+1. Ralph replies in the root message's thread with the start card.
+2. The loop runs in an isolated worktree for that Slack thread.
+3. Progress updates coalesce into the progress card/stream surface.
+4. Human questions appear in-thread; answer in the thread.
+5. Completion posts the final card and keeps Tail / Status / feedback controls available.
 
-## Thread UX
+## Commands and buttons
 
-Inside a bound Ralph thread:
+Text commands are thread-local and accepted as `status`, `!status`, or `/status`:
 
-- If a `human.interact` question is pending, a plain reply becomes `human.response` and clears the pending question.
-- If no question is pending, a plain reply becomes `human.guidance` and is injected on the next loop iteration.
-- Commands are thread-local: `help`, `status`, `tail [n]`, `stop` / `cancel`.
-- Commands win over pending questions; `status` does not accidentally answer a question.
-- `stop` is limited to the Slack user who started the thread.
+- `help` — show command help.
+- `status` — show current thread binding, loop status, pending-question state, and process id.
+- `tail [n]` — show the last `n` events/log lines, clamped to 1..25 and redacted for token-shaped strings.
+- `stop` / `cancel` — terminate the loop process; only the Slack user who started the thread can stop it.
 
-Slack nuance: slash commands generally do not behave like native thread replies. For in-thread steering, use plain thread text (`status`, `tail 10`, `stop`) or app mention behavior. Treat slash commands as channel-level starts only unless Slack changes its threading behavior.
+Buttons:
+
+- Status — same as `status`.
+- Tail 10 — same as `tail 10`.
+- Stop/Cancel — same as `stop`, with creator authorization.
+- Approve / Request changes — final-card feedback controls; they route as thread-local text (`approved` / `request changes`) through the same pending-question or guidance path rather than mutating repo state directly.
+
+Commands win over pending questions. For example, `status` does not accidentally answer a `human.interact` prompt.
+
+## Streaming capability
+
+`SlackApi` includes wrappers for Slack's AI streaming methods:
+
+- `chat.startStream`
+- `chat.appendStream`
+- `chat.stopStream`
+
+The implementation detects common streaming fallback errors (`unsupported_method`, `missing_scope`, `method_not_supported_for_channel_type`, `not_allowed_token_type`) so a workspace without the Slack AI app capability can fall back to normal Block Kit messages. Treat streaming as an enhancement, not an authorization bypass: starts, updates, stops, attachments, and replies still use the same channel/user/thread gates.
 
 ## File attachments
 
@@ -107,7 +134,7 @@ Ralph can attach loop-local files to a pending `human.interact` question when th
 }
 ```
 
-The file path must resolve under the configured repo/workspace root and be a regular file. Slack uploads use `files.getUploadURLExternal` followed by `files.completeUploadExternal`; deprecated `files.upload` is not used. The completion call targets the persisted `channel_id` and root thread `thread_ts` for the bound loop.
+The file path must resolve under the configured repo/workspace root and be a regular file. Slack uploads use `files.getUploadURLExternal` followed by `files.completeUploadExternal`; deprecated `files.upload` is not used. The completion call targets the persisted `channel_id` and root `thread_ts` for the bound loop. Slack inbound text never selects arbitrary local files.
 
 ## Security model
 
@@ -120,24 +147,28 @@ Ralph gates before side effects:
 5. Require a configured `channel_id -> repo_root` mapping for starts.
 6. Validate loop IDs before deriving `.worktrees/<loop_id>` paths.
 7. Route thread replies through the persisted binding, not daemon current working directory.
+8. Require loop creator authorization before Stop/Cancel.
+9. Require file attachments to stay inside the bound repo/workspace root.
 
-Secrets are not printed by docs or status output. Event tails are redacted for token-shaped strings before Slack replies.
+Secrets are not printed by docs, status output, command tails, or Kanban reports. Event tails are redacted for token-shaped strings before Slack replies.
 
 ## Limitations
 
 - Socket Mode is the supported MVP path; HTTP Events API/signing-secret deployment is reserved for hosted deployments.
 - Slack is not end-to-end encrypted.
 - Slack text cannot select arbitrary repos or workspace roots.
-- Each Slack-started loop should be reviewed like any other control-plane action; use explicit allowed users/channels.
+- Slack AI streaming requires workspace/app support and may need app reinstall after adding `assistant:write`.
+- Slash commands generally do not behave like native thread replies. Use in-thread text or Block Kit buttons for steering.
 - A live Slack smoke test requires a dedicated Slack app token set. Local/fake tests do not require Slack credentials.
 
-## Local test path
-
-The fake/local test suite covers the control-plane contract without real Slack tokens:
+## Local verification path
 
 ```bash
-cargo test -p ralph-slack
-cargo test -p ralph-cli bot::tests
+cargo +stable fmt --all --check
+cargo +stable check -p ralph-slack -p ralph-cli
+cargo +stable test -p ralph-slack
+cargo +stable test -p ralph-cli bot::tests
+git diff --check
 ```
 
-Coverage includes Socket Mode envelope parsing and ack-before-slow-work, root app mention starts, thread binding, fake loop spawning, question post/response flow, guidance routing, commands, multi-repo channel routing, unauthorized user/channel rejection, duplicate events, bot-message ignore, stop auth, and traversal-shaped loop IDs.
+Coverage includes Socket Mode envelope parsing and ack-before-slow-work, Block Kit renderers, streaming API payloads/fallback errors, root app mention starts, thread binding, fake loop spawning, progress/final message timestamps, file uploads, question post/response flow, guidance routing, commands, interactive buttons, multi-repo channel routing, unauthorized user/channel rejection, duplicate events, bot-message ignore, stop auth, and traversal-shaped loop IDs.

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -1,16 +1,18 @@
 # Slack RObot guide
 
-Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One allowed Slack channel maps to one repo/workspace root, and one Slack root thread maps to one Ralph loop. Root app mentions start loops; replies in the bound thread answer pending questions, add guidance, or run thread-local commands.
+Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One allowed Slack channel maps to one repo/workspace root, and one Slack root thread maps to one Ralph loop. Root app mentions start loops; replies in a running bound thread answer pending questions, add guidance, or run thread-local commands. Once a loop is completed, failed, or stopped, its bound thread becomes an archived read-only audit record, not a reusable steering target.
 
 ## UX model
 
 - Root app mention starts exactly one loop in the mentioned message's thread.
 - Ralph posts a Block Kit start card with loop id, repo, branch, prompt summary, and Status / Tail 10 / Stop buttons.
 - Progress is low-noise: the daemon stores message timestamps and updates one progress surface with Loop, Iteration, Hat, Topic, elapsed time, and the latest redacted message instead of spamming every event.
-- Completion posts a final Block Kit card with status, duration, note, and Tail 10 / Status / Approve / Request changes buttons.
+- Completion posts a final Block Kit card with status, duration, and Tail 10 / Status buttons; the binding is retained with loop id, channel/thread timestamps, repo root, final card timestamp, and local log/handoff/artifact paths when available.
 - Button payloads route through the same authorized command path as text commands.
-- Plain thread replies become `human.response` when a `human.interact` question is pending; otherwise they become `human.guidance` for the next loop iteration.
-- Thread commands are accepted with or without `!` or `/` prefixes: `help`, `status`, `tail [n]`, `stop`, `cancel`.
+- Plain thread replies in running threads become `human.response` when a `human.interact` question is pending; otherwise they become `human.guidance` for the next loop iteration.
+- Plain replies in completed/failed/stopped threads are ignored so they cannot append `human.response` or `human.guidance` to the old loop event file.
+- Thread commands are accepted with or without `!` or `/` prefixes: `help`, `status`, `tail [n]`, `log [n]`, `handoff`, `repo`, `artifacts`, `stop`, `cancel`.
+- New work from an archived thread must be explicit: `followup <prompt>`, `follow-up <prompt>`, `fork <prompt>`, or `new work <prompt>`. Ralph creates a new bound loop/worktree keyed to that follow-up message and records `parent_loop_id` on the new binding.
 
 Slack timestamps are strings, not floats. Treat the external address as `channel_id + root thread_ts`; never synthesize routing from display names or channel text.
 
@@ -93,7 +95,7 @@ Expected UX:
 2. The loop runs in an isolated worktree for that Slack thread.
 3. Progress updates coalesce into the progress card/stream surface.
 4. Human questions appear in-thread; answer in the thread.
-5. Completion posts the final card and keeps Tail / Status / feedback controls available.
+5. Completion posts the final card and keeps read-only Tail / Status surfaces available. Follow-up work requires `followup <prompt>` or `fork <prompt>` and starts a new linked binding/worktree.
 
 ## Commands and buttons
 
@@ -101,17 +103,33 @@ Text commands are thread-local and accepted as `status`, `!status`, or `/status`
 
 - `help` — show command help.
 - `status` — show current thread binding, loop status, pending-question state, and process id.
-- `tail [n]` — show the last `n` events/log lines, clamped to 1..25 and redacted for token-shaped strings.
-- `stop` / `cancel` — terminate the loop process; only the Slack user who started the thread can stop it.
+- `tail [n]` — show the last `n` loop events, clamped to 1..25 and redacted for token-shaped strings.
+- `log [n]` — show the last `n` process log lines, clamped to 1..50 and redacted.
+- `handoff` — show `.ralph/agent/summary.md` from the loop worktree when present.
+- `repo` — show the bound repo/workspace root, status, and parent loop id.
+- `artifacts` — list local loop artifact paths under the loop `.ralph` directory when present.
+- `followup <prompt>` / `fork <prompt>` — from an archived thread only, start new work in a new loop/worktree linked to the archived loop.
+- `stop` / `cancel` — terminate the running loop process; only the Slack user who started the thread can stop it.
 
 Buttons:
 
 - Status — same as `status`.
 - Tail 10 — same as `tail 10`.
 - Stop/Cancel — same as `stop`, with creator authorization.
-- Approve / Request changes — final-card feedback controls; they route as thread-local text (`approved` / `request changes`) through the same pending-question or guidance path rather than mutating repo state directly.
+- Final cards intentionally stay read-only; new work requires an explicit follow-up/fork command rather than recycling the completed thread.
 
-Commands win over pending questions. For example, `status` does not accidentally answer a `human.interact` prompt.
+Commands win over pending questions. For example, `status` does not accidentally answer a `human.interact` prompt. Terminal status also clears `process_id` and `pending_questions[loop_id]`, so archived threads cannot accidentally answer stale questions.
+
+## Archived thread cleanup
+
+Archived Slack bindings are local audit records; pruning them never mutates Slack history. Operators can list terminal bindings and prune local archived state/worktree/log artifacts older than a retention window from the bound repo root:
+
+```bash
+cargo +stable run -p ralph-cli -- bot slack-archives list
+cargo +stable run -p ralph-cli -- bot slack-archives prune --older-than-days 30
+```
+
+Prune removes matching local `.ralph/slack-state.json` binding entries, `.worktrees/<loop_id>` directories, and `.ralph/slack-loop-logs/<loop_id>.log` files after the retention window. Keep retention long enough for review and incident forensics.
 
 ## Streaming capability
 
@@ -149,6 +167,7 @@ Ralph gates before side effects:
 7. Route thread replies through the persisted binding, not daemon current working directory.
 8. Require loop creator authorization before Stop/Cancel.
 9. Require file attachments to stay inside the bound repo/workspace root.
+10. Treat completed/failed/stopped bindings as read-only: only status/log/handoff/repo/artifacts commands are allowed, and explicit follow-up/fork creates a separate linked loop.
 
 Secrets are not printed by docs, status output, command tails, or Kanban reports. Event tails are redacted for token-shaped strings before Slack replies.
 
@@ -171,4 +190,4 @@ cargo +stable test -p ralph-cli bot::tests
 git diff --check
 ```
 
-Coverage includes Socket Mode envelope parsing and ack-before-slow-work, Block Kit renderers, streaming API payloads/fallback errors, root app mention starts, thread binding, fake loop spawning, progress/final message timestamps, file uploads, question post/response flow, guidance routing, commands, interactive buttons, multi-repo channel routing, unauthorized user/channel rejection, duplicate events, bot-message ignore, stop auth, and traversal-shaped loop IDs.
+Coverage includes Socket Mode envelope parsing and ack-before-slow-work, Block Kit renderers, streaming API payloads/fallback errors, root app mention starts, thread binding, fake loop spawning, progress/final message timestamps, file uploads, question post/response flow, guidance routing, read-only archived-thread commands, follow-up/fork routing, cleanup command parsing, interactive buttons, multi-repo channel routing, unauthorized user/channel rejection, duplicate events, bot-message ignore, stop auth, and traversal-shaped loop IDs.

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -1,0 +1,128 @@
+# Slack RObot guide
+
+Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One Slack thread maps to one Ralph loop. A root app mention starts a loop; replies in that thread answer pending questions, add guidance, or run thread-local commands.
+
+## Model
+
+- One daemon owns Slack inbound traffic: `ralph bot daemon --slack -c ralph.slack.yml`.
+- Each allowed Slack channel is locked to one repo/workspace root through `RObot.slack.channel_repos`.
+- Slack text cannot choose arbitrary repos. The daemon resolves the repo from the Slack `channel_id`; after a loop starts, the persisted thread binding supplies the repo root for every reply.
+- The external address is `channel_id + root thread_ts`; Slack timestamps are strings, not floats.
+- Loop-local outbound messages use `SlackService` through the shared `RobotService` trait.
+
+## Slack app setup
+
+Create a Slack app in your workspace and enable Socket Mode.
+
+Required tokens:
+
+- Bot token: `xoxb-...`, exposed as `RALPH_SLACK_BOT_TOKEN` or `RObot.slack.bot_token`.
+- App-level token: `xapp-...` with `connections:write`, exposed as `RALPH_SLACK_APP_TOKEN` or `RObot.slack.app_token`. This is required for `ralph bot daemon --slack`.
+
+Required bot scopes for the MVP:
+
+- `chat:write` — post loop starts, questions, progress, command replies, and results.
+- `app_mentions:read` — receive root app mentions that start loops.
+- `channels:history` — receive replies in public channels.
+- `groups:history` — only if you allow private channels.
+- `im:history` — only if you intentionally support direct-message threads.
+- `commands` — only if you enable channel-level slash command starts.
+
+Subscribe to events:
+
+- `app_mention` for root starts.
+- `message.channels` for public-channel thread replies.
+- `message.groups` / `message.im` only if those surfaces are enabled.
+
+## Example config
+
+See the root `ralph.slack.yml` example. The important part is the explicit provider and routing map:
+
+```yaml
+RObot:
+  enabled: true
+  surface: slack
+  timeout_seconds: 86400
+  checkin_interval_seconds: 300
+  slack:
+    bot_token: null       # prefer RALPH_SLACK_BOT_TOKEN
+    app_token: null       # prefer RALPH_SLACK_APP_TOKEN
+    channel_ids:
+      - C0123456789
+    allowed_users:
+      - U0123456789
+    channel_repos:
+      C0123456789: /absolute/path/to/repo
+    start_mode: app_mention
+```
+
+Daemon mode requires every allowed channel to have a `channel_repos` entry, and every repo path must be absolute and exist. This is deliberate: authorization and repo routing happen before loop spawn or event-file writes.
+
+## Launch
+
+```bash
+export RALPH_SLACK_BOT_TOKEN=xoxb-...
+export RALPH_SLACK_APP_TOKEN=xapp-...
+ralph bot status --slack
+ralph bot test --slack --channel C0123456789 "Ralph Slack is wired"
+ralph bot daemon --slack -c ralph.slack.yml
+```
+
+A user starts a loop in an allowed channel:
+
+```text
+@ralph implement the next small slice
+```
+
+Ralph replies in the root message's thread:
+
+```text
+🤖 Ralph loop started
+Loop: slack-C0123456789-1780792150-138669
+Status: running
+```
+
+## Thread UX
+
+Inside a bound Ralph thread:
+
+- If a `human.interact` question is pending, a plain reply becomes `human.response` and clears the pending question.
+- If no question is pending, a plain reply becomes `human.guidance` and is injected on the next loop iteration.
+- Commands are thread-local: `help`, `status`, `tail [n]`, `stop` / `cancel`.
+- Commands win over pending questions; `status` does not accidentally answer a question.
+- `stop` is limited to the Slack user who started the thread.
+
+Slack nuance: slash commands generally do not behave like native thread replies. For in-thread steering, use plain thread text (`status`, `tail 10`, `stop`) or app mention behavior. Treat slash commands as channel-level starts only unless Slack changes its threading behavior.
+
+## Security model
+
+Ralph gates before side effects:
+
+1. Ignore bot/self messages.
+2. Require an allowed channel.
+3. Require an allowed user.
+4. Dedupe Slack event IDs/envelope IDs.
+5. Require a configured `channel_id -> repo_root` mapping for starts.
+6. Validate loop IDs before deriving `.worktrees/<loop_id>` paths.
+7. Route thread replies through the persisted binding, not daemon current working directory.
+
+Secrets are not printed by docs or status output. Event tails are redacted for token-shaped strings before Slack replies.
+
+## Limitations
+
+- Socket Mode is the supported MVP path; HTTP Events API/signing-secret deployment is reserved for hosted deployments.
+- Slack is not end-to-end encrypted.
+- Slack text cannot select arbitrary repos or workspace roots.
+- Each Slack-started loop should be reviewed like any other control-plane action; use explicit allowed users/channels.
+- A live Slack smoke test requires a dedicated Slack app token set. Local/fake tests do not require Slack credentials.
+
+## Local test path
+
+The fake/local test suite covers the control-plane contract without real Slack tokens:
+
+```bash
+cargo test -p ralph-slack
+cargo test -p ralph-cli bot::tests
+```
+
+Coverage includes Socket Mode envelope parsing and ack-before-slow-work, root app mention starts, thread binding, fake loop spawning, question post/response flow, guidance routing, commands, multi-repo channel routing, unauthorized user/channel rejection, duplicate events, bot-message ignore, stop auth, and traversal-shaped loop IDs.

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -1,6 +1,6 @@
 # Slack RObot guide
 
-Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One allowed Slack channel maps to one repo/workspace root, and one Slack root thread maps to one Ralph loop. Root app mentions start loops; replies in the bound thread answer pending questions, add guidance, or run thread-local commands.
+Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orchestration. One allowed Slack channel maps to one default repo alias, and one Slack root thread maps to one Ralph loop. Root app mentions start loops; replies in the bound thread answer pending questions, add guidance, or run thread-local commands.
 
 ## UX model
 
@@ -62,12 +62,23 @@ RObot:
       - C0123456789
     allowed_users:
       - U0123456789
+    repo_aliases:
+      ralph: /absolute/path/to/repo
     channel_repos:
-      C0123456789: /absolute/path/to/repo
+      C0123456789: ralph
     start_mode: app_mention
 ```
 
-Daemon mode requires every allowed channel to have a `channel_repos` entry, and every repo path must be absolute and exist. Authorization and repo routing happen before loop spawn, event-file writes, process stops, or file uploads.
+Daemon mode requires at least one `repo_aliases` entry and every allowed channel to have a `channel_repos` entry that references a configured alias. Repo alias paths must be absolute and exist. Authorization and repo routing happen before loop spawn, event-file writes, process stops, or file uploads.
+
+Slack starts can override the channel default with safe aliases and relative subdirectories:
+
+```text
+@Ralph in ralph: fix the Slack repo UX
+@Ralph repo=ralph dir=crates/ralph-slack test status command
+```
+
+Subdirectories must stay inside the repo root; absolute paths, `..`, and symlink escapes are rejected.
 
 ## Launch
 
@@ -100,6 +111,7 @@ Expected UX:
 Text commands are thread-local and accepted as `status`, `!status`, or `/status`:
 
 - `help` — show command help.
+- `repo` — show the bound repo alias, root, subdirectory, loop id, worktree, and branch.
 - `status` — show current thread binding, loop status, pending-question state, and process id.
 - `tail [n]` — show the last `n` events/log lines, clamped to 1..25 and redacted for token-shaped strings.
 - `stop` / `cancel` — terminate the loop process; only the Slack user who started the thread can stop it.
@@ -144,7 +156,7 @@ Ralph gates before side effects:
 2. Require an allowed channel.
 3. Require an allowed user.
 4. Dedupe Slack event IDs/envelope IDs.
-5. Require a configured `channel_id -> repo_root` mapping for starts.
+5. Require a configured repo alias, either from the channel default or a safe start-message override.
 6. Validate loop IDs before deriving `.worktrees/<loop_id>` paths.
 7. Route thread replies through the persisted binding, not daemon current working directory.
 8. Require loop creator authorization before Stop/Cancel.
@@ -156,7 +168,7 @@ Secrets are not printed by docs, status output, command tails, or Kanban reports
 
 - Socket Mode is the supported MVP path; HTTP Events API/signing-secret deployment is reserved for hosted deployments.
 - Slack is not end-to-end encrypted.
-- Slack text cannot select arbitrary repos or workspace roots.
+- Slack text can select only configured repo aliases and safe relative subdirectories.
 - Slack AI streaming requires workspace/app support and may need app reinstall after adding `assistant:write`.
 - Slash commands generally do not behave like native thread replies. Use in-thread text or Block Kit buttons for steering.
 - A live Slack smoke test requires a dedicated Slack app token set. Local/fake tests do not require Slack credentials.

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -9,6 +9,7 @@ Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orche
 - Slack text cannot choose arbitrary repos. The daemon resolves the repo from the Slack `channel_id`; after a loop starts, the persisted thread binding supplies the repo root for every reply.
 - The external address is `channel_id + root thread_ts`; Slack timestamps are strings, not floats.
 - Loop-local outbound messages use `SlackService` through the shared `RobotService` trait.
+- Structured `human.interact` attachment payloads can upload local files; Slack inbound text never selects arbitrary local paths.
 
 ## Slack app setup
 
@@ -22,6 +23,7 @@ Required tokens:
 Required bot scopes for the MVP:
 
 - `chat:write` — post loop starts, questions, progress, command replies, and results.
+- `files:write` — upload loop-local artifacts through Slack's external file-upload flow into the bound thread.
 - `app_mentions:read` — receive root app mentions that start loops.
 - `channels:history` — receive replies in public channels.
 - `groups:history` — only if you allow private channels.
@@ -93,6 +95,19 @@ Inside a bound Ralph thread:
 - `stop` is limited to the Slack user who started the thread.
 
 Slack nuance: slash commands generally do not behave like native thread replies. For in-thread steering, use plain thread text (`status`, `tail 10`, `stop`) or app mention behavior. Treat slash commands as channel-level starts only unless Slack changes its threading behavior.
+
+## File attachments
+
+Ralph can attach loop-local files to a pending `human.interact` question when the event payload is structured JSON, for example:
+
+```json
+{
+  "question": "Review the generated report?",
+  "attachments": [{"path": "/absolute/path/to/repo/report.md", "caption": "Generated report"}]
+}
+```
+
+The file path must resolve under the configured repo/workspace root and be a regular file. Slack uploads use `files.getUploadURLExternal` followed by `files.completeUploadExternal`; deprecated `files.upload` is not used. The completion call targets the persisted `channel_id` and root thread `thread_ts` for the bound loop.
 
 ## Security model
 

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -6,7 +6,8 @@ Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orche
 
 - Root app mention starts exactly one loop in the mentioned message's thread.
 - Ralph posts a Block Kit start card with loop id, repo, branch, prompt summary, and Status / Obs / Tail 10 / Stop buttons.
-- Progress is low-noise: the daemon stores message timestamps and updates one progress surface with Loop, Iteration, Hat, Topic, elapsed time, and the latest redacted message instead of spamming every event.
+- Ralph also sets Slack's assistant thread status line as an ambient live pulse: start/spawn set a compact `is ...` status, progress/check-ins update it at low frequency, `human.interact` sets `needs your answer`, and terminal completed/failed/stopped states clear it.
+- Progress is low-noise: the daemon stores message timestamps and updates one durable progress surface with Loop, Iteration, Hat, Topic, elapsed time, and the latest redacted message instead of spamming every event.
 - Completion posts a final Block Kit card with status, duration, and Obs / Tail 10 / Status buttons; the binding is retained with loop id, channel/thread timestamps, repo root, final card timestamp, and local log/handoff/artifact paths when available.
 - Button payloads route through the same authorized command path as text commands.
 - Plain thread replies in running threads become `human.response` when a `human.interact` question is pending; otherwise they become `human.guidance` for the next loop iteration.
@@ -27,7 +28,7 @@ Required tokens:
 
 Required bot scopes for the shippable Slack thread surface:
 
-- `chat:write` — start cards, questions, progress updates, command replies, final cards, and Block Kit messages.
+- `chat:write` — start cards, questions, progress updates, assistant thread status-line updates (`assistant.threads.setStatus`), command replies, final cards, and Block Kit messages.
 - `files:write` — loop-local artifact uploads through Slack's external file-upload flow.
 - `app_mentions:read` — root app mentions that start loops.
 - `channels:history` — public channel root mentions and thread replies.
@@ -104,9 +105,10 @@ Expected UX:
 
 1. Ralph replies in the root message's thread with the start card.
 2. The loop runs in an isolated worktree for that Slack thread.
-3. Progress updates coalesce into the progress card/stream surface.
-4. Human questions appear in-thread; answer in the thread.
-5. Completion posts the final card and keeps read-only Tail / Status surfaces available. Follow-up work requires `followup <prompt>` or `fork <prompt>` and starts a new linked binding/worktree.
+3. The assistant thread status line shows the live ambient pulse (`is starting...`, `is iter N · hat X · topic`, or `needs your answer`) without raw logs or paths.
+4. Progress updates coalesce into the durable progress card/stream surface.
+5. Human questions appear in-thread; answer in the thread.
+6. Completion posts the final card, clears the assistant status line, and keeps read-only Tail / Status surfaces available. Follow-up work requires `followup <prompt>` or `fork <prompt>` and starts a new linked binding/worktree.
 
 ## Commands and buttons
 
@@ -130,6 +132,15 @@ Buttons:
 - Tail 10 — same as `tail 10`.
 - Stop/Cancel — same as `stop`, with creator authorization.
 - Final cards intentionally stay read-only; new work requires an explicit follow-up/fork command rather than recycling the completed thread.
+
+## Observability hierarchy
+
+- Assistant thread status line — ambient live pulse only. It is short, redacted, sanitized, throttled, and reads naturally after Slack prepends the app name (`is working in ralph`, `is iter 3 · hat executor · agent.message`, `needs your answer`). Start/spawn status may include only the repo alias, never repo roots, subdirs, or path fragments. It clears when the loop completes, fails, or is stopped.
+- Progress card/stream — durable state for normal monitoring: loop id, iteration, hat, topic, elapsed time, and the latest redacted message.
+- `obs` — compact debug snapshot when the ambient pulse is not enough: binding status, pending question, process id, repo/worktree, message timestamps, latest event, and latest log line.
+- `tail` / `log` — raw detail surfaces for troubleshooting, still clamped and redacted; do not treat them as the default observability UI.
+
+## Bot test
 
 Commands win over pending questions. For example, `status` does not accidentally answer a `human.interact` prompt. Terminal status also clears `process_id` and `pending_questions[loop_id]`, so archived threads cannot accidentally answer stale questions.
 

--- a/docs/guide/slack.md
+++ b/docs/guide/slack.md
@@ -5,13 +5,13 @@ Ralph's Slack surface is a Socket Mode control plane for human-in-the-loop orche
 ## UX model
 
 - Root app mention starts exactly one loop in the mentioned message's thread.
-- Ralph posts a Block Kit start card with loop id, repo, branch, prompt summary, and Status / Tail 10 / Stop buttons.
+- Ralph posts a Block Kit start card with loop id, repo, branch, prompt summary, and Status / Obs / Tail 10 / Stop buttons.
 - Progress is low-noise: the daemon stores message timestamps and updates one progress surface with Loop, Iteration, Hat, Topic, elapsed time, and the latest redacted message instead of spamming every event.
-- Completion posts a final Block Kit card with status, duration, and Tail 10 / Status buttons; the binding is retained with loop id, channel/thread timestamps, repo root, final card timestamp, and local log/handoff/artifact paths when available.
+- Completion posts a final Block Kit card with status, duration, and Obs / Tail 10 / Status buttons; the binding is retained with loop id, channel/thread timestamps, repo root, final card timestamp, and local log/handoff/artifact paths when available.
 - Button payloads route through the same authorized command path as text commands.
 - Plain thread replies in running threads become `human.response` when a `human.interact` question is pending; otherwise they become `human.guidance` for the next loop iteration.
 - Plain replies in completed/failed/stopped threads are ignored so they cannot append `human.response` or `human.guidance` to the old loop event file.
-- Thread commands are accepted with or without `!` or `/` prefixes: `help`, `status`, `tail [n]`, `log [n]`, `handoff`, `repo`, `artifacts`, `stop`, `cancel`.
+- Thread commands are accepted with or without `!` or `/` prefixes: `help`, `repo`, `obs` / `observe`, `status`, `tail [n]`, `log [n]`, `handoff`, `artifacts`, `stop`, `cancel`.
 - New work from an archived thread must be explicit: `followup <prompt>`, `follow-up <prompt>`, `fork <prompt>`, or `new work <prompt>`. Ralph creates a new bound loop/worktree keyed to that follow-up message and records `parent_loop_id` on the new binding.
 
 Slack timestamps are strings, not floats. Treat the external address as `channel_id + root thread_ts`; never synthesize routing from display names or channel text.
@@ -41,7 +41,7 @@ Subscribe to events:
 - `app_mention` for root starts.
 - `message.channels` for public-channel thread replies.
 - `message.groups` / `message.im` only for enabled private-channel/DM surfaces.
-- `block_actions` interactivity for Status / Tail / Stop / Approve / Request changes buttons.
+- `block_actions` interactivity for Status / Obs / Tail / Stop / Approve / Request changes buttons.
 - `slash_commands` only if slash-command starts are enabled.
 - Optional Slack AI events for the later Assistant entrypoint: `assistant_thread_started` and `assistant_thread_context_changed`.
 
@@ -114,11 +114,11 @@ Text commands are thread-local and accepted as `status`, `!status`, or `/status`
 
 - `help` — show command help.
 - `repo` — show the bound repo alias, root, subdirectory, loop id, worktree, and branch.
+- `obs` / `observe` — show a compact observability snapshot: loop status, pending question, process id, repo/worktree, message timestamps, latest iter/hat/topic/message, and latest log line.
 - `status` — show current thread binding, loop status, pending-question state, and process id.
 - `tail [n]` — show the last `n` loop events, clamped to 1..25 and redacted for token-shaped strings.
 - `log [n]` — show the last `n` process log lines, clamped to 1..50 and redacted.
 - `handoff` — show `.ralph/agent/summary.md` from the loop worktree when present.
-- `repo` — show the bound repo/workspace root, status, and parent loop id.
 - `artifacts` — list local loop artifact paths under the loop `.ralph` directory when present.
 - `followup <prompt>` / `fork <prompt>` — from an archived thread only, start new work in a new loop/worktree linked to the archived loop.
 - `stop` / `cancel` — terminate the running loop process; only the Slack user who started the thread can stop it.
@@ -126,6 +126,7 @@ Text commands are thread-local and accepted as `status`, `!status`, or `/status`
 Buttons:
 
 - Status — same as `status`.
+- Obs — same as `obs`.
 - Tail 10 — same as `tail 10`.
 - Stop/Cancel — same as `stop`, with creator authorization.
 - Final cards intentionally stay read-only; new work requires an explicit follow-up/fork command rather than recycling the completed thread.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -6,9 +6,10 @@ Operational checklists for reviewing and smoking Ralph features. These are meant
 
 Use these in order for `feat/slack-thread-surface`:
 
-1. [Slack final verification review](slack-final-verification-review.md) — local branch, code, docs, tests, and security review.
-2. [Slack live smoke test](slack-live-smoke-test.md) — dedicated Slack app setup and one real Slack thread-as-loop smoke.
-3. [Slack review signoff template](slack-review-signoff-template.md) — fill this out when closing the final review/Kanban/PR.
+1. [Slack app manifest](slack-app-manifest.yml) — least-privilege public-channel Slack app manifest to paste into Slack app creation.
+2. [Slack final verification review](slack-final-verification-review.md) — local branch, code, docs, tests, and security review.
+3. [Slack live smoke test](slack-live-smoke-test.md) — dedicated Slack app setup and one real Slack thread-as-loop smoke.
+4. [Slack review signoff template](slack-review-signoff-template.md) — fill this out when closing the final review/Kanban/PR.
 
 Safety defaults:
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,18 @@
+# Ralph runbooks
+
+Operational checklists for reviewing and smoking Ralph features. These are meant to be followed by a human operator, not by the loop itself.
+
+## Slack thread RObot surface
+
+Use these in order for `feat/slack-thread-surface`:
+
+1. [Slack final verification review](slack-final-verification-review.md) — local branch, code, docs, tests, and security review.
+2. [Slack live smoke test](slack-live-smoke-test.md) — dedicated Slack app setup and one real Slack thread-as-loop smoke.
+3. [Slack review signoff template](slack-review-signoff-template.md) — fill this out when closing the final review/Kanban/PR.
+
+Safety defaults:
+
+- Never paste Slack token values into logs, commits, Slack, or review comments.
+- Keep real tokens in environment variables or a local secret store only.
+- Do not check in a config file containing real `xoxb-`, `xapp-`, or signing-secret values.
+- Treat Slack as an operator control plane: only allow explicit channels and explicit users.

--- a/docs/runbooks/slack-app-manifest.yml
+++ b/docs/runbooks/slack-app-manifest.yml
@@ -1,0 +1,27 @@
+_metadata:
+  major_version: 1
+  minor_version: 1
+display_information:
+  name: Ralph
+  description: Ralph Orchestrator human-in-the-loop Slack surface
+  background_color: "#2f3136"
+features:
+  bot_user:
+    display_name: Ralph
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - chat:write
+      - channels:history
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+  interactivity:
+    is_enabled: false
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false

--- a/docs/runbooks/slack-app-manifest.yml
+++ b/docs/runbooks/slack-app-manifest.yml
@@ -15,6 +15,7 @@ oauth_config:
       - app_mentions:read
       - chat:write
       - channels:history
+      - files:write
 settings:
   event_subscriptions:
     bot_events:

--- a/docs/runbooks/slack-app-manifest.yml
+++ b/docs/runbooks/slack-app-manifest.yml
@@ -22,7 +22,7 @@ settings:
       - app_mention
       - message.channels
   interactivity:
-    is_enabled: false
+    is_enabled: true
   org_deploy_enabled: false
   socket_mode_enabled: true
   token_rotation_enabled: false

--- a/docs/runbooks/slack-final-verification-review.md
+++ b/docs/runbooks/slack-final-verification-review.md
@@ -13,7 +13,7 @@ The feature is intended to provide:
 - replies in running known threads become `human.response` when a question is pending, otherwise `human.guidance`;
 - completed/failed/stopped threads are archived read-only audit records;
 - explicit `followup <prompt>` / `fork <prompt>` from an archived thread creates a new linked loop/worktree instead of steering the old loop;
-- thread-local commands: `help`, `status`, `tail [n]`, `log [n]`, `handoff`, `repo`, `artifacts`, `stop` / `cancel`;
+- thread-local commands: `help`, `repo`, `obs` / `observe`, `status`, `tail [n]`, `log [n]`, `handoff`, `artifacts`, `stop` / `cancel`;
 - operator cleanup commands list/prune archived local state without mutating Slack history;
 - authorization and dedupe before side effects.
 

--- a/docs/runbooks/slack-final-verification-review.md
+++ b/docs/runbooks/slack-final-verification-review.md
@@ -1,0 +1,158 @@
+# Slack final verification review runbook
+
+Use this to review `feat/slack-thread-surface` before accepting the final Kanban/PR handoff. This is the local, token-free review. The live Slack smoke is covered separately in [Slack live smoke test](slack-live-smoke-test.md).
+
+## Scope
+
+The feature is intended to provide:
+
+- one Slack thread per Ralph loop;
+- one Slack channel mapped to one repo/workspace root via `RObot.slack.channel_repos`;
+- Slack text cannot choose arbitrary repos;
+- root app mentions start/bind loops;
+- replies in known threads become `human.response` when a question is pending, otherwise `human.guidance`;
+- thread-local commands: `help`, `status`, `tail [n]`, `stop` / `cancel`;
+- authorization and dedupe before side effects.
+
+## Prerequisites
+
+```bash
+cd /Users/rook/projects/ralph-orchestrator.slack-surface
+git switch feat/slack-thread-surface
+rustup toolchain list | grep -q '^stable' || rustup toolchain install stable
+```
+
+Do not export or print Slack tokens for this local review.
+
+## 1. Confirm branch state
+
+```bash
+git status --short --branch
+git log -1 --oneline
+```
+
+Expected:
+
+- Branch is `feat/slack-thread-surface`.
+- The feature commit is present; current handoff commit was `0936bbaded70660214ed56376354ccdf321b7b02` (`feat: add Slack thread RObot surface`) before these runbooks were added.
+- Product changes are committed. Local `.hermes/` Kanban planning artifacts may exist in this worktree; they are not part of the product branch.
+
+## 2. Inspect changed files
+
+```bash
+git diff --stat main...HEAD
+git diff --name-only main...HEAD
+```
+
+Expected high-level shape:
+
+- `crates/ralph-slack/` exists with API, Socket Mode, daemon, handler, service, state, and tests.
+- `crates/ralph-core/src/config.rs` contains provider-aware `RObot` config, `RobotSurface`, and Slack config validation.
+- `crates/ralph-cli/src/bot.rs`, `loop_runner.rs`, and `main.rs` dispatch Telegram/Slack surfaces intentionally.
+- `docs/guide/slack.md` and `ralph.slack.yml` document/configure the Slack surface.
+- No runtime state such as `.ralph/slack-state.json`, logs, `target/`, or token-bearing local config is committed.
+
+## 3. Run formatting and tests
+
+Prefer the stable toolchain explicitly because this worktree may not have a default Rust toolchain set.
+
+```bash
+cargo +stable fmt --all --check
+cargo +stable test -p ralph-slack
+cargo +stable test -p ralph-core
+cargo +stable test -p ralph-cli
+cargo +stable test
+git diff --check
+```
+
+Expected:
+
+- All commands pass.
+- The prior closeout worker reported:
+  - `ralph-slack`: 22 tests passed;
+  - `ralph-core`: 855 unit + 24 integration + 13 doctests passed, 1 doctest ignored;
+  - `ralph-cli`: 436 unit/integration tests passed, 3 ignored;
+  - full workspace tests/doctests passed.
+
+If disk space is tight, check first:
+
+```bash
+df -h .
+```
+
+If less than ~20 GB is available, run package tests first and postpone full workspace test until space is freed.
+
+## 4. Security review checklist
+
+Review the code paths before accepting the branch. Commands below are search aids, not substitutes for reading the matching functions.
+
+```bash
+rg -n "allowed_users|channel_ids|channel_repos|authorize|bot_id|event_id|thread_ts|loop_id|tail|stop|cancel|redact|token" crates/ralph-slack crates/ralph-core/src/config.rs crates/ralph-cli/src
+```
+
+Pass criteria:
+
+- [ ] Bot/self messages are ignored before state changes.
+- [ ] Channel allowlist is checked before binding a thread, spawning a loop, handling commands, or appending events.
+- [ ] User allowlist is checked before binding a thread, spawning a loop, handling commands, or appending events.
+- [ ] Empty/missing allowlists fail closed for Slack daemon startup; there is no "trust first inbound Slack event" path.
+- [ ] `channel_repos` is required for allowed channels and maps to canonical absolute repo roots.
+- [ ] Slack text cannot select arbitrary repos or paths.
+- [ ] Thread replies route using the persisted `channel_id + root thread_ts -> loop_id + repo_root` binding, not daemon cwd.
+- [ ] Event/envelope dedupe occurs before loop spawn or event append.
+- [ ] Loop IDs used for worktree/event paths reject traversal, slash, empty, overly long, or control-character inputs.
+- [ ] Thread commands are handled before guidance/response routing; command text does not accidentally answer a pending question.
+- [ ] `stop` / `cancel` is restricted to the thread creator.
+- [ ] `tail` output redacts token-shaped strings before posting to Slack.
+- [ ] Examples use `null`/env placeholders and never commit real `xoxb-`, `xapp-`, signing-secret, or bearer token values.
+
+## 5. Product behavior review checklist
+
+```bash
+cargo +stable test -p ralph-slack -- --nocapture
+```
+
+Confirm test names cover these behaviors:
+
+- [ ] Fake Socket Mode root `app_mention` starts a fake loop.
+- [ ] Socket Mode envelope ack happens before slow loop spawn work.
+- [ ] Thread binding stores channel, root `thread_ts`, loop id, and repo root.
+- [ ] `human.interact` question posts into the bound root thread.
+- [ ] Reply with pending question writes `human.response` and clears pending question.
+- [ ] Reply without pending question writes `human.guidance`.
+- [ ] Duplicate event id does not double-spawn or double-write.
+- [ ] Unauthorized user/channel and unknown channel mapping are rejected before side effects.
+- [ ] Bot/self messages are ignored.
+- [ ] Path traversal loop IDs are rejected.
+- [ ] Multi-channel routing uses the persisted repo root for replies.
+- [ ] `help`, `status`, `tail`, `stop` command semantics are covered.
+
+## 6. Docs/config review checklist
+
+Read these end to end:
+
+```bash
+sed -n '1,220p' docs/guide/slack.md
+sed -n '1,180p' ralph.slack.yml
+```
+
+Pass criteria:
+
+- [ ] Guide explains Socket Mode and required Slack scopes/events.
+- [ ] Guide states one channel maps to one repo/workspace root.
+- [ ] Guide states Slack text cannot choose arbitrary repos.
+- [ ] Guide explains root app mention start and thread reply behavior.
+- [ ] Guide explains slash-command/thread nuance.
+- [ ] Example config uses env vars for secrets and placeholder IDs/paths only.
+- [ ] Example config includes `RObot.surface: slack`, `channel_ids`, `allowed_users`, and `channel_repos`.
+
+## 7. Decision
+
+Accept local verification if:
+
+- formatting/tests pass;
+- security checklist passes;
+- docs/config checklist passes;
+- the only remaining blocker is the real Slack smoke prerequisites listed in [Slack live smoke test](slack-live-smoke-test.md).
+
+If a local issue is found, do not proceed to live smoke. Capture the exact failing command, file, and reason in [Slack review signoff template](slack-review-signoff-template.md), then send it back for repair.

--- a/docs/runbooks/slack-final-verification-review.md
+++ b/docs/runbooks/slack-final-verification-review.md
@@ -10,8 +10,11 @@ The feature is intended to provide:
 - one Slack channel mapped to one repo/workspace root via `RObot.slack.channel_repos`;
 - Slack text cannot choose arbitrary repos;
 - root app mentions start/bind loops;
-- replies in known threads become `human.response` when a question is pending, otherwise `human.guidance`;
-- thread-local commands: `help`, `status`, `tail [n]`, `stop` / `cancel`;
+- replies in running known threads become `human.response` when a question is pending, otherwise `human.guidance`;
+- completed/failed/stopped threads are archived read-only audit records;
+- explicit `followup <prompt>` / `fork <prompt>` from an archived thread creates a new linked loop/worktree instead of steering the old loop;
+- thread-local commands: `help`, `status`, `tail [n]`, `log [n]`, `handoff`, `repo`, `artifacts`, `stop` / `cancel`;
+- operator cleanup commands list/prune archived local state without mutating Slack history;
 - authorization and dedupe before side effects.
 
 ## Prerequisites
@@ -103,7 +106,9 @@ Pass criteria:
 - [ ] Loop IDs used for worktree/event paths reject traversal, slash, empty, overly long, or control-character inputs.
 - [ ] Thread commands are handled before guidance/response routing; command text does not accidentally answer a pending question.
 - [ ] `stop` / `cancel` is restricted to the thread creator.
-- [ ] `tail` output redacts token-shaped strings before posting to Slack.
+- [ ] Completed/failed/stopped replies do not append `human.response` / `human.guidance` to old event files.
+- [ ] Explicit follow-up/fork from a terminal binding creates a separate binding with `parent_loop_id`.
+- [ ] `tail` and `log` output redact token-shaped strings before posting to Slack.
 - [ ] Examples use `null`/env placeholders and never commit real `xoxb-`, `xapp-`, signing-secret, or bearer token values.
 
 ## 5. Product behavior review checklist
@@ -125,7 +130,10 @@ Confirm test names cover these behaviors:
 - [ ] Bot/self messages are ignored.
 - [ ] Path traversal loop IDs are rejected.
 - [ ] Multi-channel routing uses the persisted repo root for replies.
-- [ ] `help`, `status`, `tail`, `stop` command semantics are covered.
+- [ ] `help`, `status`, `tail`, `log`, `handoff`, `repo`, `artifacts`, `stop` command semantics are covered.
+- [ ] Completed-thread plain replies are ignored, pending questions are cleared, and process ids are cleared.
+- [ ] Completed-thread `fork`/`followup` creates a new bound loop/worktree linked to the old loop.
+- [ ] `ralph bot slack-archives list/prune` parsing/cleanup behavior is covered.
 
 ## 6. Docs/config review checklist
 
@@ -141,7 +149,8 @@ Pass criteria:
 - [ ] Guide explains Socket Mode and required Slack scopes/events.
 - [ ] Guide states one channel maps to one repo/workspace root.
 - [ ] Guide states Slack text cannot choose arbitrary repos.
-- [ ] Guide explains root app mention start and thread reply behavior.
+- [ ] Guide explains root app mention start and running-thread reply behavior.
+- [ ] Guide explains archived-thread lifecycle, explicit follow-up/fork, and cleanup retention policy.
 - [ ] Guide explains slash-command/thread nuance.
 - [ ] Example config uses env vars for secrets and placeholder IDs/paths only.
 - [ ] Example config includes `RObot.surface: slack`, `channel_ids`, `allowed_users`, and `channel_repos`.

--- a/docs/runbooks/slack-final-verification-review.md
+++ b/docs/runbooks/slack-final-verification-review.md
@@ -7,8 +7,8 @@ Use this to review `feat/slack-thread-surface` before accepting the final Kanban
 The feature is intended to provide:
 
 - one Slack thread per Ralph loop;
-- one Slack channel mapped to one repo/workspace root via `RObot.slack.channel_repos`;
-- Slack text cannot choose arbitrary repos;
+- one Slack channel mapped to one safe repo alias via `RObot.slack.channel_repos`;
+- Slack text can choose only configured repo aliases and safe relative subdirs;
 - root app mentions start/bind loops;
 - replies in known threads become `human.response` when a question is pending, otherwise `human.guidance`;
 - thread-local commands: `help`, `status`, `tail [n]`, `stop` / `cancel`;
@@ -96,9 +96,10 @@ Pass criteria:
 - [ ] Channel allowlist is checked before binding a thread, spawning a loop, handling commands, or appending events.
 - [ ] User allowlist is checked before binding a thread, spawning a loop, handling commands, or appending events.
 - [ ] Empty/missing allowlists fail closed for Slack daemon startup; there is no "trust first inbound Slack event" path.
-- [ ] `channel_repos` is required for allowed channels and maps to canonical absolute repo roots.
-- [ ] Slack text cannot select arbitrary repos or paths.
-- [ ] Thread replies route using the persisted `channel_id + root thread_ts -> loop_id + repo_root` binding, not daemon cwd.
+- [ ] `repo_aliases` maps safe aliases to canonical absolute repo roots.
+- [ ] `channel_repos` is required for allowed channels and references configured aliases.
+- [ ] Slack text cannot select arbitrary repos or unsafe paths.
+- [ ] Thread replies route using the persisted `channel_id + root thread_ts -> loop_id + repo_root + dir` binding, not daemon cwd.
 - [ ] Event/envelope dedupe occurs before loop spawn or event append.
 - [ ] Loop IDs used for worktree/event paths reject traversal, slash, empty, overly long, or control-character inputs.
 - [ ] Thread commands are handled before guidance/response routing; command text does not accidentally answer a pending question.
@@ -139,12 +140,12 @@ sed -n '1,180p' ralph.slack.yml
 Pass criteria:
 
 - [ ] Guide explains Socket Mode and required Slack scopes/events.
-- [ ] Guide states one channel maps to one repo/workspace root.
-- [ ] Guide states Slack text cannot choose arbitrary repos.
+- [ ] Guide states one channel maps to one default repo alias.
+- [ ] Guide states Slack text can choose only configured aliases and safe relative subdirs.
 - [ ] Guide explains root app mention start and thread reply behavior.
 - [ ] Guide explains slash-command/thread nuance.
 - [ ] Example config uses env vars for secrets and placeholder IDs/paths only.
-- [ ] Example config includes `RObot.surface: slack`, `channel_ids`, `allowed_users`, and `channel_repos`.
+- [ ] Example config includes `RObot.surface: slack`, `channel_ids`, `allowed_users`, `repo_aliases`, and `channel_repos`.
 
 ## 7. Decision
 

--- a/docs/runbooks/slack-live-smoke-test.md
+++ b/docs/runbooks/slack-live-smoke-test.md
@@ -23,6 +23,7 @@ Required app setup:
 - Bot token scopes:
   - `app_mentions:read`
   - `chat:write`
+  - `files:write` for artifact/file upload smoke
   - `channels:history` for public-channel smoke
   - `groups:history` only if smoking a private channel
   - `im:history` only if intentionally smoking DMs
@@ -181,7 +182,25 @@ cd /absolute/path/to/repo
 rg -n 'human\.response|human\.guidance|human\.interact' .ralph .worktrees 2>/dev/null || true
 ```
 
-## 8. Negative checks
+## 8. Verify file upload routing
+
+From the mapped repo/workspace, create a harmless smoke artifact and have a loop emit a structured `human.interact` attachment payload for that path:
+
+```bash
+cd /absolute/path/to/repo
+mkdir -p .ralph/smoke-artifacts
+printf 'Slack file upload smoke artifact\n' > .ralph/smoke-artifacts/slack-file-smoke.txt
+```
+
+Expected:
+
+- The file appears in the same Slack thread as the loop question, not in a new channel/root message.
+- The upload completes only after the app has `files:write` and has been reinstalled after adding the scope.
+- The upload uses the bound `channel_id` and root `thread_ts`; a reply timestamp must not become the file thread target.
+- Slack text/replies do not trigger arbitrary local file uploads.
+- Token values and file contents are not printed in daemon logs or review notes.
+
+## 9. Negative checks
 
 Perform only safe negative checks:
 
@@ -191,7 +210,7 @@ Perform only safe negative checks:
 
 Do not attempt destructive commands against a production repo.
 
-## 9. Cleanup
+## 10. Cleanup
 
 Stop the daemon with `Ctrl-C`.
 
@@ -209,13 +228,14 @@ cd /absolute/path/to/repo
 find .ralph .worktrees -maxdepth 3 -type f 2>/dev/null | sed -n '1,120p'
 ```
 
-## 10. Pass/fail criteria
+## 11. Pass/fail criteria
 
 Pass live smoke if:
 
 - daemon connects through Socket Mode;
 - root app mention in the allowlisted channel starts exactly one loop;
 - Ralph posts replies in the root Slack thread;
+- structured loop-local file attachment upload appears in that same root thread;
 - thread reply routes to `human.response` or `human.guidance` as expected;
 - `status`/`tail` work in-thread;
 - unauthorized channel/user attempts do not create side effects;

--- a/docs/runbooks/slack-live-smoke-test.md
+++ b/docs/runbooks/slack-live-smoke-test.md
@@ -1,16 +1,17 @@
 # Slack live smoke test runbook
 
-Use this after the local review passes. This proves the real Slack app can drive one Ralph loop through one Slack thread.
+Use this after local review passes. It proves the real Slack app can drive one Ralph loop through one Slack thread with polished cards, low-noise progress, in-thread commands/buttons, optional streaming, file uploads, and completion closeout.
 
-Do not run this with the Hermes Slack app. Use a dedicated Ralph Slack app so its Socket Mode event stream, scopes, and tokens are isolated.
+Do not run this with the Hermes Slack app. Use a dedicated Ralph Slack app so Socket Mode events, scopes, tokens, and test channels are isolated.
 
 ## 0. Safety rules
 
 - Do not paste token values into Slack, commits, screenshots, Kanban comments, or review notes.
 - Do not run `set -x` while tokens are exported.
-- Do not commit the smoke config if it contains real IDs you do not want public, and never commit token values.
+- Do not commit smoke configs that contain real workspace/channel/user IDs you do not want public, and never commit token values.
 - Use a low-risk test channel and repo/worktree.
-- Invite only the reviewers who should be allowed to start/steer Ralph loops.
+- Invite only reviewers/operators who should be allowed to start or steer Ralph loops.
+- Run destructive controls only against a disposable smoke loop.
 
 ## 1. Slack app prerequisites
 
@@ -18,29 +19,41 @@ Create or open the dedicated Ralph Slack app in Slack app management.
 
 Required app setup:
 
-- Socket Mode: enabled.
-- App-level token: created with `connections:write` scope.
-- Bot token scopes:
-  - `app_mentions:read`
-  - `chat:write`
-  - `files:write` for artifact/file upload smoke
-  - `channels:history` for public-channel smoke
-  - `groups:history` only if smoking a private channel
-  - `im:history` only if intentionally smoking DMs
-- Event subscriptions:
-  - `app_mention`
-  - `message.channels` for public-channel smoke
-  - `message.groups` / `message.im` only for those surfaces
-- Bot installed to the workspace.
+- Socket Mode enabled.
+- App-level token created with `connections:write` scope.
+- Interactivity enabled so Block Kit buttons reach Socket Mode as `block_actions`.
+- Bot installed to the workspace after the final scope/event changes.
 - Bot invited to the allowlisted test channel.
+
+Required bot token scopes:
+
+- `chat:write` for cards, progress updates, command replies, final cards, and stream fallback messages.
+- `files:write` for artifact/file upload smoke.
+- `app_mentions:read` for root app mentions.
+- `channels:history` for public-channel smoke.
+- `groups:history` only if smoking private channels.
+- `im:history` only if intentionally smoking DMs.
+- `commands` only if smoking slash-command starts.
+- `assistant:write` only if smoking Slack AI streaming APIs (`chat.startStream`, `chat.appendStream`, `chat.stopStream`). Without it, verify the Block Kit fallback path instead.
+
+Required event subscriptions:
+
+- `app_mention`
+- `message.channels` for public-channel replies
+- `message.groups` / `message.im` only for those surfaces
+- `block_actions` through Slack Interactivity
+- `slash_commands` only if slash-command starts are configured
+- Optional AI events for future assistant entrypoint smoke: `assistant_thread_started`, `assistant_thread_context_changed`
+
+After adding scopes/events or enabling interactivity, reinstall the app to the workspace. If smoke returns `missing_scope`, add the exact missing scope, reinstall, and retry.
 
 Collect non-secret IDs:
 
-- team/workspace id, if your config/review wants it;
 - test channel id, e.g. `C...`;
-- reviewer Slack user id(s), e.g. `U...`;
+- reviewer/operator Slack user id(s), e.g. `U...`;
 - bot user id, if needed for self-message filtering review;
-- absolute repo path that channel should map to.
+- absolute repo path that the channel maps to;
+- optional team/workspace id if your streaming smoke requires it.
 
 ## 2. Export tokens without printing them
 
@@ -95,10 +108,22 @@ Rules:
 
 - `channel_repos` value must be an absolute existing path.
 - Every `channel_ids` entry must have a `channel_repos` entry.
-- Do not put token values in the YAML.
+- Do not put token values in YAML.
 - Do not add broad channel/user wildcards.
 
-## 4. Preflight status and test post
+## 4. Local preflight before live Slack
+
+```bash
+cargo +stable fmt --all --check
+cargo +stable check -p ralph-slack -p ralph-cli
+cargo +stable test -p ralph-slack
+cargo +stable test -p ralph-cli bot::tests
+git diff --check
+```
+
+Expected: all pass before the real Slack app is exercised.
+
+## 5. Slack status and test post
 
 ```bash
 cargo +stable run -p ralph-cli -- bot status --slack -c /tmp/ralph-slack-smoke.yml
@@ -110,9 +135,9 @@ Expected:
 - Status reports Slack config/token presence without revealing token values.
 - Test post appears in the target Slack channel.
 - If the test post fails with `not_in_channel`, invite the bot to the channel and retry.
-- If it fails with `missing_scope`, add the missing Slack scope, reinstall the app, and retry.
+- If it fails with `missing_scope`, add the missing scope, reinstall the app, and retry.
 
-## 5. Start daemon
+## 6. Start daemon
 
 In a dedicated terminal:
 
@@ -123,25 +148,27 @@ cargo +stable run -p ralph-cli -- bot daemon --slack -c /tmp/ralph-slack-smoke.y
 
 Expected:
 
-- Daemon connects to Socket Mode.
+- Daemon connects through Socket Mode.
 - It does not print token values.
+- It acks Socket Mode envelopes before slow loop work.
 - Leave this terminal running for the smoke.
 
-## 6. Start one Slack thread loop
+## 7. Start one Slack thread loop
 
 In the allowlisted Slack channel, send a root message that mentions the Ralph app:
 
 ```text
-@Ralph smoke: start a tiny loop and ask me one question before doing anything risky
+@Ralph smoke: start a tiny loop, report status, and ask me one question before doing anything risky
 ```
 
 Expected:
 
 - Ralph replies in the root message's thread.
-- The reply includes a loop id/status.
+- The first reply is a Block Kit start card with loop id, status, repo/branch, prompt summary, and Status / Tail 10 / Stop buttons.
 - A Slack state file appears under the mapped repo root, typically `.ralph/slack-state.json`.
-- A loop log file appears under the mapped repo root, typically `.ralph/slack-loop-logs/<loop-id>.log`.
-- The loop/thread binding uses the test channel id and root `thread_ts`.
+- The state binding contains `channel_id`, root `thread_ts`, `loop_id`, `workspace_root`, and `start_card_ts`.
+- A loop log appears under the mapped repo root, typically `.ralph/slack-loop-logs/<loop-id>.log`.
+- The loop runs in an isolated `.worktrees/<loop-id>` worktree when appropriate.
 
 Inspect state locally without printing secrets:
 
@@ -153,37 +180,55 @@ p = pathlib.Path('.ralph/slack-state.json')
 print('state exists:', p.exists())
 if p.exists():
     data = json.loads(p.read_text())
+    threads = data.get('threads', data.get('thread_bindings', {}))
     print('top-level keys:', sorted(data.keys()))
-    print('bindings:', len(data.get('threads', data.get('thread_bindings', {}))))
+    print('bindings:', len(threads))
+    for loop_id, binding in list(threads.items())[-2:]:
+        print('loop:', loop_id)
+        print('binding keys:', sorted(binding.keys()))
 PY
 ```
 
-## 7. Verify human-in-the-loop routing
+## 8. Verify polished progress UX
+
+Wait for the loop to emit progress, then verify:
+
+- A progress Block Kit card or streaming surface appears in the same root thread.
+- It shows Loop, Iteration, Hat, Topic, elapsed time, and Last message.
+- Progress updates coalesce through stored `progress_message_ts` / `stream_ts` rather than creating noisy event spam.
+- Token-shaped strings in tails/progress are redacted.
+- If Slack AI streaming is enabled, `chat.startStream`/`appendStream`/`stopStream` works; otherwise the fallback Block Kit messages remain usable and no auth gate is bypassed.
+
+## 9. Verify in-thread commands and buttons
 
 In the Slack thread:
 
 1. Reply with a normal answer/guidance sentence.
-2. Send `status`.
-3. Send `tail 10`.
-4. If safe, send `stop` / `cancel` from the original creator account.
+2. Send `status` and `!status`.
+3. Send `tail 10` and `!tail 10`.
+4. Click Status.
+5. Click Tail 10.
+6. If safe, click Stop/Cancel or send `stop` / `cancel` from the original creator account.
 
 Expected:
 
 - Plain reply is accepted only from an allowlisted user.
 - If a pending `human.interact` exists, plain reply becomes `human.response` and clears pending state.
 - If no pending question exists, plain reply becomes `human.guidance`.
-- `status` responds as a command and does not clear a pending question.
+- Commands win over pending questions and do not accidentally answer a question.
+- `status` responds with the bound loop/thread state.
 - `tail 10` redacts token-shaped strings.
-- `stop` / `cancel` works only from the thread creator.
+- Status/Tail buttons behave like their command equivalents.
+- Stop/Cancel works only for the thread creator and does not allow a different authorized user to kill someone else's loop.
 
 Inspect events from the mapped repo:
 
 ```bash
 cd /absolute/path/to/repo
-rg -n 'human\.response|human\.guidance|human\.interact' .ralph .worktrees 2>/dev/null || true
+rg -n 'human\.response|human\.guidance|human\.interact|approved|request changes' .ralph .worktrees 2>/dev/null || true
 ```
 
-## 8. Verify file upload routing
+## 10. Verify file upload routing
 
 From the mapped repo/workspace, create a harmless smoke artifact and have a loop emit a structured `human.interact` attachment payload for that path:
 
@@ -201,17 +246,30 @@ Expected:
 - Slack text/replies do not trigger arbitrary local file uploads.
 - Token values and file contents are not printed in daemon logs or review notes.
 
-## 9. Negative checks
+## 11. Verify completion card
+
+Let the loop complete naturally or stop the disposable smoke loop.
+
+Expected:
+
+- The final card appears in the same root thread.
+- It includes status, loop id, duration, and a short note.
+- Tail 10 / Status remain available.
+- Approve / Request changes buttons route as `approved` / `request changes` thread text through the pending-question or guidance path rather than mutating repo state directly.
+- The final state in `.ralph/slack-state.json` is `completed`, `failed`, or `stopped`, and `process_id` is cleared.
+
+## 12. Negative checks
 
 Perform only safe negative checks:
 
 - From a non-allowlisted Slack user, reply in the thread. Expected: no event append and no control action.
 - In a non-allowlisted channel, mention the Ralph app. Expected: no loop spawn and no thread binding.
 - Send `status` in unrelated channel chatter without a known thread binding. Expected: ignored unless it is an authorized start pattern.
+- Try Stop/Cancel from an allowlisted user who did not create the thread. Expected: denied/no process kill.
 
 Do not attempt destructive commands against a production repo.
 
-## 10. Cleanup
+## 13. Cleanup
 
 Stop the daemon with `Ctrl-C`.
 
@@ -221,33 +279,37 @@ Remove local smoke config if it contains environment-specific IDs you do not wan
 rm -f /tmp/ralph-slack-smoke.yml
 ```
 
-Optional cleanup in the mapped repo after collecting evidence:
+Review runtime artifacts before deleting them:
 
 ```bash
 cd /absolute/path/to/repo
-# Review before deleting; these are runtime artifacts.
 find .ralph .worktrees -maxdepth 3 -type f 2>/dev/null | sed -n '1,120p'
 ```
 
-## 11. Pass/fail criteria
+Do not commit `.ralph/slack-state.json`, `.ralph/slack-loop-logs/`, smoke artifacts, token-bearing configs, or `.worktrees/` runtime output.
+
+## 14. Pass/fail criteria
 
 Pass live smoke if:
 
 - daemon connects through Socket Mode;
 - root app mention in the allowlisted channel starts exactly one loop;
-- Ralph posts replies in the root Slack thread;
+- Ralph posts the start/progress/final surfaces in the root Slack thread;
+- Status / Tail buttons work;
+- `status` / `!status` and `tail 10` / `!tail 10` work in-thread;
+- completion card appears with Tail / Status / feedback controls;
 - structured loop-local file attachment upload appears in that same root thread;
 - thread reply routes to `human.response` or `human.guidance` as expected;
-- `status`/`tail` work in-thread;
-- unauthorized channel/user attempts do not create side effects;
+- unauthorized channel/user/stop attempts do not create side effects;
+- streaming works when `assistant:write` and workspace AI app support are available, or Block Kit fallback is confirmed when they are not;
 - tokens are never printed.
 
 If any item fails, capture:
 
 - command run;
 - sanitized error message;
-- Slack app scope/event/channel/user setup state;
-- whether bot was installed/invited;
+- Slack app scope/event/interactivity/channel/user setup state;
+- whether bot was installed/invited/reinstalled after the latest scope changes;
 - relevant file/function if it looks like code behavior.
 
 Then fill out [Slack review signoff template](slack-review-signoff-template.md) with `Decision: Blocked`.

--- a/docs/runbooks/slack-live-smoke-test.md
+++ b/docs/runbooks/slack-live-smoke-test.md
@@ -140,6 +140,7 @@ Expected:
 - Ralph replies in the root message's thread.
 - The reply includes a loop id/status.
 - A Slack state file appears under the mapped repo root, typically `.ralph/slack-state.json`.
+- A loop log file appears under the mapped repo root, typically `.ralph/slack-loop-logs/<loop-id>.log`.
 - The loop/thread binding uses the test channel id and root `thread_ts`.
 
 Inspect state locally without printing secrets:

--- a/docs/runbooks/slack-live-smoke-test.md
+++ b/docs/runbooks/slack-live-smoke-test.md
@@ -1,0 +1,232 @@
+# Slack live smoke test runbook
+
+Use this after the local review passes. This proves the real Slack app can drive one Ralph loop through one Slack thread.
+
+Do not run this with the Hermes Slack app. Use a dedicated Ralph Slack app so its Socket Mode event stream, scopes, and tokens are isolated.
+
+## 0. Safety rules
+
+- Do not paste token values into Slack, commits, screenshots, Kanban comments, or review notes.
+- Do not run `set -x` while tokens are exported.
+- Do not commit the smoke config if it contains real IDs you do not want public, and never commit token values.
+- Use a low-risk test channel and repo/worktree.
+- Invite only the reviewers who should be allowed to start/steer Ralph loops.
+
+## 1. Slack app prerequisites
+
+Create or open the dedicated Ralph Slack app in Slack app management.
+
+Required app setup:
+
+- Socket Mode: enabled.
+- App-level token: created with `connections:write` scope.
+- Bot token scopes:
+  - `app_mentions:read`
+  - `chat:write`
+  - `channels:history` for public-channel smoke
+  - `groups:history` only if smoking a private channel
+  - `im:history` only if intentionally smoking DMs
+- Event subscriptions:
+  - `app_mention`
+  - `message.channels` for public-channel smoke
+  - `message.groups` / `message.im` only for those surfaces
+- Bot installed to the workspace.
+- Bot invited to the allowlisted test channel.
+
+Collect non-secret IDs:
+
+- team/workspace id, if your config/review wants it;
+- test channel id, e.g. `C...`;
+- reviewer Slack user id(s), e.g. `U...`;
+- bot user id, if needed for self-message filtering review;
+- absolute repo path that channel should map to.
+
+## 2. Export tokens without printing them
+
+```bash
+cd /Users/rook/projects/ralph-orchestrator.slack-surface
+
+# Paste values into your shell. Do not echo them.
+export RALPH_SLACK_BOT_TOKEN='xoxb-...'
+export RALPH_SLACK_APP_TOKEN='xapp-...'
+
+python3 - <<'PY'
+import os
+for name in ["RALPH_SLACK_BOT_TOKEN", "RALPH_SLACK_APP_TOKEN"]:
+    value = os.environ.get(name)
+    print(f"{name}: {'set' if value else 'missing'} ({len(value) if value else 0} chars)")
+PY
+```
+
+Expected: both variables report `set`. The command must not print token values.
+
+## 3. Create a local smoke config
+
+Use a local copy rather than editing `ralph.slack.yml` in place.
+
+```bash
+cp ralph.slack.yml /tmp/ralph-slack-smoke.yml
+${EDITOR:-nano} /tmp/ralph-slack-smoke.yml
+```
+
+Replace placeholders:
+
+```yaml
+RObot:
+  enabled: true
+  surface: slack
+  timeout_seconds: 86400
+  checkin_interval_seconds: 300
+  slack:
+    bot_token: null       # use RALPH_SLACK_BOT_TOKEN
+    app_token: null       # use RALPH_SLACK_APP_TOKEN
+    signing_secret: null
+    channel_ids:
+      - C_REAL_TEST_CHANNEL
+    allowed_users:
+      - U_YOUR_USER_ID
+    channel_repos:
+      C_REAL_TEST_CHANNEL: /absolute/path/to/repo
+    start_mode: app_mention
+```
+
+Rules:
+
+- `channel_repos` value must be an absolute existing path.
+- Every `channel_ids` entry must have a `channel_repos` entry.
+- Do not put token values in the YAML.
+- Do not add broad channel/user wildcards.
+
+## 4. Preflight status and test post
+
+```bash
+cargo +stable run -p ralph-cli -- bot status --slack -c /tmp/ralph-slack-smoke.yml
+cargo +stable run -p ralph-cli -- bot test --slack -c /tmp/ralph-slack-smoke.yml --channel C_REAL_TEST_CHANNEL "Ralph Slack smoke preflight: test post"
+```
+
+Expected:
+
+- Status reports Slack config/token presence without revealing token values.
+- Test post appears in the target Slack channel.
+- If the test post fails with `not_in_channel`, invite the bot to the channel and retry.
+- If it fails with `missing_scope`, add the missing Slack scope, reinstall the app, and retry.
+
+## 5. Start daemon
+
+In a dedicated terminal:
+
+```bash
+cd /Users/rook/projects/ralph-orchestrator.slack-surface
+cargo +stable run -p ralph-cli -- bot daemon --slack -c /tmp/ralph-slack-smoke.yml
+```
+
+Expected:
+
+- Daemon connects to Socket Mode.
+- It does not print token values.
+- Leave this terminal running for the smoke.
+
+## 6. Start one Slack thread loop
+
+In the allowlisted Slack channel, send a root message that mentions the Ralph app:
+
+```text
+@Ralph smoke: start a tiny loop and ask me one question before doing anything risky
+```
+
+Expected:
+
+- Ralph replies in the root message's thread.
+- The reply includes a loop id/status.
+- A Slack state file appears under the mapped repo root, typically `.ralph/slack-state.json`.
+- The loop/thread binding uses the test channel id and root `thread_ts`.
+
+Inspect state locally without printing secrets:
+
+```bash
+cd /absolute/path/to/repo
+python3 - <<'PY'
+import json, pathlib
+p = pathlib.Path('.ralph/slack-state.json')
+print('state exists:', p.exists())
+if p.exists():
+    data = json.loads(p.read_text())
+    print('top-level keys:', sorted(data.keys()))
+    print('bindings:', len(data.get('threads', data.get('thread_bindings', {}))))
+PY
+```
+
+## 7. Verify human-in-the-loop routing
+
+In the Slack thread:
+
+1. Reply with a normal answer/guidance sentence.
+2. Send `status`.
+3. Send `tail 10`.
+4. If safe, send `stop` / `cancel` from the original creator account.
+
+Expected:
+
+- Plain reply is accepted only from an allowlisted user.
+- If a pending `human.interact` exists, plain reply becomes `human.response` and clears pending state.
+- If no pending question exists, plain reply becomes `human.guidance`.
+- `status` responds as a command and does not clear a pending question.
+- `tail 10` redacts token-shaped strings.
+- `stop` / `cancel` works only from the thread creator.
+
+Inspect events from the mapped repo:
+
+```bash
+cd /absolute/path/to/repo
+rg -n 'human\.response|human\.guidance|human\.interact' .ralph .worktrees 2>/dev/null || true
+```
+
+## 8. Negative checks
+
+Perform only safe negative checks:
+
+- From a non-allowlisted Slack user, reply in the thread. Expected: no event append and no control action.
+- In a non-allowlisted channel, mention the Ralph app. Expected: no loop spawn and no thread binding.
+- Send `status` in unrelated channel chatter without a known thread binding. Expected: ignored unless it is an authorized start pattern.
+
+Do not attempt destructive commands against a production repo.
+
+## 9. Cleanup
+
+Stop the daemon with `Ctrl-C`.
+
+Remove local smoke config if it contains environment-specific IDs you do not want kept:
+
+```bash
+rm -f /tmp/ralph-slack-smoke.yml
+```
+
+Optional cleanup in the mapped repo after collecting evidence:
+
+```bash
+cd /absolute/path/to/repo
+# Review before deleting; these are runtime artifacts.
+find .ralph .worktrees -maxdepth 3 -type f 2>/dev/null | sed -n '1,120p'
+```
+
+## 10. Pass/fail criteria
+
+Pass live smoke if:
+
+- daemon connects through Socket Mode;
+- root app mention in the allowlisted channel starts exactly one loop;
+- Ralph posts replies in the root Slack thread;
+- thread reply routes to `human.response` or `human.guidance` as expected;
+- `status`/`tail` work in-thread;
+- unauthorized channel/user attempts do not create side effects;
+- tokens are never printed.
+
+If any item fails, capture:
+
+- command run;
+- sanitized error message;
+- Slack app scope/event/channel/user setup state;
+- whether bot was installed/invited;
+- relevant file/function if it looks like code behavior.
+
+Then fill out [Slack review signoff template](slack-review-signoff-template.md) with `Decision: Blocked`.

--- a/docs/runbooks/slack-live-smoke-test.md
+++ b/docs/runbooks/slack-live-smoke-test.md
@@ -52,7 +52,7 @@ Collect non-secret IDs:
 - test channel id, e.g. `C...`;
 - reviewer/operator Slack user id(s), e.g. `U...`;
 - bot user id, if needed for self-message filtering review;
-- absolute repo path that the channel maps to;
+- repo alias and absolute repo path that the channel maps to;
 - optional team/workspace id if your streaming smoke requires it.
 
 ## 2. Export tokens without printing them
@@ -99,15 +99,18 @@ RObot:
       - C_REAL_TEST_CHANNEL
     allowed_users:
       - U_YOUR_USER_ID
+    repo_aliases:
+      ralph: /absolute/path/to/repo
     channel_repos:
-      C_REAL_TEST_CHANNEL: /absolute/path/to/repo
+      C_REAL_TEST_CHANNEL: ralph
     start_mode: app_mention
 ```
 
 Rules:
 
-- `channel_repos` value must be an absolute existing path.
+- `repo_aliases` values must be absolute existing paths.
 - Every `channel_ids` entry must have a `channel_repos` entry.
+- Every `channel_repos` value must reference a configured repo alias.
 - Do not put token values in YAML.
 - Do not add broad channel/user wildcards.
 
@@ -204,11 +207,12 @@ Wait for the loop to emit progress, then verify:
 In the Slack thread:
 
 1. Reply with a normal answer/guidance sentence.
-2. Send `status` and `!status`.
-3. Send `tail 10` and `!tail 10`.
-4. Click Status.
-5. Click Tail 10.
-6. If safe, click Stop/Cancel or send `stop` / `cancel` from the original creator account.
+2. Send `repo`.
+3. Send `status` and `!status`.
+4. Send `tail 10` and `!tail 10`.
+5. Click Status.
+6. Click Tail 10.
+7. If safe, click Stop/Cancel or send `stop` / `cancel` from the original creator account.
 
 Expected:
 
@@ -216,6 +220,7 @@ Expected:
 - If a pending `human.interact` exists, plain reply becomes `human.response` and clears pending state.
 - If no pending question exists, plain reply becomes `human.guidance`.
 - Commands win over pending questions and do not accidentally answer a question.
+- `repo` responds with the bound alias, root, subdirectory, loop id, worktree, and branch.
 - `status` responds with the bound loop/thread state.
 - `tail 10` redacts token-shaped strings.
 - Status/Tail buttons behave like their command equivalents.

--- a/docs/runbooks/slack-review-signoff-template.md
+++ b/docs/runbooks/slack-review-signoff-template.md
@@ -1,0 +1,81 @@
+# Slack review signoff template
+
+Copy this into the final Kanban comment, PR review, or release handoff after running the review runbooks.
+
+```markdown
+# Ralph Slack thread surface final review
+
+Branch: `feat/slack-thread-surface`
+Commit(s) reviewed:
+Reviewer:
+Date:
+
+## Decision
+
+- [ ] Accepted: local verification passed and live Slack smoke passed.
+- [ ] Accepted with caveat: local verification passed; live Slack smoke is blocked only on missing dedicated Slack app/tokens/real IDs.
+- [ ] Blocked: local verification or live smoke found an issue that needs repair.
+
+## Local verification
+
+Commands run:
+
+- `cargo +stable fmt --all --check` →
+- `cargo +stable test -p ralph-slack` →
+- `cargo +stable test -p ralph-core` →
+- `cargo +stable test -p ralph-cli` →
+- `cargo +stable test` →
+- `git diff --check` →
+
+Local result:
+
+Security checklist:
+
+- [ ] Auth before side effects
+- [ ] Explicit allowed users/channels
+- [ ] No first-inbound trust
+- [ ] Channel maps to repo via `RObot.slack.channel_repos`
+- [ ] Slack text cannot choose arbitrary repos
+- [ ] Thread replies use persisted repo binding
+- [ ] Event/envelope dedupe before spawn/write
+- [ ] Loop/path traversal rejected
+- [ ] Commands do not accidentally answer pending questions
+- [ ] `stop`/`cancel` creator-only
+- [ ] Tail/status/token handling redacts secrets
+- [ ] Docs/examples do not contain real secrets
+
+Notes:
+
+## Live Slack smoke
+
+Dedicated Ralph Slack app used: yes/no
+Bot installed and invited to channel: yes/no
+Tokens present locally without printing values: yes/no
+Allowlisted channel id configured: yes/no
+Allowlisted user id configured: yes/no
+`channel_repos` absolute repo mapping configured: yes/no
+
+Smoke commands/results:
+
+- `ralph bot status --slack -c /tmp/ralph-slack-smoke.yml` →
+- `ralph bot test --slack -c /tmp/ralph-slack-smoke.yml --channel ...` →
+- `ralph bot daemon --slack -c /tmp/ralph-slack-smoke.yml` →
+- Root app mention starts one thread loop →
+- Thread reply routes to `human.response`/`human.guidance` →
+- `status` / `tail` work →
+- Unauthorized user/channel negative check →
+
+Live smoke result:
+
+## Remaining blocker, if any
+
+Exact missing setup/action:
+
+## Final handoff
+
+Changed files reviewed:
+
+Known caveats:
+
+Recommended next action:
+```

--- a/docs/runbooks/slack-review-signoff-template.md
+++ b/docs/runbooks/slack-review-signoff-template.md
@@ -34,9 +34,10 @@ Security checklist:
 - [ ] Auth before side effects
 - [ ] Explicit allowed users/channels
 - [ ] No first-inbound trust
-- [ ] Channel maps to repo via `RObot.slack.channel_repos`
-- [ ] Slack text cannot choose arbitrary repos
-- [ ] Thread replies use persisted repo binding
+- [ ] Safe repo aliases configured via `RObot.slack.repo_aliases`
+- [ ] Channel maps to repo alias via `RObot.slack.channel_repos`
+- [ ] Slack text can choose only configured aliases and safe relative subdirs
+- [ ] Thread replies use persisted repo/dir binding
 - [ ] Event/envelope dedupe before spawn/write
 - [ ] Loop/path traversal rejected
 - [ ] Commands do not accidentally answer pending questions
@@ -55,7 +56,8 @@ Bot installed and invited to channel: yes/no
 Tokens present locally without printing values: yes/no
 Allowlisted channel id configured: yes/no
 Allowlisted user id configured: yes/no
-`channel_repos` absolute repo mapping configured: yes/no
+`repo_aliases` absolute repo mapping configured: yes/no
+`channel_repos` channel-to-alias default configured: yes/no
 
 Smoke commands/results:
 

--- a/docs/runbooks/slack-review-signoff-template.md
+++ b/docs/runbooks/slack-review-signoff-template.md
@@ -42,6 +42,8 @@ Security checklist:
 - [ ] Commands do not accidentally answer pending questions
 - [ ] `stop`/`cancel` creator-only
 - [ ] Tail/status/token handling redacts secrets
+- [ ] File uploads require `files:write`, use Slack external upload flow, and stay bound to the root thread
+- [ ] File path validation rejects non-workspace paths before reading
 - [ ] Docs/examples do not contain real secrets
 
 Notes:
@@ -63,6 +65,7 @@ Smoke commands/results:
 - Root app mention starts one thread loop →
 - Thread reply routes to `human.response`/`human.guidance` →
 - `status` / `tail` work →
+- Structured file upload appears in root thread after `files:write` reinstall →
 - Unauthorized user/channel negative check →
 
 Live smoke result:

--- a/ralph.slack.yml
+++ b/ralph.slack.yml
@@ -5,8 +5,8 @@
 #   export RALPH_SLACK_APP_TOKEN=xapp-...
 #   ralph bot daemon --slack -c ralph.slack.yml
 #
-# Replace channel/user IDs and repo roots before use. Slack text cannot pick
-# arbitrary repos; each channel is explicitly mapped to one workspace root.
+# Replace channel/user IDs and repo alias roots before use. Slack text can pick
+# only configured aliases and safe relative subdirectories.
 
 event_loop:
   prompt_file: "PROMPT.md"
@@ -42,8 +42,10 @@ RObot:
       - C0123456789
     allowed_users:
       - U0123456789
+    repo_aliases:
+      ralph: /absolute/path/to/repo
     channel_repos:
-      C0123456789: /absolute/path/to/repo
+      C0123456789: ralph
     start_mode: app_mention
 
 tasks:

--- a/ralph.slack.yml
+++ b/ralph.slack.yml
@@ -18,7 +18,7 @@ event_loop:
   starting_event: "plan.start"
 
 cli:
-  backend: "claude"
+  backend: "codex"
 
 core:
   specs_dir: "./specs/"
@@ -83,11 +83,13 @@ hats:
     name: "Reviewer"
     description: "Reviews completed work and decides whether the loop is done."
     triggers: ["work.done"]
-    publishes: ["plan.start", "human.interact"]
+    publishes: ["plan.start", "human.interact", "LOOP_COMPLETE"]
     backend:
       type: "codex"
     instructions: |
-      Verify the work against the request. If it is complete, output LOOP_COMPLETE.
+      Verify the work against the request and any Slack-thread steering.
+      If it is complete and no further human decision is required, emit the completion
+      event exactly with `ralph emit "LOOP_COMPLETE" "approved"` and stop.
       If it needs revision, emit plan.start with the specific follow-up. If human
       signoff is required, emit human.interact in the bound Slack thread.
 

--- a/ralph.slack.yml
+++ b/ralph.slack.yml
@@ -1,0 +1,97 @@
+# Slack Human-in-the-Loop preset
+#
+# Usage:
+#   export RALPH_SLACK_BOT_TOKEN=xoxb-...
+#   export RALPH_SLACK_APP_TOKEN=xapp-...
+#   ralph bot daemon --slack -c ralph.slack.yml
+#
+# Replace channel/user IDs and repo roots before use. Slack text cannot pick
+# arbitrary repos; each channel is explicitly mapped to one workspace root.
+
+event_loop:
+  prompt_file: "PROMPT.md"
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 2000
+  max_runtime_seconds: 999999999
+  cooldown_delay_seconds: 5
+  checkpoint_interval: 1
+  starting_event: "plan.start"
+
+cli:
+  backend: "claude"
+
+core:
+  specs_dir: "./specs/"
+  guardrails:
+    - "Use Slack thread replies for human.response and human.guidance."
+    - "Do not complete the loop unless the work satisfies the configured completion promise."
+
+RObot:
+  enabled: true
+  surface: slack
+  timeout_seconds: 86400
+  checkin_interval_seconds: 300
+  slack:
+    # Prefer env vars over checked-in secrets:
+    #   RALPH_SLACK_BOT_TOKEN=xoxb-...
+    #   RALPH_SLACK_APP_TOKEN=xapp-...
+    bot_token: null
+    app_token: null
+    signing_secret: null
+    channel_ids:
+      - C0123456789
+    allowed_users:
+      - U0123456789
+    channel_repos:
+      C0123456789: /absolute/path/to/repo
+    start_mode: app_mention
+
+tasks:
+  enabled: true
+
+memories:
+  enabled: true
+  inject: auto
+  budget: 2000
+
+hats:
+  planner:
+    name: "Planner"
+    description: "Plans work and asks Slack-thread questions when human input is required."
+    triggers: ["plan.start", "human.response"]
+    publishes: ["human.interact", "work.start"]
+    default_publishes: "work.start"
+    instructions: |
+      Read the starting prompt or human response. If you need a human decision,
+      emit human.interact with one clear question; otherwise emit work.start with
+      the concrete implementation request.
+
+  executor:
+    name: "Executor"
+    description: "Executes the requested task."
+    triggers: ["work.start", "human.guidance"]
+    publishes: ["work.done", "human.interact"]
+    default_publishes: "work.done"
+    backend:
+      type: "codex"
+    instructions: |
+      Implement the requested work. Treat human.guidance from the Slack thread as
+      live steering. If blocked, emit human.interact; otherwise emit work.done
+      with a concise summary and verification evidence.
+
+  reviewer:
+    name: "Reviewer"
+    description: "Reviews completed work and decides whether the loop is done."
+    triggers: ["work.done"]
+    publishes: ["plan.start", "human.interact"]
+    backend:
+      type: "codex"
+    instructions: |
+      Verify the work against the request. If it is complete, output LOOP_COMPLETE.
+      If it needs revision, emit plan.start with the specific follow-up. If human
+      signoff is required, emit human.interact in the bound Slack thread.
+
+skills:
+  enabled: true
+  dirs:
+    - ".claude/skills"


### PR DESCRIPTION
## Summary
- Add Slack thread-bound Ralph/RObot surface with Socket Mode daemon, thread lifecycle, progress/status/tail controls, file upload support, and assistant status pulses.
- Add Slack runbooks/manifests/signoff docs and local verification paths.
- Preserve safety boundaries: configured channel/user/repo allowlists, token redaction, and no arbitrary local file upload from inbound text.

## Verification
- Worker handoffs recorded full workspace `cargo +stable test`, `cargo +stable fmt --all --check`, package-specific Slack/core/CLI tests, and `git diff --check`.
- Branch pushed from `/Users/rook/projects/ralph-orchestrator.slack-surface` at `e3f4dd29d5ed533162a61ee85b45fd0f40b4620f`.
- Final live Slack smoke still requires dedicated app reinstall/tokens/channel/user/repo mapping in the operator environment.

Kanban closeout: `t_4cb52073`, `t_8e8070d1`, `t_6dff8096`.
