### PR TITLE
feat(tui): export iteration buffers on demand

### DIFF
--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -525,6 +525,7 @@ pub async fn run_loop_impl(
                 prompt: prompt_content.clone(),
                 max_iterations: Some(config.event_loop.max_iterations),
                 backend: config.cli.backend.clone(),
+                workspace_root: Some(ctx.workspace().to_string_lossy().to_string()),
                 started_at: rpc_state_started_at,
             };
             let _ = tx.try_send(started_event);
@@ -548,6 +549,7 @@ pub async fn run_loop_impl(
         let tui = Tui::new()
             .with_hat_map(hat_map)
             .with_termination_signal(terminated_rx)
+            .with_export_workspace_root(ctx.workspace().to_path_buf())
             .with_events_path(resolve_current_events_path(&ctx))
             .with_urgent_steer_path(urgent_steer_path.clone());
 

--- a/crates/ralph-proto/src/json_rpc.rs
+++ b/crates/ralph-proto/src/json_rpc.rs
@@ -160,6 +160,9 @@ pub enum RpcEvent {
         max_iterations: Option<u32>,
         /// Backend being used.
         backend: String,
+        /// Workspace root for the loop emitting this event.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_root: Option<String>,
         /// Unix timestamp (milliseconds) when the loop started.
         started_at: u64,
     },
@@ -653,6 +656,7 @@ mod tests {
             prompt: "test prompt".to_string(),
             max_iterations: Some(10),
             backend: "claude".to_string(),
+            workspace_root: Some("/tmp/ralph-workspace".to_string()),
             started_at: 1_700_000_000_000,
         };
         let json = serde_json::to_string(&event).unwrap();

--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -121,6 +121,12 @@ pub fn dispatch_action(action: Action, state: &mut TuiState, viewport_height: us
         Action::ToggleMouseMode => {
             state.mouse_capture_enabled = !state.mouse_capture_enabled;
         }
+        Action::ExportCurrentIteration => {
+            state.export_current_iteration_to_disk();
+        }
+        Action::ExportAllIterations => {
+            state.export_all_iterations_to_disk();
+        }
         Action::None => {}
     }
     false
@@ -391,6 +397,7 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
 
                     // Clear expired flash messages (e.g., guidance send confirmation)
                     state.clear_expired_guidance_flash();
+                    state.clear_expired_export_flash();
 
                     // Autoscroll: if user hasn't scrolled away, keep them at the bottom
                     // as new content arrives. This mimics standard terminal behavior.
@@ -456,7 +463,7 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
 mod tests {
     use super::*;
     use crate::input::{Action, map_key};
-    use crate::state::TuiState;
+    use crate::state::{ExportOutcome, TuiState};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::text::Line;
 
@@ -662,6 +669,89 @@ mod tests {
 
         dispatch_action(Action::ToggleMouseMode, &mut state, 10);
         assert!(!state.mouse_capture_enabled);
+    }
+
+    #[test]
+    fn dispatch_action_export_current_writes_current_iteration_file() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut state = TuiState::new();
+        state.set_export_workspace_root(temp_dir.path());
+        state.start_new_iteration_with_metadata(Some("Builder".to_string()), Some("codex".into()));
+        state
+            .current_iteration_mut()
+            .unwrap()
+            .append_line(Line::from("current only"));
+
+        let should_quit = dispatch_action(Action::ExportCurrentIteration, &mut state, 10);
+
+        assert!(!should_quit);
+        let path = match &state.export_flash.as_ref().unwrap().outcome {
+            ExportOutcome::Success { path } => path.clone(),
+            ExportOutcome::Failed { message } => panic!("export failed: {message}"),
+        };
+        assert!(path.starts_with(temp_dir.path().join(".ralph/tui-exports")));
+        assert!(
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("ralph-tui-current-"))
+        );
+        let text = std::fs::read_to_string(path).unwrap();
+        assert!(text.contains("Iteration 1"));
+        assert!(text.contains("Hat: Builder"));
+        assert!(text.contains("Backend: codex"));
+        assert!(text.contains("current only"));
+    }
+
+    #[test]
+    fn dispatch_action_export_all_writes_single_file_with_all_iterations() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut state = TuiState::new();
+        state.set_export_workspace_root(temp_dir.path());
+        state.start_new_iteration();
+        state
+            .current_iteration_mut()
+            .unwrap()
+            .append_line(Line::from("iteration one"));
+        state.start_new_iteration();
+        state
+            .current_iteration_mut()
+            .unwrap()
+            .append_line(Line::from("iteration two"));
+
+        dispatch_action(Action::ExportAllIterations, &mut state, 10);
+
+        let path = match &state.export_flash.as_ref().unwrap().outcome {
+            ExportOutcome::Success { path } => path.clone(),
+            ExportOutcome::Failed { message } => panic!("export failed: {message}"),
+        };
+        assert!(
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("ralph-tui-all-"))
+        );
+        let text = std::fs::read_to_string(path).unwrap();
+        assert!(text.contains("Iterations: 2"));
+        assert!(text.contains("Iteration 1"));
+        assert!(text.contains("iteration one"));
+        assert!(text.contains("Iteration 2"));
+        assert!(text.contains("iteration two"));
+    }
+
+    #[test]
+    fn dispatch_action_export_all_without_iterations_sets_failure_status() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut state = TuiState::new();
+        state.set_export_workspace_root(temp_dir.path());
+
+        dispatch_action(Action::ExportAllIterations, &mut state, 10);
+
+        match &state.export_flash.as_ref().unwrap().outcome {
+            ExportOutcome::Success { path } => panic!("unexpected export at {}", path.display()),
+            ExportOutcome::Failed { message } => {
+                assert!(message.contains("no iteration buffers to export"));
+            }
+        }
+        assert!(!temp_dir.path().join(".ralph/tui-exports").exists());
     }
 
     // =========================================================================

--- a/crates/ralph-tui/src/export.rs
+++ b/crates/ralph-tui/src/export.rs
@@ -1,0 +1,256 @@
+//! Export helpers for TUI iteration buffers.
+
+use crate::state::IterationBuffer;
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use ratatui::text::Line;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+
+const EXPORT_DIR: &str = ".ralph/tui-exports";
+
+/// Which set of iteration buffers to export.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportScope {
+    /// Export only the currently viewed iteration.
+    Current,
+    /// Export every iteration currently held in memory.
+    All,
+}
+
+impl ExportScope {
+    fn file_slug(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+            Self::All => "all",
+        }
+    }
+
+    /// Human-readable label for status messages.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Current => "current iteration",
+            Self::All => "all iterations",
+        }
+    }
+}
+
+/// Plain-text snapshot of one iteration buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IterationExport {
+    /// Iteration number as shown in the TUI.
+    pub number: u32,
+    /// Hat display captured for the iteration.
+    pub hat_display: Option<String>,
+    /// Backend captured for the iteration.
+    pub backend: Option<String>,
+    /// Plain text lines from the buffer.
+    pub lines: Vec<String>,
+}
+
+impl IterationExport {
+    /// Creates a plain-text snapshot from a live iteration buffer.
+    pub fn from_buffer(buffer: &IterationBuffer) -> Result<Self> {
+        let lines = buffer
+            .lines
+            .lock()
+            .map_err(|_| anyhow::anyhow!("iteration buffer lock poisoned"))?
+            .iter()
+            .map(line_to_text)
+            .collect();
+
+        Ok(Self {
+            number: buffer.number,
+            hat_display: buffer.hat_display.clone(),
+            backend: buffer.backend.clone(),
+            lines,
+        })
+    }
+}
+
+/// Returns the TUI export directory for a workspace root.
+pub fn export_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(EXPORT_DIR)
+}
+
+/// Writes a collision-safe export file and returns its path.
+pub fn write_export(
+    workspace_root: &Path,
+    scope: ExportScope,
+    iterations: &[IterationExport],
+) -> Result<PathBuf> {
+    if iterations.is_empty() {
+        bail!("no iteration buffers to export");
+    }
+
+    let dir = export_dir(workspace_root);
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+
+    let stem = format!(
+        "ralph-tui-{}-{}",
+        scope.file_slug(),
+        Utc::now().format("%Y%m%dT%H%M%S%.6fZ")
+    );
+    write_collision_safe(&dir, &stem, &format_iterations(iterations))
+}
+
+/// Formats iteration snapshots as a stable plain-text artifact.
+pub fn format_iterations(iterations: &[IterationExport]) -> String {
+    let mut output = String::new();
+    output.push_str("# Ralph TUI Export\n");
+    output.push_str(&format!("Iterations: {}\n\n", iterations.len()));
+
+    for (idx, iteration) in iterations.iter().enumerate() {
+        if idx > 0 {
+            output.push('\n');
+        }
+
+        output.push_str(
+            "================================================================================\n",
+        );
+        output.push_str(&format!("Iteration {}\n", iteration.number));
+        output.push_str(&format!(
+            "Hat: {}\n",
+            iteration.hat_display.as_deref().unwrap_or("unknown")
+        ));
+        output.push_str(&format!(
+            "Backend: {}\n",
+            iteration.backend.as_deref().unwrap_or("unknown")
+        ));
+        output.push_str(&format!("Lines: {}\n", iteration.lines.len()));
+        output.push_str(
+            "================================================================================\n",
+        );
+
+        for line in &iteration.lines {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+
+    output
+}
+
+fn line_to_text(line: &Line<'_>) -> String {
+    line.spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect::<String>()
+}
+
+fn write_collision_safe(dir: &Path, stem: &str, content: &str) -> Result<PathBuf> {
+    for suffix in 0..1000 {
+        let filename = if suffix == 0 {
+            format!("{stem}.txt")
+        } else {
+            format!("{stem}-{suffix:03}.txt")
+        };
+        let path = dir.join(filename);
+
+        let mut file = match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => continue,
+            Err(err) => {
+                return Err(err).with_context(|| format!("failed to create {}", path.display()));
+            }
+        };
+
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("failed to write {}", path.display()))?;
+        return Ok(path);
+    }
+
+    bail!(
+        "could not allocate a unique TUI export path in {}",
+        dir.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::text::{Line, Span};
+
+    #[test]
+    fn format_iterations_uses_clear_stable_headers() {
+        let text = format_iterations(&[
+            IterationExport {
+                number: 1,
+                hat_display: Some("Planner".to_string()),
+                backend: Some("claude".to_string()),
+                lines: vec!["first line".to_string(), "second line".to_string()],
+            },
+            IterationExport {
+                number: 2,
+                hat_display: None,
+                backend: None,
+                lines: vec!["done".to_string()],
+            },
+        ]);
+
+        assert_eq!(
+            text,
+            "# Ralph TUI Export\n\
+Iterations: 2\n\
+\n\
+================================================================================\n\
+Iteration 1\n\
+Hat: Planner\n\
+Backend: claude\n\
+Lines: 2\n\
+================================================================================\n\
+first line\n\
+second line\n\
+\n\
+================================================================================\n\
+Iteration 2\n\
+Hat: unknown\n\
+Backend: unknown\n\
+Lines: 1\n\
+================================================================================\n\
+done\n"
+        );
+    }
+
+    #[test]
+    fn from_buffer_flattens_styled_spans_to_text() {
+        let mut buffer = IterationBuffer::new(7);
+        buffer.hat_display = Some("Builder".to_string());
+        buffer.backend = Some("codex".to_string());
+        buffer.append_line(Line::from(vec![Span::raw("hello "), Span::raw("world")]));
+
+        let export = IterationExport::from_buffer(&buffer).unwrap();
+
+        assert_eq!(export.number, 7);
+        assert_eq!(export.hat_display.as_deref(), Some("Builder"));
+        assert_eq!(export.backend.as_deref(), Some("codex"));
+        assert_eq!(export.lines, vec!["hello world"]);
+    }
+
+    #[test]
+    fn export_dir_is_under_workspace_ralph_directory() {
+        let root = Path::new("/tmp/workspace");
+
+        assert_eq!(
+            export_dir(root),
+            PathBuf::from("/tmp/workspace/.ralph/tui-exports")
+        );
+    }
+
+    #[test]
+    fn write_collision_safe_adds_suffix_when_name_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("ralph-tui-current-fixed.txt");
+        fs::write(&existing, "existing").unwrap();
+
+        let written = write_collision_safe(dir.path(), "ralph-tui-current-fixed", "new").unwrap();
+
+        assert_eq!(
+            written.file_name().and_then(|name| name.to_str()),
+            Some("ralph-tui-current-fixed-001.txt")
+        );
+        assert_eq!(fs::read_to_string(written).unwrap(), "new");
+        assert_eq!(fs::read_to_string(existing).unwrap(), "existing");
+    }
+}

--- a/crates/ralph-tui/src/input.rs
+++ b/crates/ralph-tui/src/input.rs
@@ -44,6 +44,10 @@ pub enum Action {
     EnterWaveView,
     /// Toggle mouse capture for wheel scrolling vs native text selection
     ToggleMouseMode,
+    /// Export the currently viewed iteration buffer to disk
+    ExportCurrentIteration,
+    /// Export every iteration buffer to disk
+    ExportAllIterations,
     /// Key not mapped to any action
     None,
 }
@@ -62,6 +66,8 @@ pub enum Action {
 /// - `n`: Next search match
 /// - `N`: Previous search match
 /// - `m`: Toggle mouse mode
+/// - `e`: Export current iteration
+/// - `E`: Export all iterations
 /// - `?`: Show help
 /// - `Esc`: Dismiss help/cancel search
 pub fn map_key(key: KeyEvent) -> Action {
@@ -93,6 +99,10 @@ pub fn map_key(key: KeyEvent) -> Action {
 
         // Mouse mode
         KeyCode::Char('m') => Action::ToggleMouseMode,
+
+        // Export
+        KeyCode::Char('e') => Action::ExportCurrentIteration,
+        KeyCode::Char('E') => Action::ExportAllIterations,
 
         // Help
         KeyCode::Char('?') => Action::ShowHelp,
@@ -227,7 +237,21 @@ mod tests {
         assert_eq!(map_key(key), Action::ToggleMouseMode);
     }
 
-    // AC18: Unknown Key Returns None
+    // AC18: e Exports Current Iteration
+    #[test]
+    fn e_returns_export_current_iteration() {
+        let key = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE);
+        assert_eq!(map_key(key), Action::ExportCurrentIteration);
+    }
+
+    // AC19: E Exports All Iterations
+    #[test]
+    fn shift_e_returns_export_all_iterations() {
+        let key = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::SHIFT);
+        assert_eq!(map_key(key), Action::ExportAllIterations);
+    }
+
+    // AC20: Unknown Key Returns None
     #[test]
     fn unknown_key_returns_none() {
         let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);

--- a/crates/ralph-tui/src/lib.rs
+++ b/crates/ralph-tui/src/lib.rs
@@ -23,6 +23,7 @@
 //!    communicates via JSON lines over stdin/stdout. Start with [`Tui::spawn`].
 
 mod app;
+pub mod export;
 pub mod input;
 pub mod rpc_bridge;
 pub mod rpc_client;
@@ -204,6 +205,15 @@ impl Tui {
     #[must_use]
     pub fn with_termination_signal(mut self, terminated_rx: watch::Receiver<bool>) -> Self {
         self.terminated_rx = Some(terminated_rx);
+        self
+    }
+
+    /// Sets the workspace root used for TUI export artifacts.
+    #[must_use]
+    pub fn with_export_workspace_root(self, root: std::path::PathBuf) -> Self {
+        if let Ok(mut state) = self.state.lock() {
+            state.set_export_workspace_root(root);
+        }
         self
     }
 

--- a/crates/ralph-tui/src/rpc_source.rs
+++ b/crates/ralph-tui/src/rpc_source.rs
@@ -229,11 +229,15 @@ fn apply_rpc_event(event: &RpcEvent, state: &Arc<Mutex<TuiState>>, acc: &mut Tex
         RpcEvent::LoopStarted {
             max_iterations,
             backend,
+            workspace_root,
             ..
         } => {
             s.loop_started = Some(Instant::now());
             s.max_iterations = *max_iterations;
             s.pending_backend = Some(backend.clone());
+            if let Some(workspace_root) = workspace_root {
+                s.set_export_workspace_root(workspace_root);
+            }
         }
 
         RpcEvent::IterationStart {
@@ -599,6 +603,7 @@ mod tests {
             prompt: "test".to_string(),
             max_iterations: Some(10),
             backend: "claude".to_string(),
+            workspace_root: Some("/tmp/loop-workspace".to_string()),
             started_at: 0,
         };
         apply_rpc_event(&event, &state, &mut acc);
@@ -606,6 +611,10 @@ mod tests {
         let s = state.lock().unwrap();
         assert!(s.loop_started.is_some());
         assert_eq!(s.max_iterations, Some(10));
+        assert_eq!(
+            s.export_workspace_root(),
+            std::path::Path::new("/tmp/loop-workspace")
+        );
     }
 
     #[test]
@@ -1132,6 +1141,7 @@ mod tests {
             prompt: "test".to_string(),
             max_iterations: Some(10),
             backend: "claude".to_string(),
+            workspace_root: None,
             started_at: 0,
         };
         let line = format!("{}\n", serde_json::to_string(&event).unwrap());

--- a/crates/ralph-tui/src/state.rs
+++ b/crates/ralph-tui/src/state.rs
@@ -1,7 +1,9 @@
 //! State management for the TUI.
 
+use crate::export::{ExportScope, IterationExport};
 use ralph_proto::{Event, HatId};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 // ============================================================================
@@ -113,6 +115,26 @@ pub enum GuidanceResult {
     Failed,
 }
 
+/// Result of exporting iteration buffers to disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExportOutcome {
+    /// Export completed and wrote the given path.
+    Success { path: PathBuf },
+    /// Export failed with a user-facing message.
+    Failed { message: String },
+}
+
+/// Brief status shown after an export action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportFlash {
+    /// Which export action produced this status.
+    pub scope: ExportScope,
+    /// Export success or failure details.
+    pub outcome: ExportOutcome,
+    /// When the flash was created.
+    pub when: Instant,
+}
+
 /// Status of the background update check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UpdateStatus {
@@ -209,6 +231,10 @@ pub struct TuiState {
     pub update_status: UpdateStatus,
     /// Git branch for the workspace the TUI was launched from.
     current_branch: Option<String>,
+    /// Workspace root used for `.ralph/tui-exports`.
+    export_workspace_root: PathBuf,
+    /// Brief flash message after attempting an export.
+    pub export_flash: Option<ExportFlash>,
     /// Map of event topics to hat display information (for custom hats).
     /// Key: event topic (e.g., "review.security")
     /// Value: (HatId, display name including emoji)
@@ -323,6 +349,8 @@ impl TuiState {
             idle_timeout_remaining: None,
             update_status: UpdateStatus::Unknown,
             current_branch: None,
+            export_workspace_root: default_export_workspace_root(),
+            export_flash: None,
             hat_map: HashMap::new(),
             // Iteration management
             iterations: Vec::new(),
@@ -376,6 +404,23 @@ impl TuiState {
         self.current_branch.as_deref()
     }
 
+    /// Sets the workspace root used by TUI exports.
+    pub fn set_export_workspace_root(&mut self, root: impl Into<PathBuf>) {
+        self.export_workspace_root = root.into();
+    }
+
+    /// Returns the workspace root used by TUI exports.
+    pub fn export_workspace_root(&self) -> &Path {
+        &self.export_workspace_root
+    }
+
+    /// Returns a compact display path for an export artifact.
+    pub fn display_export_path(&self, path: &Path) -> String {
+        path.strip_prefix(&self.export_workspace_root)
+            .map(|relative| relative.display().to_string())
+            .unwrap_or_else(|_| path.display().to_string())
+    }
+
     /// Replaces the dynamic topic-to-hat mapping without resetting the rest of the state.
     pub fn set_hat_map(&mut self, hat_map: HashMap<String, (HatId, String)>) {
         self.hat_map = hat_map;
@@ -412,6 +457,8 @@ impl TuiState {
                 let saved_new_iteration_alert = self.new_iteration_alert.take();
                 let saved_pending_backend = self.pending_backend.clone();
                 let saved_current_branch = self.current_branch.clone();
+                let saved_export_workspace_root = self.export_workspace_root.clone();
+                let saved_export_flash = self.export_flash.clone();
                 let saved_guidance_next_queue = Arc::clone(&self.guidance_next_queue);
                 let saved_events_path = self.events_path.clone();
                 let saved_urgent_steer_path = self.urgent_steer_path.clone();
@@ -425,6 +472,8 @@ impl TuiState {
                 self.new_iteration_alert = saved_new_iteration_alert;
                 self.pending_backend = saved_pending_backend;
                 self.current_branch = saved_current_branch;
+                self.export_workspace_root = saved_export_workspace_root;
+                self.export_flash = saved_export_flash;
                 self.guidance_next_queue = saved_guidance_next_queue;
                 self.events_path = saved_events_path;
                 self.urgent_steer_path = saved_urgent_steer_path;
@@ -822,6 +871,101 @@ impl TuiState {
     }
 
     // ========================================================================
+    // Export Methods
+    // ========================================================================
+
+    /// Exports the currently viewed iteration buffer to `.ralph/tui-exports`.
+    pub fn export_current_iteration_to_disk(&mut self) -> bool {
+        let result = self
+            .current_export_buffer()
+            .ok_or_else(|| anyhow::anyhow!("no current iteration buffer to export"))
+            .and_then(IterationExport::from_buffer)
+            .and_then(|snapshot| {
+                crate::export::write_export(
+                    &self.export_workspace_root,
+                    ExportScope::Current,
+                    &[snapshot],
+                )
+            });
+
+        self.record_export_result(ExportScope::Current, result)
+    }
+
+    /// Exports all in-memory iteration buffers to `.ralph/tui-exports`.
+    pub fn export_all_iterations_to_disk(&mut self) -> bool {
+        let result = self.all_export_snapshots().and_then(|snapshots| {
+            crate::export::write_export(&self.export_workspace_root, ExportScope::All, &snapshots)
+        });
+
+        self.record_export_result(ExportScope::All, result)
+    }
+
+    fn current_export_buffer(&self) -> Option<&IterationBuffer> {
+        if self.wave_view_active {
+            self.current_wave_worker_buffer()
+        } else {
+            self.current_iteration()
+        }
+    }
+
+    fn all_export_snapshots(&self) -> anyhow::Result<Vec<IterationExport>> {
+        let mut snapshots = Vec::new();
+        for iteration in &self.iterations {
+            snapshots.push(IterationExport::from_buffer(iteration)?);
+            if let Some(wave) = &iteration.wave_info {
+                for worker in &wave.worker_buffers {
+                    snapshots.push(IterationExport::from_buffer(worker)?);
+                }
+            }
+        }
+
+        if let Some(wave) = &self.wave_active {
+            for worker in &wave.worker_buffers {
+                snapshots.push(IterationExport::from_buffer(worker)?);
+            }
+        }
+
+        Ok(snapshots)
+    }
+
+    fn record_export_result(
+        &mut self,
+        scope: ExportScope,
+        result: anyhow::Result<PathBuf>,
+    ) -> bool {
+        let ok = result.is_ok();
+        let outcome = match result {
+            Ok(path) => ExportOutcome::Success { path },
+            Err(error) => ExportOutcome::Failed {
+                message: error.to_string(),
+            },
+        };
+
+        self.export_flash = Some(ExportFlash {
+            scope,
+            outcome,
+            when: Instant::now(),
+        });
+        ok
+    }
+
+    /// Clears export flash if it has expired.
+    pub fn clear_expired_export_flash(&mut self) {
+        if let Some(flash) = &self.export_flash
+            && flash.when.elapsed() >= Duration::from_secs(4)
+        {
+            self.export_flash = None;
+        }
+    }
+
+    /// Returns active export flash if still within the display window.
+    pub fn active_export_flash(&self) -> Option<&ExportFlash> {
+        self.export_flash
+            .as_ref()
+            .filter(|flash| flash.when.elapsed() < Duration::from_secs(4))
+    }
+
+    // ========================================================================
     // Guidance Methods
     // ========================================================================
 
@@ -1183,6 +1327,24 @@ impl IterationBuffer {
     }
 }
 
+fn default_export_workspace_root() -> PathBuf {
+    if let Some(root) = std::env::var_os("RALPH_WORKSPACE_ROOT") {
+        return PathBuf::from(root);
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    discover_workspace_root(&cwd).unwrap_or(cwd)
+}
+
+fn discover_workspace_root(start: &Path) -> Option<PathBuf> {
+    for candidate in start.ancestors() {
+        if candidate.join(".ralph").is_dir() {
+            return Some(candidate.to_path_buf());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1523,6 +1685,74 @@ mod tests {
         assert_eq!(state.iteration, 1);
         assert_eq!(state.prev_iteration, 0);
         assert!(state.iteration_changed(), "should detect iteration change");
+    }
+
+    #[test]
+    fn discover_workspace_root_finds_ancestor_ralph_dir() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let workspace = temp_dir.path().join("workspace");
+        let nested = workspace.join("src/module");
+        std::fs::create_dir_all(workspace.join(".ralph")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(discover_workspace_root(&nested), Some(workspace));
+    }
+
+    #[test]
+    fn export_current_uses_visible_wave_worker_buffer() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut state = TuiState::new();
+        state.set_export_workspace_root(temp_dir.path());
+        state.start_new_iteration();
+        state
+            .current_iteration_mut()
+            .unwrap()
+            .append_line(ratatui::text::Line::raw("main iteration output"));
+
+        let mut wave = WaveInfo::new("Reviewer".to_string(), 2);
+        wave.worker_buffers[1].append_line(ratatui::text::Line::raw("visible worker output"));
+        state.wave_active = Some(wave);
+        state.wave_active_iteration_idx = Some(0);
+        state.enter_wave_view();
+        state.wave_view_index = 1;
+
+        assert!(state.export_current_iteration_to_disk());
+        let text = only_export_text(temp_dir.path());
+        assert!(text.contains("visible worker output"));
+        assert!(!text.contains("main iteration output"));
+    }
+
+    #[test]
+    fn export_all_includes_wave_worker_buffers() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut state = TuiState::new();
+        state.set_export_workspace_root(temp_dir.path());
+        state.start_new_iteration();
+        state
+            .current_iteration_mut()
+            .unwrap()
+            .append_line(ratatui::text::Line::raw("main iteration output"));
+
+        let mut wave = WaveInfo::new("Reviewer".to_string(), 1);
+        wave.worker_buffers[0].append_line(ratatui::text::Line::raw("worker output"));
+        state.wave_active = Some(wave);
+        state.wave_active_iteration_idx = Some(0);
+
+        assert!(state.export_all_iterations_to_disk());
+        let text = only_export_text(temp_dir.path());
+        assert!(text.contains("Iterations: 2"));
+        assert!(text.contains("main iteration output"));
+        assert!(text.contains("worker output"));
+    }
+
+    fn only_export_text(workspace_root: &Path) -> String {
+        let dir = crate::export::export_dir(workspace_root);
+        let entries = std::fs::read_dir(&dir)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        std::fs::read_to_string(entries[0].path()).unwrap()
     }
 
     #[test]

--- a/crates/ralph-tui/src/widgets/footer.rs
+++ b/crates/ralph-tui/src/widgets/footer.rs
@@ -1,4 +1,4 @@
-use crate::state::TuiState;
+use crate::state::{ExportOutcome, TuiState};
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Color, Style},
@@ -54,6 +54,31 @@ impl Widget for Footer<'_> {
                 }
                 // Shouldn't happen, but degrade gracefully
                 _ => ("\u{2717} failed to send guidance", Color::Red),
+            };
+
+            let line = Line::from(vec![
+                Span::raw(" "),
+                Span::styled(msg, Style::default().fg(color)),
+            ]);
+            Paragraph::new(line).render(inner_area, buf);
+            return;
+        }
+
+        // Export flash (brief after writing iteration buffers)
+        if let Some(flash) = self.state.active_export_flash() {
+            let (msg, color) = match &flash.outcome {
+                ExportOutcome::Success { path } => (
+                    format!(
+                        "\u{2713} exported {}: {}",
+                        flash.scope.label(),
+                        self.state.display_export_path(path)
+                    ),
+                    Color::Green,
+                ),
+                ExportOutcome::Failed { message } => (
+                    format!("\u{2717} export {} failed: {message}", flash.scope.label()),
+                    Color::Red,
+                ),
             };
 
             let line = Line::from(vec![
@@ -129,6 +154,13 @@ impl Widget for Footer<'_> {
             "Total Time Elapsed: 00:00".to_string()
         };
         left_spans.push(Span::raw(elapsed_display));
+        if inner_area.width >= 58 {
+            left_spans.push(Span::raw(" │ "));
+            left_spans.push(Span::styled(
+                "e export E all",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
         if self.state.mouse_capture_enabled {
             left_spans.push(Span::raw(" │ "));
             left_spans.push(Span::styled(
@@ -376,6 +408,64 @@ mod tests {
             scroll_text.contains("Mouse: scroll (m)"),
             "should show scroll mode when mouse capture enabled, got: {}",
             scroll_text
+        );
+    }
+
+    #[test]
+    fn footer_shows_export_key_hint() {
+        let state = TuiState::new();
+        let text = render_to_string(&state);
+
+        assert!(
+            text.contains("e export E all"),
+            "should show export key hint, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn footer_shows_export_success_flash() {
+        let mut state = TuiState::new();
+        state.set_export_workspace_root("/tmp/workspace");
+        state.export_flash = Some(crate::state::ExportFlash {
+            scope: crate::export::ExportScope::Current,
+            outcome: ExportOutcome::Success {
+                path: "/tmp/workspace/.ralph/tui-exports/ralph-tui-current.txt".into(),
+            },
+            when: std::time::Instant::now(),
+        });
+
+        let text = render_to_string(&state);
+
+        assert!(
+            text.contains("exported current iteration"),
+            "should show export success, got: {}",
+            text
+        );
+        assert!(
+            text.contains(".ralph/tui-exports/ralph-tui-current.txt"),
+            "should show relative export path, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn footer_shows_export_failure_flash() {
+        let mut state = TuiState::new();
+        state.export_flash = Some(crate::state::ExportFlash {
+            scope: crate::export::ExportScope::All,
+            outcome: ExportOutcome::Failed {
+                message: "permission denied".to_string(),
+            },
+            when: std::time::Instant::now(),
+        });
+
+        let text = render_to_string(&state);
+
+        assert!(
+            text.contains("export all iterations failed: permission denied"),
+            "should show export failure, got: {}",
+            text
         );
     }
 }

--- a/crates/ralph-tui/src/widgets/help.rs
+++ b/crates/ralph-tui/src/widgets/help.rs
@@ -64,6 +64,16 @@ pub fn render(f: &mut Frame, area: Rect) {
             Span::raw("    Next/prev match"),
         ]),
         Line::from(""),
+        Line::from(Span::styled("Export:", Style::default().fg(Color::Yellow))),
+        Line::from(vec![
+            Span::styled("  e", Style::default().fg(Color::Cyan)),
+            Span::raw("      Export current iteration"),
+        ]),
+        Line::from(vec![
+            Span::styled("  E", Style::default().fg(Color::Cyan)),
+            Span::raw("      Export all iterations"),
+        ]),
+        Line::from(""),
         Line::from(Span::styled(
             "Guidance:",
             Style::default().fg(Color::Yellow),
@@ -118,7 +128,7 @@ pub fn render(f: &mut Frame, area: Rect) {
         .block(block)
         .alignment(Alignment::Left);
 
-    let popup_area = centered_rect(50, 60, area);
+    let popup_area = centered_rect(50, 75, area);
     f.render_widget(Clear, popup_area);
     f.render_widget(paragraph, popup_area);
 }

--- a/crates/ralph-tui/tests/snapshots/integration_snapshots__footer_iter2.snap
+++ b/crates/ralph-tui/tests/snapshots/integration_snapshots__footer_iter2.snap
@@ -2,4 +2,4 @@
 source: crates/ralph-tui/tests/integration_snapshots.rs
 expression: harness.render_footer()
 ---
-──────────────────────────────────────────────────────────────────────────────── Total Time Elapsed: 00:00                                          ◉ ACTIVE
+──────────────────────────────────────────────────────────────────────────────── Total Time Elapsed: 00:00 │ e export E all                         ◉ ACTIVE

--- a/crates/ralph-tui/tests/snapshots/integration_snapshots__footer_with_alert.snap
+++ b/crates/ralph-tui/tests/snapshots/integration_snapshots__footer_with_alert.snap
@@ -2,4 +2,4 @@
 source: crates/ralph-tui/tests/integration_snapshots.rs
 expression: harness.render_footer()
 ---
-──────────────────────────────────────────────────────────────────────────────── ▶ New: iter 3 │ Total Time Elapsed: 00:00                          ◉ ACTIVE
+──────────────────────────────────────────────────────────────────────────────── ▶ New: iter 3 │ Total Time Elapsed: 00:00 │ e export E all         ◉ ACTIVE

--- a/crates/ralph-tui/tests/snapshots/integration_snapshots__full_layout_60col.snap
+++ b/crates/ralph-tui/tests/snapshots/integration_snapshots__full_layout_60col.snap
@@ -11,4 +11,4 @@ Content line 4
 Content line 5
 
 ────────────────────────────────────────────────────────────
- Total Time Elapsed: [TIME]                      ◉ ACTIVE
+ Total Time Elapsed: [TIME] │ e export E all     ◉ ACTIVE

--- a/crates/ralph-tui/tests/snapshots/integration_snapshots__full_layout_80col.snap
+++ b/crates/ralph-tui/tests/snapshots/integration_snapshots__full_layout_80col.snap
@@ -11,4 +11,4 @@ Content line 4
 Content line 5
 
 ────────────────────────────────────────────────────────────────────────────────
- Total Time Elapsed: [TIME]                                          ◉ ACTIVE
+ Total Time Elapsed: [TIME] │ e export E all                         ◉ ACTIVE

--- a/crates/ralph-tui/tests/snapshots/integration_snapshots__long_output_scrolled.snap
+++ b/crates/ralph-tui/tests/snapshots/integration_snapshots__long_output_scrolled.snap
@@ -11,4 +11,4 @@ HTTP Status line 5
 HTTP Status line 6
 HTTP Status line 7
 ────────────────────────────────────────────────────────────────────────────────
- Total Time Elapsed: [TIME]                                            ■ DONE
+ Total Time Elapsed: [TIME] │ e export E all                           ■ DONE

--- a/crates/ralph-tui/tests/snapshots/integration_snapshots__long_output_top.snap
+++ b/crates/ralph-tui/tests/snapshots/integration_snapshots__long_output_top.snap
@@ -11,4 +11,4 @@ HTTP Status line 4
 HTTP Status line 5
 HTTP Status line 6
 ────────────────────────────────────────────────────────────────────────────────
- Total Time Elapsed: [TIME]                                            ■ DONE
+ Total Time Elapsed: [TIME] │ e export E all                           ■ DONE


### PR DESCRIPTION
Closes #189.

## Summary
- Add `e` to export the current viewed iteration buffer and `E` to export all iteration buffers.
- Write plain-text artifacts under `.ralph/tui-exports/` with collision-safe timestamped filenames and per-iteration headers.
- Show export success/failure feedback in the TUI footer and update footer/help key hints.
- Resolve the export root from `RALPH_WORKSPACE_ROOT`, nearest ancestor `.ralph`, or current directory fallback.

## Verification
- `cargo fmt -p ralph-tui -- --check`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-tui export -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-tui discover_workspace_root -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-tui`
- Worker preflight: `CARGO_INCREMENTAL=0 cargo test` passed before the post-review export-root amend.

## Notes
Manual tmux/TUI smoke will be run before final merge per the backlog-zero plan.