### PR TITLE
Fix runtime completion correctness for defaults and guidance

### DIFF
--- a/crates/ralph-core/src/event_loop/loop_state.rs
+++ b/crates/ralph-core/src/event_loop/loop_state.rs
@@ -70,6 +70,9 @@ pub struct LoopState {
 
     /// Set to true when a loop.cancel event is detected.
     pub cancellation_requested: bool,
+
+    /// Human guidance messages that must be acknowledged before completion.
+    pub unacknowledged_guidance: Vec<String>,
 }
 
 impl Default for LoopState {
@@ -95,6 +98,7 @@ impl Default for LoopState {
             last_emitted_signature: None,
             consecutive_same_signature: 0,
             cancellation_requested: false,
+            unacknowledged_guidance: Vec::new(),
         }
     }
 }

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -664,6 +664,22 @@ impl EventLoop {
             }
         }
 
+        if !self.state.unacknowledged_guidance.is_empty() {
+            let guidance_count = self.state.unacknowledged_guidance.len();
+            warn!(
+                guidance_count,
+                "Rejecting LOOP_COMPLETE: human.guidance is unacknowledged"
+            );
+            self.state.completion_requested = false;
+            self.bus.publish(Event::new(
+                "task.resume",
+                format!(
+                    "Completion rejected: {guidance_count} human.guidance message(s) remain unacknowledged. Address the guidance, then emit human.guidance.ack with a summary before emitting the completion promise."
+                ),
+            ));
+            return None;
+        }
+
         self.state.completion_requested = false;
 
         // In persistent mode, suppress completion and keep the loop alive
@@ -1765,6 +1781,26 @@ impl EventLoop {
         if let Some(config) = self.registry.get_config(hat_id)
             && let Some(default_topic) = &config.default_publishes
         {
+            if default_topic.as_str() == self.config.event_loop.completion_promise {
+                warn!(
+                    hat = %hat_id.as_str(),
+                    topic = %default_topic,
+                    "default_publishes matches completion_promise — requiring explicit agent event"
+                );
+                let resume_event = Event::new(
+                    "task.resume",
+                    format!(
+                        "Recovery: hat `{}` produced no events, and its default_publishes is the completion promise `{}`. Ralph will not complete silently; emit explicit completion evidence or a valid non-terminal event.",
+                        hat_id.as_str(),
+                        default_topic
+                    ),
+                )
+                .with_target(hat_id.clone());
+                self.state.record_event(&resume_event);
+                self.bus.publish(resume_event);
+                return;
+            }
+
             let default_event = Event::new(default_topic.as_str(), "").with_source(hat_id.clone());
 
             debug!(
@@ -1774,19 +1810,6 @@ impl EventLoop {
             );
 
             self.state.record_event(&default_event);
-
-            // If the default topic is the completion promise, set the flag directly.
-            // The normal path (process_events_from_jsonl) sets this when reading from
-            // JSONL, but default_publishes bypasses JSONL entirely.
-            if default_topic.as_str() == self.config.event_loop.completion_promise {
-                info!(
-                    hat = %hat_id.as_str(),
-                    topic = %default_topic,
-                    "default_publishes matches completion_promise — requesting termination"
-                );
-                self.state.completion_requested = true;
-            }
-
             self.bus.publish(default_event);
         }
     }
@@ -2308,6 +2331,23 @@ impl EventLoop {
                 );
                 self.state.cancellation_requested = true;
                 // Continue processing remaining events (they may contain cleanup info)
+                continue;
+            }
+
+            if event.topic == "human.guidance" {
+                self.state.unacknowledged_guidance.push(payload.clone());
+                validated_events.push(Event::new(event.topic.as_str(), &payload));
+                continue;
+            }
+
+            if event.topic == "human.guidance.ack" {
+                info!(
+                    payload = %payload,
+                    guidance_count = self.state.unacknowledged_guidance.len(),
+                    "human.guidance acknowledged"
+                );
+                self.state.unacknowledged_guidance.clear();
+                validated_events.push(Event::new(event.topic.as_str(), &payload));
                 continue;
             }
 

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -1083,6 +1083,145 @@ fn test_default_publishes_injects_when_no_events() {
 }
 
 #[test]
+fn test_default_publishes_completion_promise_requires_explicit_agent_event() {
+    use std::collections::HashMap;
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut config = RalphConfig::default();
+    let mut hats = HashMap::new();
+    hats.insert(
+        "final-reviewer".to_string(),
+        crate::config::HatConfig {
+            name: "final-reviewer".to_string(),
+            description: Some("Final reviewer".to_string()),
+            triggers: vec!["review.ready".to_string()],
+            publishes: vec!["LOOP_COMPLETE".to_string()],
+            instructions: "Verify the objective is complete".to_string(),
+            extra_instructions: vec![],
+            backend_args: None,
+            backend: None,
+            default_publishes: Some("LOOP_COMPLETE".to_string()),
+            max_activations: None,
+            scratchpad: None,
+            disallowed_tools: vec![],
+            timeout: None,
+            concurrency: 1,
+            aggregate: None,
+        },
+    );
+    config.hats = hats;
+
+    let mut event_loop = EventLoop::new(config);
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+
+    let hat_id = HatId::new("final-reviewer");
+    let result = event_loop.process_events_from_jsonl().unwrap();
+    assert!(!result.had_events, "No agent events should be found");
+
+    event_loop.check_default_publishes(&hat_id);
+
+    assert!(
+        !event_loop.state.completion_requested,
+        "agent silence must not request LOOP_COMPLETE via default_publishes"
+    );
+    assert_eq!(
+        event_loop.check_completion_event(),
+        None,
+        "default_publishes must not terminate the loop on agent silence"
+    );
+    assert!(
+        event_loop.state.seen_topics.contains("task.resume"),
+        "a recovery event should be recorded instead"
+    );
+    assert!(
+        !event_loop.state.seen_topics.contains("LOOP_COMPLETE"),
+        "completion promise should not be marked seen without an explicit agent event"
+    );
+}
+
+#[test]
+fn test_unacknowledged_human_guidance_blocks_completion() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(RalphConfig::default());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+
+    write_event_to_jsonl(
+        &events_path,
+        "human.guidance",
+        "Please do not use odd Node.js versions",
+    );
+    write_event_to_jsonl(&events_path, "LOOP_COMPLETE", "done");
+    let result = event_loop.process_events_from_jsonl().unwrap();
+
+    assert!(
+        result.had_events,
+        "guidance and completion events should parse"
+    );
+    assert_eq!(
+        event_loop.check_completion_event(),
+        None,
+        "completion must be rejected until human.guidance is acknowledged"
+    );
+    assert!(
+        event_loop.has_pending_events(),
+        "completion rejection should inject task.resume for recovery"
+    );
+    assert_eq!(
+        event_loop.state.unacknowledged_guidance.len(),
+        1,
+        "guidance remains blocking until human.guidance.ack"
+    );
+}
+
+#[test]
+fn test_human_guidance_ack_allows_completion() {
+    use tempfile::tempdir;
+
+    let temp_dir = tempdir().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let mut event_loop = EventLoop::new(RalphConfig::default());
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.initialize("Test");
+
+    write_event_to_jsonl(
+        &events_path,
+        "human.guidance",
+        "Please do not use odd Node.js versions",
+    );
+    write_event_to_jsonl(
+        &events_path,
+        "human.guidance.ack",
+        "Used Node.js 22 LTS instead",
+    );
+    write_event_to_jsonl(&events_path, "LOOP_COMPLETE", "done");
+    let result = event_loop.process_events_from_jsonl().unwrap();
+
+    assert!(
+        result.had_events,
+        "guidance, ack, and completion events should parse"
+    );
+    assert!(
+        event_loop.state.unacknowledged_guidance.is_empty(),
+        "human.guidance.ack should clear guidance backpressure"
+    );
+    assert_eq!(
+        event_loop.check_completion_event(),
+        Some(TerminationReason::CompletionPromise),
+        "acknowledged guidance should allow normal completion"
+    );
+}
+
+#[test]
 fn test_default_publishes_not_injected_when_events_written() {
     use std::collections::HashMap;
     use std::io::Write;
@@ -4110,7 +4249,7 @@ fn test_default_publishes_satisfies_required_events_for_completion() {
 }
 
 #[test]
-fn test_default_publishes_completion_promise_triggers_termination() {
+fn test_default_publishes_completion_promise_injects_recovery() {
     use std::collections::HashMap;
     use tempfile::TempDir;
 
@@ -4159,14 +4298,24 @@ fn test_default_publishes_completion_promise_triggers_termination() {
     let hat_id = HatId::new("final_committer");
     event_loop.check_default_publishes(&hat_id);
 
-    // completion_requested should be set directly by check_default_publishes
-    // (not requiring a JSONL round-trip)
+    // Completion defaults are recovery-only: a silent final hat must not
+    // terminate the loop without an explicit agent-written completion event.
     let reason = event_loop.check_completion_event();
     assert_eq!(
-        reason,
-        Some(TerminationReason::CompletionPromise),
-        "default_publishes of completion_promise should trigger termination directly, \
-         not just publish to the bus where it would be lost"
+        reason, None,
+        "default_publishes of completion_promise must not silently terminate"
+    );
+    assert!(
+        !event_loop.state.completion_requested,
+        "completion should not be requested from agent silence"
+    );
+    assert!(
+        event_loop.state.seen_topics.contains("task.resume"),
+        "a recovery task.resume should be injected for the silent final hat"
+    );
+    assert!(
+        !event_loop.state.seen_topics.contains("LOOP_COMPLETE"),
+        "LOOP_COMPLETE should only be seen after an explicit event"
     );
 }
 

--- a/crates/ralph-core/src/hatless_ralph.rs
+++ b/crates/ralph-core/src/hatless_ralph.rs
@@ -327,6 +327,10 @@ impl HatlessRalph {
         }
 
         let mut section = String::from("## ROBOT GUIDANCE\n\n");
+        section.push_str(
+            "This guidance is blocking. You MUST address it before declaring completion. \
+             After addressing it, emit `human.guidance.ack` with a brief summary.\n\n",
+        );
 
         if self.robot_guidance.len() == 1 {
             section.push_str(&self.robot_guidance[0]);

--- a/crates/ralph-core/src/summary_writer.rs
+++ b/crates/ralph-core/src/summary_writer.rs
@@ -327,6 +327,7 @@ mod tests {
             last_emitted_signature: None,
             consecutive_same_signature: 0,
             cancellation_requested: false,
+            unacknowledged_guidance: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Prevent final-hat `default_publishes: LOOP_COMPLETE` from silently completing after agent silence; inject `task.resume` recovery instead.
- Track unacknowledged `human.guidance` and reject completion until `human.guidance.ack` is emitted.
- Mark robot guidance prompt text as blocking and add regression coverage.

Fixes #187.
Fixes #217.

## Verification
- `cargo test -p ralph-core default_publishes_completion_promise -- --nocapture`
- `cargo test -p ralph-core guidance -- --nocapture`
- `cargo fmt --all --check`
- `cargo test`
- `cargo test -p ralph-core --test smoke_runner`