### PR TITLE
fix: canonicalize Ralph committed artifact paths

### DIFF
--- a/.claude/agents/code-assist.md
+++ b/.claude/agents/code-assist.md
@@ -1,6 +1,6 @@
 ---
 name: code-assist
-description: "Use this agent when implementing code tasks from task files, working through structured implementation plans, or executing code changes that follow the spec-to-implementation workflow. This agent follows the code-assist SOP for systematic, high-quality code delivery.\\n\\nExamples:\\n\\n<example>\\nContext: User wants to implement a feature described in a task file.\\nuser: \"Please implement the task in tasks/add-user-auth.code-task.md\"\\nassistant: \"I'll use the code-assist agent to implement this task following the structured SOP.\"\\n<Task tool invocation to launch code-assist agent>\\n</example>\\n\\n<example>\\nContext: User has a code task file and wants systematic implementation.\\nuser: \"Run /code-assist tasks/refactor-database-layer.code-task.md\"\\nassistant: \"Let me launch the code-assist agent to work through this task systematically.\"\\n<Task tool invocation to launch code-assist agent>\\n</example>\\n\\n<example>\\nContext: User wants to implement something from an approved spec.\\nuser: \"The spec in specs/api-redesign.md is approved, please implement it\"\\nassistant: \"I'll use the code-assist agent to implement this spec following the proper workflow.\"\\n<Task tool invocation to launch code-assist agent>\\n</example>"
+description: "Use this agent when implementing code tasks from task files, working through structured implementation plans, or executing code changes that follow the spec-to-implementation workflow. This agent follows the code-assist SOP for systematic, high-quality code delivery.\\n\\nExamples:\\n\\n<example>\\nContext: User wants to implement a feature described in a task file.\\nuser: \"Please implement the task in .ralph/tasks/add-user-auth.code-task.md\"\\nassistant: \"I'll use the code-assist agent to implement this task following the structured SOP.\"\\n<Task tool invocation to launch code-assist agent>\\n</example>\\n\\n<example>\\nContext: User has a code task file and wants systematic implementation.\\nuser: \"Run /code-assist .ralph/tasks/refactor-database-layer.code-task.md\"\\nassistant: \"Let me launch the code-assist agent to work through this task systematically.\"\\n<Task tool invocation to launch code-assist agent>\\n</example>\\n\\n<example>\\nContext: User wants to implement something from an approved spec.\\nuser: \"The spec in .ralph/specs/api-redesign.md is approved, please implement it\"\\nassistant: \"I'll use the code-assist agent to implement this spec following the proper workflow.\"\\n<Task tool invocation to launch code-assist agent>\\n</example>"
 model: opus
 ---
 
@@ -18,7 +18,7 @@ You embody these principles:
 
 ### Phase 1: Orientation
 1. Read the task file completely (if provided)
-2. Read any referenced specs in `specs/`
+2. Read any referenced specs in `.ralph/specs/`
 3. Read `IMPLEMENTATION_PLAN.md` if it exists
 4. Explore the relevant codebase areas to understand existing patterns
 5. Identify acceptance criteria and success metrics

--- a/.claude/skills/code-task-generator/SKILL.md
+++ b/.claude/skills/code-task-generator/SKILL.md
@@ -25,7 +25,7 @@ These rules apply across ALL steps:
 
 - **input** (required): Task description, file path, or PDD plan path
 - **step_number** (optional, PDD only): Specific step to process. Auto-determines next uncompleted step if omitted.
-- **output_dir** (optional, default: `specs/{task_name}/tasks/`): Output directory for code task files
+- **output_dir** (optional, default: `.ralph/tasks/`): Output directory for code task files
 - **task_name** (optional, description mode only): Override auto-generated task name
 
 **Constraints:**
@@ -62,7 +62,7 @@ Present the proposed breakdown to the user:
 Create files following the Code Task Format below.
 
 **PDD mode specifics:**
-- Create `step{NN}/` folder (zero-padded: step01, step02, step10)
+- Create `.ralph/tasks/{task_name}/step{NN}/` folder by default (zero-padded: step01, step02, step10)
 - Name files sequentially: `task-01-{title}.code-task.md`, `task-02-{title}.code-task.md`
 - Break down by functional components, not testing phases
 
@@ -105,7 +105,7 @@ completed: null
 
 ## Reference Documentation
 **Required:**
-- Design: specs/{task_name}/design.md
+- Design: .ralph/specs/{task_name}/design.md
 
 **Additional References (if relevant to this task):**
 - [Specific research document or section]
@@ -139,11 +139,11 @@ completed: null
 
 **Description mode input:** `"I need a function that validates email addresses and returns detailed error messages"`
 
-**Description mode output:** `specs/email-validator/tasks/email-validator.code-task.md` — task with acceptance criteria for valid/invalid email handling, error messages, and unit tests.
+**Description mode output:** `.ralph/tasks/email-validator.code-task.md` — task with acceptance criteria for valid/invalid email handling, error messages, and unit tests.
 
-**PDD mode input:** `"specs/data-pipeline/plan.md"`
+**PDD mode input:** `".ralph/specs/data-pipeline/plan.md"`
 
-**PDD mode output:** `specs/data-pipeline/tasks/step02/` containing `task-01-create-data-models.code-task.md`, `task-02-implement-validation.code-task.md`, `task-03-add-serialization.code-task.md` — each with design.md reference, acceptance criteria, and demo requirements.
+**PDD mode output:** `.ralph/tasks/data-pipeline/step02/` containing `task-01-create-data-models.code-task.md`, `task-02-implement-validation.code-task.md`, `task-03-add-serialization.code-task.md` — each with design.md reference, acceptance criteria, and demo requirements.
 
 ## Troubleshooting
 

--- a/.claude/skills/evaluate-presets/SKILL.md
+++ b/.claude/skills/evaluate-presets/SKILL.md
@@ -209,7 +209,7 @@ For each issue, spawn a Task agent:
 
 ```
 "Use /code-task-generator to create a task for fixing: [issue from evaluation]
-Output to: tasks/preset-fixes/"
+Output to: .ralph/tasks/preset-fixes/"
 ```
 
 ### Step 3: Dispatch Implementation
@@ -217,7 +217,7 @@ Output to: tasks/preset-fixes/"
 For each created task:
 
 ```
-"Use /code-assist to implement: tasks/preset-fixes/[task-file].code-task.md
+"Use /code-assist to implement: .ralph/tasks/preset-fixes/[task-file].code-task.md
 Mode: auto"
 ```
 

--- a/.claude/skills/find-code-tasks/task-status.sh
+++ b/.claude/skills/find-code-tasks/task-status.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-TASKS_DIR="${TASKS_DIR:-tasks}"
+TASKS_DIR="${TASKS_DIR:-.ralph/tasks}"
 FORMAT="table"
 FILTER_STATUS=""
 

--- a/.gitignore
+++ b/.gitignore
@@ -104,17 +104,21 @@ PROMPT.md
 .tmp-ralph-claude-code
 
 # Ralph orchestrator state
-# All state now consolidated under .ralph/
-.ralph/
+# Keep runtime state ignored while allowing committed text artifacts.
+.ralph/*
 
 # Track git-friendly content (negations must follow the ignore)
 !.ralph/specs/
 !.ralph/specs/**
 !.ralph/tasks/
-!.ralph/tasks/**
+.ralph/tasks/**
+!.ralph/tasks/**/
+!.ralph/tasks/*.code-task.md
+!.ralph/tasks/**/*.code-task.md
 !.ralph/agent/
+.ralph/agent/*
+!.ralph/agent/decisions.md
 !.ralph/agent/memories.md
-!.ralph/agent/tasks.jsonl
 
 # Codex local state
 .codex/

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ ralph init --backend claude
 
 # 2. Plan your feature (interactive PDD session)
 ralph plan "Add user authentication with JWT"
-# Creates: specs/user-authentication/requirements.md, design.md, implementation-plan.md
+# Creates: .ralph/specs/user-authentication/requirements.md, design.md, implementation-plan.md
 
 # 3. Implement the feature
-ralph run -p "Implement the feature in specs/user-authentication/"
+ralph run -p "Implement the feature in .ralph/specs/user-authentication/"
 ```
 
 Ralph iterates until it outputs `LOOP_COMPLETE` or hits the iteration limit.
@@ -213,7 +213,7 @@ Homebrew is not currently published from this repository's automated release flo
 ```bash
 ralph init --backend claude
 ralph plan "Add user authentication with JWT"
-ralph run -p "Implement the feature in specs/user-authentication/"
+ralph run -p "Implement the feature in .ralph/specs/user-authentication/"
 ```
 
 **What backends does Ralph support?**

--- a/crates/ralph-cli/presets/autoresearch.yml
+++ b/crates/ralph-cli/presets/autoresearch.yml
@@ -40,7 +40,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — re-read autoresearch.md and git log every time"
     - "Primary metric is king — improved = keep, worse/equal = discard"

--- a/crates/ralph-cli/presets/code-assist.yml
+++ b/crates/ralph-cli/presets/code-assist.yml
@@ -13,7 +13,7 @@
 #
 # Usage:
 #   # From PDD output directory:
-#   ralph run --config presets/code-assist.yml --prompt ".agents/scratchpad/implementation/my-feature"
+#   ralph run --config presets/code-assist.yml --prompt ".ralph/specs/my-feature"
 #
 #   # From a single code task:
 #   ralph run --config presets/code-assist.yml --prompt ".ralph/tasks/my-task.code-task.md"
@@ -35,7 +35,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — save learnings to memories for next time"
     - "Verification is mandatory — tests/typecheck/lint/audit must pass"
@@ -59,13 +59,13 @@ hats:
       The Builder only sees one task at a time, but you decide when a whole step's wave is exhausted and when the next step should exist.
 
       ### Shared Documentation Directory
-      Use the upstream code-assist documentation layout:
-      `.agents/scratchpad/implementation/{task_name}/`
+      Use the canonical Ralph spec artifact layout:
+      `.ralph/specs/{task_name}/`
 
       Determine the working directory like this:
       - Existing implementation directory in the prompt: use that directory directly
-      - Single `.code-task.md` file: derive `task_name` and use `.agents/scratchpad/implementation/{task_name}/`
-      - Rough description: derive `task_name` and use `.agents/scratchpad/implementation/{task_name}/`
+      - Single `.code-task.md` file: derive `task_name` and use `.ralph/specs/{task_name}/`
+      - Rough description: derive `task_name` and use `.ralph/specs/{task_name}/`
 
       The working directory MUST contain or create:
       - `context.md` — implementation context, repo patterns, dependencies, acceptance criteria
@@ -222,7 +222,7 @@ hats:
       The loop also sets `$RALPH_BIN`; prefer `"$RALPH_BIN" tools ...` and `"$RALPH_BIN" emit ...` for task/event commands.
       Read the shared documentation directory for this run:
       - Existing PDD directory from the prompt, or
-      - `.agents/scratchpad/implementation/{task_name}/` for code-task / rough-description runs
+      - `.ralph/specs/{task_name}/` for code-task / rough-description runs
 
       Read in this order:
       1. the runtime task from the event payload via `ralph tools task show <task_id> --format json`
@@ -349,7 +349,7 @@ hats:
       If `spec_dir` exists, read from `{spec_dir}/`:
       - `plan.md` — High-level strategy and E2E scenario
       - `design.md` — Requirements to validate against
-      - `tasks/*.code-task.md` — Understand task boundaries when present
+      - `.ralph/tasks/{task_name}/**/*.code-task.md` — Understand task boundaries, including PDD step subdirectories, when present
 
       ### Review Checklist
 
@@ -445,7 +445,7 @@ hats:
       ### Shared Documentation Directory
       Use the same shared docs directory as Planner and Builder:
       - existing implementation directory from the prompt, or
-      - `.agents/scratchpad/implementation/{task_name}/`
+      - `.ralph/specs/{task_name}/`
 
       Read `context.md`, `plan.md`, `progress.md`, and `logs/` from that shared docs directory.
       The implementation target under `.eval-sandbox/` is the runnable artifact area, not the location of `plan.md` or `progress.md`.
@@ -455,7 +455,7 @@ hats:
       Use the strongest source of truth available:
 
       **If operating from a PDD directory**
-      - Check every `*.code-task.md` file in `tasks/`
+      - Check every `.code-task.md` file under `.ralph/tasks/{task_name}/` recursively
       - If any remain `pending` or `in_progress`, close or reopen the reviewed runtime task as needed, then publish `queue.advance`
       - If all are completed, confirm the design, plan, and prompt are actually satisfied end-to-end
 

--- a/crates/ralph-cli/presets/debug.yml
+++ b/crates/ralph-cli/presets/debug.yml
@@ -18,7 +18,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   investigator:

--- a/crates/ralph-cli/presets/hatless-baseline.yml
+++ b/crates/ralph-cli/presets/hatless-baseline.yml
@@ -20,7 +20,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
 
 # NO HATS - Ralph works directly without delegation
 # This is intentional for baseline testing

--- a/crates/ralph-cli/presets/merge-loop.yml
+++ b/crates/ralph-cli/presets/merge-loop.yml
@@ -35,7 +35,7 @@ cli:
   backend: "auto"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   merger:

--- a/crates/ralph-cli/presets/minimal/amp.yml
+++ b/crates/ralph-cli/presets/minimal/amp.yml
@@ -19,7 +19,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/builder.yml
+++ b/crates/ralph-cli/presets/minimal/builder.yml
@@ -22,7 +22,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/claude.yml
+++ b/crates/ralph-cli/presets/minimal/claude.yml
@@ -15,7 +15,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/code-assist.yml
+++ b/crates/ralph-cli/presets/minimal/code-assist.yml
@@ -16,7 +16,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/codex.yml
+++ b/crates/ralph-cli/presets/minimal/codex.yml
@@ -19,7 +19,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/gemini.yml
+++ b/crates/ralph-cli/presets/minimal/gemini.yml
@@ -19,7 +19,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/kiro.yml
+++ b/crates/ralph-cli/presets/minimal/kiro.yml
@@ -18,7 +18,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/opencode.yml
+++ b/crates/ralph-cli/presets/minimal/opencode.yml
@@ -29,7 +29,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/preset-evaluator.yml
+++ b/crates/ralph-cli/presets/minimal/preset-evaluator.yml
@@ -21,7 +21,7 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Document ALL findings - both successes and failures"
     - "Be specific about error messages and stack traces"

--- a/crates/ralph-cli/presets/minimal/smoke.yml
+++ b/crates/ralph-cli/presets/minimal/smoke.yml
@@ -18,7 +18,7 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/crates/ralph-cli/presets/minimal/test.yml
+++ b/crates/ralph-cli/presets/minimal/test.yml
@@ -17,7 +17,7 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document in .ralph/agent/decisions.md; <50 choose safe default + document."

--- a/crates/ralph-cli/presets/pdd-to-code-assist.yml
+++ b/crates/ralph-cli/presets/pdd-to-code-assist.yml
@@ -36,7 +36,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — save learnings to memories for next time"
     - "Verification is mandatory — tests/typecheck/lint/audit must pass"
@@ -63,16 +63,16 @@ hats:
       ### Storage Layout
       On first trigger (design.start), establish the spec identity:
       1. Derive `spec_name` from the auto-injected objective (kebab-case, e.g., "add-user-auth")
-      2. Create `.agents/scratchpad/implementation/{spec_name}/` directory using the same per-spec implementation layout as upstream code-assist
-      3. Write the objective to `.agents/scratchpad/implementation/{spec_name}/rough-idea.md`
-      4. Create or append to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
+      2. Create `.ralph/specs/{spec_name}/` using the canonical Ralph spec artifact layout
+      3. Write the objective to `.ralph/specs/{spec_name}/rough-idea.md`
+      4. Create or append to `.ralph/specs/{spec_name}/idea-honing.md`
       5. Ensure and start the requirements phase runtime task with a stable key like `pdd:{spec_name}:requirements`
 
       ### Process
       1. Review context and previous Q&A
       2. Identify the most critical gap or ambiguity
       3. Ask ONE specific, answerable question
-      4. Record your question in `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
+      4. Record your question in `.ralph/specs/{spec_name}/idea-honing.md`
 
       ### Question Types (use strategically)
       - Scope: "What is explicitly OUT of scope?"
@@ -118,7 +118,7 @@ hats:
       then synthesize everything into a comprehensive design document.
 
       ### Storage Layout
-      Store design and implementation artifacts in `.agents/scratchpad/implementation/{spec_name}/`:
+      Store design and implementation artifacts in `.ralph/specs/{spec_name}/`:
       - `rough-idea.md` — Original prompt/idea
       - `idea-honing.md` — Question/answer transcript from idea honing
       - `requirements.md` — Consolidated requirements and assumptions
@@ -129,7 +129,7 @@ hats:
       2. Read the question carefully
       3. Research if needed (explore codebase, check patterns)
       4. Provide a clear, specific answer
-      5. Append the answer to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
+      5. Append the answer to `.ralph/specs/{spec_name}/idea-honing.md`
       6. Publish `answer.proposed` with the active `task_id` and `task_key`
 
       ### When Triggered by requirements.complete
@@ -137,11 +137,11 @@ hats:
 
       1. Close the requirements-answering task if it is complete.
       2. Ensure and start the design-drafting runtime task with a stable key like `pdd:{spec_name}:design-draft`
-      3. Read `.agents/scratchpad/implementation/{spec_name}/rough-idea.md` and `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
-      4. Write consolidated requirements to `.agents/scratchpad/implementation/{spec_name}/requirements.md`
-      5. Then write the full design to `.agents/scratchpad/implementation/{spec_name}/design.md`
+      3. Read `.ralph/specs/{spec_name}/rough-idea.md` and `.ralph/specs/{spec_name}/idea-honing.md`
+      4. Write consolidated requirements to `.ralph/specs/{spec_name}/requirements.md`
+      5. Then write the full design to `.ralph/specs/{spec_name}/design.md`
 
-      Design Document Structure (write to `.agents/scratchpad/implementation/{spec_name}/design.md`):
+      Design Document Structure (write to `.ralph/specs/{spec_name}/design.md`):
       1. **Overview** — Problem statement and solution summary
       2. **Detailed Requirements** — Consolidated from Q&A, each requirement numbered
       3. **Architecture Overview** — High-level system design with Mermaid diagram (REQUIRED)
@@ -189,7 +189,7 @@ hats:
       A weak design that slips through costs far more to fix in code.
 
       ### Storage Layout
-      Read design artifacts from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read design artifacts from `.ralph/specs/{spec_name}/`:
       - `idea-honing.md` — Raw question/answer transcript
       - `design.md` — The design document to review
       - `requirements.md` — Requirements to validate against
@@ -253,17 +253,17 @@ hats:
       Find existing patterns, identify integration points, surface constraints.
 
       ### Storage Layout
-      Read design artifacts from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read design artifacts from `.ralph/specs/{spec_name}/`:
       - `design.md` — The detailed design to implement
       - `requirements.md` — The consolidated requirements
 
-      Write research findings to `.agents/scratchpad/implementation/{spec_name}/research/`:
+      Write research findings to `.ralph/specs/{spec_name}/research/`:
       - `existing-patterns.md` — Similar features and coding conventions found
       - `technologies.md` — Libraries, frameworks, dependencies available
       - `broken-windows.md` — Low-risk code smells in touched files
       - Additional topic-specific files as needed
 
-      Write implementation context to `.agents/scratchpad/implementation/{spec_name}/context.md`:
+      Write implementation context to `.ralph/specs/{spec_name}/context.md`:
       - Summary of research findings
       - Integration points and dependencies
       - Constraints and considerations
@@ -315,7 +315,7 @@ hats:
       - Performance optimizations requiring benchmarks
       - Anything requiring new tests to validate
 
-      Write findings to `.agents/scratchpad/implementation/{spec_name}/research/broken-windows.md`:
+      Write findings to `.ralph/specs/{spec_name}/research/broken-windows.md`:
       ```markdown
       ## Broken Windows
 
@@ -355,11 +355,11 @@ hats:
       TDD means tests come first — plan them thoroughly.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `design.md` — The approved design
       - `context.md` — Codebase patterns and integration points
 
-      Write the upstream code-assist implementation plan artifact to `.agents/scratchpad/implementation/{spec_name}/plan.md`:
+      Write the upstream code-assist implementation plan artifact to `.ralph/specs/{spec_name}/plan.md`:
       - Test strategy (unit, integration, E2E scenarios)
       - Numbered implementation steps in TDD order
       - Success criteria and demo outcome for each step
@@ -436,20 +436,20 @@ hats:
 
       You convert the implementation plan into discrete, well-structured code task files.
       Then you materialize ONLY the current numbered step's runtime-task wave.
-      The code task files are the spec artifacts; runtime tasks are the live queue.
+      The code task files are the task artifacts; runtime tasks are the live queue.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `plan.md` — Implementation steps and test strategy
       - `design.md` — Architecture and component details
       - `context.md` — Codebase patterns to follow
 
-      Write code task files to `.agents/scratchpad/implementation/{spec_name}/tasks/`:
+      Write code task files to `.ralph/tasks/{spec_name}/`:
       - `task-01-{kebab-case-title}.code-task.md`
       - `task-02-{kebab-case-title}.code-task.md`
       - etc.
 
-      Create the `tasks/` subdirectory if it doesn't exist.
+      Create `.ralph/tasks/{spec_name}/` if it doesn't exist.
 
       ### Code Task File Format
       Each task file MUST follow this exact structure:
@@ -471,11 +471,11 @@ hats:
 
       ## Reference Documentation
       **Required:**
-      - Design: .agents/scratchpad/implementation/{spec_name}/design.md
+      - Design: .ralph/specs/{spec_name}/design.md
 
       **Additional References:**
-      - .agents/scratchpad/implementation/{spec_name}/context.md (codebase patterns)
-      - .agents/scratchpad/implementation/{spec_name}/plan.md (overall strategy)
+      - .ralph/specs/{spec_name}/context.md (codebase patterns)
+      - .ralph/specs/{spec_name}/plan.md (overall strategy)
 
       **Note:** You MUST read the design document before beginning implementation.
 
@@ -511,15 +511,15 @@ hats:
 
       ### Process On `plan.ready`
       1. Ensure and start the task-writing runtime task with a stable key like `pdd:{spec_name}:task-writing`
-      2. Read the implementation plan from `.agents/scratchpad/implementation/{spec_name}/plan.md`
+      2. Read the implementation plan from `.ralph/specs/{spec_name}/plan.md`
       3. For each numbered step in the plan, create a code task file
       4. Extract acceptance criteria from the plan and convert to Given-When-Then format
       5. Include unit test requirements in each task (not as separate tasks)
       6. Ensure tasks are sequenced correctly with dependencies noted
-      7. Write all task files to `.agents/scratchpad/implementation/{spec_name}/tasks/`
+      7. Write all task files to `.ralph/tasks/{spec_name}/`
       8. Select Step 1 as the current implementation step
       9. Mirror ONLY Step 1's code task files into runtime tasks with stable keys like `pdd:{spec_name}:step-01:{task_slug}`
-      10. Record the current step and active wave in `.agents/scratchpad/implementation/{spec_name}/progress.md`
+      10. Record the current step and active wave in `.ralph/specs/{spec_name}/progress.md`
       11. Close the task-writing phase task
       12. Publish `tasks.ready` for exactly one Step 1 runtime task with:
           - the mirrored runtime `task_id`
@@ -564,19 +564,19 @@ hats:
       You do NOT decide overall completion. You hand each finished task to the Critic.
 
       ### Storage Layout
-      Read code task files from `.agents/scratchpad/implementation/{spec_name}/tasks/`:
+      Read code task files from `.ralph/tasks/{spec_name}/`:
       - `task-01-*.code-task.md`, `task-02-*.code-task.md`, etc.
 
       Also reference:
-      - `.agents/scratchpad/implementation/{spec_name}/design.md` — Architecture and component details
-      - `.agents/scratchpad/implementation/{spec_name}/context.md` — Codebase patterns to follow
+      - `.ralph/specs/{spec_name}/design.md` — Architecture and component details
+      - `.ralph/specs/{spec_name}/context.md` — Codebase patterns to follow
 
-      Track evidence in `.agents/scratchpad/implementation/{spec_name}/progress.md`:
+      Track evidence in `.ralph/specs/{spec_name}/progress.md`:
       - TDD cycle documentation (RED → GREEN → REFACTOR)
       - Build output summaries
       - Verification notes for the active runtime task
 
-      Save build/test logs to `.agents/scratchpad/implementation/{spec_name}/logs/`:
+      Save build/test logs to `.ralph/specs/{spec_name}/logs/`:
       - `build.log` — Latest build output
       - `test.log` — Latest test output
       Create the `logs/` directory if it doesn't exist.
@@ -651,7 +651,7 @@ hats:
       Refactor to align if any items fail. Code should not look "foreign" to the codebase.
 
       ### Broken Windows (Optional)
-      Check `.agents/scratchpad/implementation/{spec_name}/research/broken-windows.md` for low-risk fixes.
+      Check `.ralph/specs/{spec_name}/research/broken-windows.md` for low-risk fixes.
       During refactor, you MAY fix broken windows in files you're already touching:
       - Only fix issues in files modified by this task
       - Only fix if truly low-risk (no behavior change)
@@ -746,7 +746,7 @@ hats:
       ### What To Read
       - the reviewed `task_id`, `task_key`, and task path from the `review.passed` payload
       - the reviewed runtime task via `ralph tools task show <task_id> --format json`
-      - all `.agents/scratchpad/implementation/{spec_name}/tasks/*.code-task.md` files
+      - all `.ralph/tasks/{spec_name}/*.code-task.md` files
       - `design.md`, `plan.md`, and `progress.md` when needed to resolve ambiguity
 
       ### Decision Process
@@ -787,13 +787,13 @@ hats:
       Be thorough, be skeptical, verify everything yourself.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `plan.md` — E2E test scenario to execute manually
       - `design.md` — Requirements to validate against
       - `progress.md` — Build and verification evidence
-      - `tasks/*.code-task.md` — All task files (verify all have `status: completed`)
+      - `.ralph/tasks/{spec_name}/*.code-task.md` — All task files (verify all have `status: completed`)
 
-      Write validation results to `.agents/scratchpad/implementation/{spec_name}/validation.md`:
+      Write validation results to `.ralph/specs/{spec_name}/validation.md`:
       - Task completion verification (all tasks must be `status: completed`)
       - Test suite results
       - Build/lint verification
@@ -803,7 +803,7 @@ hats:
       ### Validation Checklist
 
       **0. All Code Tasks Complete**
-      Check every `*.code-task.md` file in `.agents/scratchpad/implementation/{spec_name}/tasks/`:
+      Check every `*.code-task.md` file in `.ralph/tasks/{spec_name}/`:
       - All must have `status: completed` in frontmatter
       - All must have valid `completed: YYYY-MM-DD` dates
       FAIL if any task is not marked completed.
@@ -911,10 +911,10 @@ hats:
       Follow conventional commit format and document the implementation.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `design.md` — For commit message context
       - `validation.md` — Confirmation of passing validation
-      - `tasks/*.code-task.md` — Update all to `status: completed`
+      - `.ralph/tasks/{spec_name}/*.code-task.md` — Update all to `status: completed`
 
       Ensure and start the commit runtime task with a stable key like `pdd:{spec_name}:commit`.
 
@@ -953,7 +953,7 @@ hats:
       error messages for common format issues. Supports international
       domains and includes performance optimization for bulk validation.
 
-      Spec: .agents/scratchpad/implementation/email-validator/design.md
+      Spec: .ralph/specs/email-validator/design.md
       ```
 
       ### Constraints

--- a/crates/ralph-cli/presets/research.yml
+++ b/crates/ralph-cli/presets/research.yml
@@ -20,7 +20,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   researcher:

--- a/crates/ralph-cli/presets/review.yml
+++ b/crates/ralph-cli/presets/review.yml
@@ -19,7 +19,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   reviewer:

--- a/crates/ralph-cli/sops/code-task-generator.md
+++ b/crates/ralph-cli/sops/code-task-generator.md
@@ -25,7 +25,7 @@ These rules apply across ALL steps:
 
 - **input** (required): Task description, file path, or PDD plan path
 - **step_number** (optional, PDD only): Specific step to process. Auto-determines next uncompleted step if omitted.
-- **output_dir** (optional, default: `specs/{task_name}/tasks/`): Output directory for code task files
+- **output_dir** (optional, default: `.ralph/tasks/`): Output directory for code task files
 - **task_name** (optional, description mode only): Override auto-generated task name
 
 **Constraints:**
@@ -62,7 +62,7 @@ Present the proposed breakdown to the user:
 Create files following the Code Task Format below.
 
 **PDD mode specifics:**
-- Create `step{NN}/` folder (zero-padded: step01, step02, step10)
+- Create `.ralph/tasks/{task_name}/step{NN}/` folder by default (zero-padded: step01, step02, step10)
 - Name files sequentially: `task-01-{title}.code-task.md`, `task-02-{title}.code-task.md`
 - Break down by functional components, not testing phases
 
@@ -105,7 +105,7 @@ completed: null
 
 ## Reference Documentation
 **Required:**
-- Design: specs/{task_name}/design.md
+- Design: .ralph/specs/{task_name}/design.md
 
 **Additional References (if relevant to this task):**
 - [Specific research document or section]
@@ -139,11 +139,11 @@ completed: null
 
 **Description mode input:** `"I need a function that validates email addresses and returns detailed error messages"`
 
-**Description mode output:** `specs/email-validator/tasks/email-validator.code-task.md` — task with acceptance criteria for valid/invalid email handling, error messages, and unit tests.
+**Description mode output:** `.ralph/tasks/email-validator.code-task.md` — task with acceptance criteria for valid/invalid email handling, error messages, and unit tests.
 
-**PDD mode input:** `"specs/data-pipeline/plan.md"`
+**PDD mode input:** `".ralph/specs/data-pipeline/plan.md"`
 
-**PDD mode output:** `specs/data-pipeline/tasks/step02/` containing `task-01-create-data-models.code-task.md`, `task-02-implement-validation.code-task.md`, `task-03-add-serialization.code-task.md` — each with design.md reference, acceptance criteria, and demo requirements.
+**PDD mode output:** `.ralph/tasks/data-pipeline/step02/` containing `task-01-create-data-models.code-task.md`, `task-02-implement-validation.code-task.md`, `task-03-add-serialization.code-task.md` — each with design.md reference, acceptance criteria, and demo requirements.
 
 ## Troubleshooting
 

--- a/crates/ralph-cli/src/presets.rs
+++ b/crates/ralph-cli/src/presets.rs
@@ -232,16 +232,40 @@ mod tests {
     }
 
     #[test]
+    fn test_embedded_presets_use_canonical_artifact_boundary() {
+        for preset in PRESETS {
+            let config =
+                RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
+
+            assert_eq!(
+                config.core.specs_dir, ".ralph/specs/",
+                "Preset '{}' should use the canonical committed specs boundary",
+                preset.name
+            );
+            assert!(
+                !preset.content.contains(".agents/scratchpad"),
+                "Preset '{}' should not direct artifacts to the legacy agents scratchpad",
+                preset.name
+            );
+            assert!(
+                !preset.content.contains("./specs/"),
+                "Preset '{}' should not direct artifacts to the legacy top-level specs directory",
+                preset.name
+            );
+        }
+    }
+
+    #[test]
     fn test_pdd_to_code_assist_uses_reviewed_increment_loop() {
         let preset = get_preset("pdd-to-code-assist").expect("pdd-to-code-assist should exist");
         let config =
             RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
 
-        assert_eq!(config.core.specs_dir, ".agents/scratchpad/");
+        assert_eq!(config.core.specs_dir, ".ralph/specs/");
         assert!(
             preset
                 .content
-                .contains(".agents/scratchpad/implementation/{spec_name}/idea-honing.md")
+                .contains(".ralph/specs/{spec_name}/idea-honing.md")
         );
         assert!(!preset.content.contains("requirements-interview.md"));
 
@@ -405,12 +429,12 @@ mod tests {
     }
 
     #[test]
-    fn test_code_assist_uses_upstream_artifact_layout_and_builder_workflow() {
+    fn test_code_assist_uses_canonical_artifact_layout_and_builder_workflow() {
         let preset = get_preset("code-assist").expect("code-assist should exist");
         let config =
             RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
 
-        assert_eq!(config.core.specs_dir, ".agents/scratchpad/");
+        assert_eq!(config.core.specs_dir, ".ralph/specs/");
         assert_eq!(
             config.event_loop.required_events,
             vec!["review.passed".to_string()]
@@ -420,11 +444,7 @@ mod tests {
             .hats
             .get("planner")
             .expect("planner hat should exist");
-        assert!(
-            planner
-                .instructions
-                .contains(".agents/scratchpad/implementation/{task_name}/")
-        );
+        assert!(planner.instructions.contains(".ralph/specs/{task_name}/"));
         assert!(
             planner
                 .instructions
@@ -557,11 +577,7 @@ mod tests {
                 .instructions
                 .contains("ralph tools task reopen <task_id>")
         );
-        assert!(
-            finalizer
-                .instructions
-                .contains(".agents/scratchpad/implementation/{task_name}/")
-        );
+        assert!(finalizer.instructions.contains(".ralph/specs/{task_name}/"));
         assert!(
             finalizer
                 .instructions
@@ -722,7 +738,7 @@ mod tests {
         let config =
             RalphConfig::parse_yaml(preset.content).expect("embedded preset YAML should parse");
 
-        assert_eq!(config.core.specs_dir, ".agents/scratchpad/");
+        assert_eq!(config.core.specs_dir, ".ralph/specs/");
         assert_eq!(
             config.event_loop.required_events,
             vec!["research.finding".to_string()]

--- a/crates/ralph-cli/tests/integration_gitignore.rs
+++ b/crates/ralph-cli/tests/integration_gitignore.rs
@@ -1,0 +1,101 @@
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn workspace_root() -> Result<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .map(Path::to_path_buf)
+        .context("resolve workspace root")
+}
+
+fn git_check_ignore(repo: &Path, path: &str) -> Result<bool> {
+    let output = Command::new("git")
+        .arg("check-ignore")
+        .arg("--quiet")
+        .arg("--no-index")
+        .arg(path)
+        .current_dir(repo)
+        .output()
+        .with_context(|| format!("run git check-ignore for {path}"))?;
+
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => bail!(
+            "git check-ignore failed for {path}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ),
+    }
+}
+
+#[test]
+fn ralph_gitignore_tracks_committed_artifacts_not_runtime_state() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let repo = temp_dir.path();
+    let workspace_root = workspace_root()?;
+
+    let init = Command::new("git").arg("init").current_dir(repo).output()?;
+    assert!(
+        init.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    fs::copy(workspace_root.join(".gitignore"), repo.join(".gitignore"))?;
+
+    fs::create_dir_all(repo.join(".ralph/specs/example"))?;
+    fs::create_dir_all(repo.join(".ralph/tasks"))?;
+    fs::create_dir_all(repo.join(".ralph/tasks/data-pipeline/step02"))?;
+    fs::create_dir_all(repo.join(".ralph/agent"))?;
+    fs::write(repo.join(".ralph/specs/example/spec.md"), "# Spec\n")?;
+    fs::write(repo.join(".ralph/tasks/example.code-task.md"), "# Task\n")?;
+    fs::write(
+        repo.join(".ralph/tasks/data-pipeline/step02/task-01-create-model.code-task.md"),
+        "# Task\n",
+    )?;
+    fs::write(repo.join(".ralph/tasks/debug.log"), "debug\n")?;
+    fs::write(repo.join(".ralph/tasks/note.txt"), "note\n")?;
+    fs::write(
+        repo.join(".ralph/tasks/data-pipeline/step02/tmp.json"),
+        "{}\n",
+    )?;
+    fs::write(repo.join(".ralph/agent/decisions.md"), "# Decisions\n")?;
+    fs::write(repo.join(".ralph/agent/memories.md"), "# Memories\n")?;
+    fs::write(repo.join(".ralph/agent/tasks.jsonl"), "{}\n")?;
+    fs::write(repo.join(".ralph/agent/scratchpad.md"), "draft\n")?;
+    fs::write(repo.join(".ralph/loops.json"), "{}\n")?;
+
+    for tracked in [
+        ".ralph/specs/example/spec.md",
+        ".ralph/tasks/example.code-task.md",
+        ".ralph/tasks/data-pipeline/step02/task-01-create-model.code-task.md",
+        ".ralph/agent/decisions.md",
+        ".ralph/agent/memories.md",
+    ] {
+        assert!(
+            !git_check_ignore(repo, tracked)?,
+            "{tracked} should be visible to git"
+        );
+    }
+
+    for ignored in [
+        ".ralph/tasks/debug.log",
+        ".ralph/tasks/note.txt",
+        ".ralph/tasks/data-pipeline/step02/tmp.json",
+        ".ralph/agent/tasks.jsonl",
+        ".ralph/agent/scratchpad.md",
+        ".ralph/loops.json",
+    ] {
+        assert!(
+            git_check_ignore(repo, ignored)?,
+            "{ignored} should stay ignored"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/ralph-core/data/ralph-tools-tasks.md
+++ b/crates/ralph-core/data/ralph-tools-tasks.md
@@ -12,7 +12,7 @@ metadata:
 | System | Command | Purpose | Storage |
 |--------|---------|---------|---------|
 | **Runtime tasks** | `ralph tools task` | Track work items during runs | `.ralph/agent/tasks.jsonl` |
-| **Code tasks** | `ralph task` | Implementation planning | `tasks/*.code-task.md` |
+| **Code tasks** | `ralph task` | Implementation planning | `.ralph/tasks/*.code-task.md` |
 
 This skill covers **runtime tasks**. For code tasks, see `/code-task-generator`.
 

--- a/docs/api/ralph-cli.md
+++ b/docs/api/ralph-cli.md
@@ -48,7 +48,7 @@ Notes:
 
 ## Runtime Directories
 
-Ralph runtime artifacts are stored in `.ralph/` (for example `.ralph/agent`, `.ralph/tasks`, `.ralph/specs`), not `.agent/`.
+Ralph runtime state is stored under `.ralph/` and remains ignored by default. Committed planning artifacts live in `.ralph/specs/`, and committed code task files live in `.ralph/tasks/`; legacy `.agent/` paths are not used for new artifacts.
 
 ## Command Dispatch
 

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -70,9 +70,10 @@ ralph-orchestrator/
 │   ├── ralph-cli/             # Binary entry point
 │   ├── ralph-e2e/             # E2E testing
 │   └── ralph-bench/           # Benchmarking
+├── .ralph/
+│   ├── specs/                 # Committed development specs and designs
+│   └── tasks/                 # Committed code task files
 ├── presets/                   # Hat collection presets
-├── specs/                     # Development specs
-├── tasks/                     # Code tasks
 ├── docs/                      # Documentation
 ├── scripts/                   # Utility scripts
 ├── Cargo.toml                 # Workspace config

--- a/docs/examples/pdd-design.md
+++ b/docs/examples/pdd-design.md
@@ -15,7 +15,7 @@ Once the interview is complete, a `PDD Author` writes the design package and a `
 
 ## Output
 
-The workflow writes a PDD-style package under `.agents/scratchpad/implementation/{spec_name}/`:
+The workflow writes a PDD-style package under `.ralph/specs/{spec_name}/`:
 
 - `rough-idea.md`
 - `idea-honing.md`

--- a/docs/examples/presets/auto-pdd.yml
+++ b/docs/examples/presets/auto-pdd.yml
@@ -23,7 +23,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration. Persist assumptions and decisions to disk."
     - "Stay in design mode only. Do not write production code or code-task files."
@@ -46,9 +46,9 @@ hats:
       ### Storage Layout
       On first trigger, establish the spec identity:
       1. Derive `spec_name` from the original prompt using kebab-case.
-      2. Create `.agents/scratchpad/implementation/{spec_name}/`.
-      3. Write the original prompt to `.agents/scratchpad/implementation/{spec_name}/rough-idea.md`.
-      4. Create or append to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`.
+      2. Create `.ralph/specs/{spec_name}/`.
+      3. Write the original prompt to `.ralph/specs/{spec_name}/rough-idea.md`.
+      4. Create or append to `.ralph/specs/{spec_name}/idea-honing.md`.
 
       ### Process
       1. Read the original prompt, prior idea-honing transcript, and any design-review feedback.
@@ -93,7 +93,7 @@ hats:
       Answer as a pragmatic product owner who wants a useful, defensible design from an imperfect brief.
 
       ### Storage Layout
-      Append every Q&A pair to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`.
+      Append every Q&A pair to `.ralph/specs/{spec_name}/idea-honing.md`.
 
       ### Process
       1. Read the original prompt, the latest question, and the existing interview transcript.
@@ -127,7 +127,7 @@ hats:
       The output should be strong enough for a later implementation workflow to consume.
 
       ### Storage Layout
-      Write artifacts in `.agents/scratchpad/implementation/{spec_name}/`:
+      Write artifacts in `.ralph/specs/{spec_name}/`:
       - `requirements.md` — Consolidated requirements and assumptions
       - `design.md` — Full design package
 
@@ -177,9 +177,9 @@ hats:
 
       ### Review Inputs
       Read:
-      - `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
-      - `.agents/scratchpad/implementation/{spec_name}/requirements.md`
-      - `.agents/scratchpad/implementation/{spec_name}/design.md`
+      - `.ralph/specs/{spec_name}/idea-honing.md`
+      - `.ralph/specs/{spec_name}/requirements.md`
+      - `.ralph/specs/{spec_name}/design.md`
 
       ### Review Checklist
       Reject the design if any of these are weak:

--- a/docs/examples/spec-driven.md
+++ b/docs/examples/spec-driven.md
@@ -13,7 +13,7 @@ If you specifically want an example-only automated design workflow, see [Automat
 
 ## Workflow
 
-1. Create specification/design artifacts in `.agents/scratchpad/implementation/{spec_name}/`
+1. Create specification/design artifacts in `.ralph/specs/{spec_name}/`
 2. Review and approve spec
 3. Generate implementation tasks
 4. Execute with Ralph orchestration

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -132,7 +132,7 @@ core:
   scratchpad:                            # Scratchpad configuration
     enabled: true                        # Enable scratchpad (default: true)
     path: .ralph/agent/scratchpad.md     # Scratchpad file path
-  specs_dir: "./specs/"                  # Specifications directory
+  specs_dir: ".ralph/specs/"             # Committed specifications directory
   guardrails:                            # Rules injected into every prompt
     - "Fresh context each iteration"
     - "Never modify production database"
@@ -241,7 +241,7 @@ Core behaviors, scratchpad, and guardrails.
 | `scratchpad` | string or object | `{ enabled: true, path: ".ralph/agent/scratchpad.md" }` | Scratchpad configuration (see below) |
 | `scratchpad.enabled` | boolean | `true` | Enable the scratchpad |
 | `scratchpad.path` | string | `".ralph/agent/scratchpad.md"` | Scratchpad file path |
-| `specs_dir` | string | `"./specs/"` | Specifications directory |
+| `specs_dir` | string | `".ralph/specs/"` | Committed specifications directory |
 | `guardrails` | list | `[]` | Rules injected into every prompt |
 
 The `scratchpad` field accepts a plain string (shorthand for setting `path` with `enabled: true`) or a structured object with `enabled` and `path`:

--- a/docs/guide/roo-backend.md
+++ b/docs/guide/roo-backend.md
@@ -65,7 +65,7 @@ cli:
     - "medium"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"
@@ -134,7 +134,7 @@ cli:
     - "medium"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — save learnings to memories for next time"
     - "Verification is mandatory — tests/typecheck/lint/audit must pass"

--- a/presets/autoresearch.yml
+++ b/presets/autoresearch.yml
@@ -40,7 +40,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — re-read autoresearch.md and git log every time"
     - "Primary metric is king — improved = keep, worse/equal = discard"

--- a/presets/code-assist.yml
+++ b/presets/code-assist.yml
@@ -13,7 +13,7 @@
 #
 # Usage:
 #   # From PDD output directory:
-#   ralph run --config presets/code-assist.yml --prompt ".agents/scratchpad/implementation/my-feature"
+#   ralph run --config presets/code-assist.yml --prompt ".ralph/specs/my-feature"
 #
 #   # From a single code task:
 #   ralph run --config presets/code-assist.yml --prompt ".ralph/tasks/my-task.code-task.md"
@@ -35,7 +35,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — save learnings to memories for next time"
     - "Verification is mandatory — tests/typecheck/lint/audit must pass"
@@ -59,13 +59,13 @@ hats:
       The Builder only sees one task at a time, but you decide when a whole step's wave is exhausted and when the next step should exist.
 
       ### Shared Documentation Directory
-      Use the upstream code-assist documentation layout:
-      `.agents/scratchpad/implementation/{task_name}/`
+      Use the canonical Ralph spec artifact layout:
+      `.ralph/specs/{task_name}/`
 
       Determine the working directory like this:
       - Existing implementation directory in the prompt: use that directory directly
-      - Single `.code-task.md` file: derive `task_name` and use `.agents/scratchpad/implementation/{task_name}/`
-      - Rough description: derive `task_name` and use `.agents/scratchpad/implementation/{task_name}/`
+      - Single `.code-task.md` file: derive `task_name` and use `.ralph/specs/{task_name}/`
+      - Rough description: derive `task_name` and use `.ralph/specs/{task_name}/`
 
       The working directory MUST contain or create:
       - `context.md` — implementation context, repo patterns, dependencies, acceptance criteria
@@ -222,7 +222,7 @@ hats:
       The loop also sets `$RALPH_BIN`; prefer `"$RALPH_BIN" tools ...` and `"$RALPH_BIN" emit ...` for task/event commands.
       Read the shared documentation directory for this run:
       - Existing PDD directory from the prompt, or
-      - `.agents/scratchpad/implementation/{task_name}/` for code-task / rough-description runs
+      - `.ralph/specs/{task_name}/` for code-task / rough-description runs
 
       Read in this order:
       1. the runtime task from the event payload via `ralph tools task show <task_id> --format json`
@@ -349,7 +349,7 @@ hats:
       If `spec_dir` exists, read from `{spec_dir}/`:
       - `plan.md` — High-level strategy and E2E scenario
       - `design.md` — Requirements to validate against
-      - `tasks/*.code-task.md` — Understand task boundaries when present
+      - `.ralph/tasks/{task_name}/**/*.code-task.md` — Understand task boundaries, including PDD step subdirectories, when present
 
       ### Review Checklist
 
@@ -445,7 +445,7 @@ hats:
       ### Shared Documentation Directory
       Use the same shared docs directory as Planner and Builder:
       - existing implementation directory from the prompt, or
-      - `.agents/scratchpad/implementation/{task_name}/`
+      - `.ralph/specs/{task_name}/`
 
       Read `context.md`, `plan.md`, `progress.md`, and `logs/` from that shared docs directory.
       The implementation target under `.eval-sandbox/` is the runnable artifact area, not the location of `plan.md` or `progress.md`.
@@ -455,7 +455,7 @@ hats:
       Use the strongest source of truth available:
 
       **If operating from a PDD directory**
-      - Check every `*.code-task.md` file in `tasks/`
+      - Check every `.code-task.md` file under `.ralph/tasks/{task_name}/` recursively
       - If any remain `pending` or `in_progress`, close or reopen the reviewed runtime task as needed, then publish `queue.advance`
       - If all are completed, confirm the design, plan, and prompt are actually satisfied end-to-end
 

--- a/presets/debug.yml
+++ b/presets/debug.yml
@@ -18,7 +18,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   investigator:

--- a/presets/hatless-baseline.yml
+++ b/presets/hatless-baseline.yml
@@ -20,7 +20,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
 
 # NO HATS - Ralph works directly without delegation
 # This is intentional for baseline testing

--- a/presets/minimal/amp.yml
+++ b/presets/minimal/amp.yml
@@ -19,7 +19,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/builder.yml
+++ b/presets/minimal/builder.yml
@@ -22,7 +22,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/claude.yml
+++ b/presets/minimal/claude.yml
@@ -15,7 +15,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/code-assist.yml
+++ b/presets/minimal/code-assist.yml
@@ -16,7 +16,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/codex.yml
+++ b/presets/minimal/codex.yml
@@ -19,7 +19,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/gemini.yml
+++ b/presets/minimal/gemini.yml
@@ -19,7 +19,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/kiro.yml
+++ b/presets/minimal/kiro.yml
@@ -18,7 +18,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/opencode.yml
+++ b/presets/minimal/opencode.yml
@@ -29,7 +29,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/preset-evaluator.yml
+++ b/presets/minimal/preset-evaluator.yml
@@ -21,7 +21,7 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Document ALL findings - both successes and failures"
     - "Be specific about error messages and stack traces"

--- a/presets/minimal/roo.yml
+++ b/presets/minimal/roo.yml
@@ -18,7 +18,7 @@ cli:
 
 # Core behaviors (always injected into prompts)
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/smoke.yml
+++ b/presets/minimal/smoke.yml
@@ -18,7 +18,7 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Don't assume 'not implemented' - search first"

--- a/presets/minimal/test.yml
+++ b/presets/minimal/test.yml
@@ -17,7 +17,7 @@ cli:
 
 # Core behaviors
 core:
-  specs_dir: "./specs/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration - save learnings to memories for next time"
     - "Confidence protocol: score decisions 0-100. >80 proceed autonomously; 50-80 proceed + document in .ralph/agent/decisions.md; <50 choose safe default + document."

--- a/presets/pdd-to-code-assist.yml
+++ b/presets/pdd-to-code-assist.yml
@@ -36,7 +36,7 @@ cli:
   prompt_mode: "arg"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
   guardrails:
     - "Fresh context each iteration — save learnings to memories for next time"
     - "Verification is mandatory — tests/typecheck/lint/audit must pass"
@@ -63,16 +63,16 @@ hats:
       ### Storage Layout
       On first trigger (design.start), establish the spec identity:
       1. Derive `spec_name` from the auto-injected objective (kebab-case, e.g., "add-user-auth")
-      2. Create `.agents/scratchpad/implementation/{spec_name}/` directory using the same per-spec implementation layout as upstream code-assist
-      3. Write the objective to `.agents/scratchpad/implementation/{spec_name}/rough-idea.md`
-      4. Create or append to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
+      2. Create `.ralph/specs/{spec_name}/` using the canonical Ralph spec artifact layout
+      3. Write the objective to `.ralph/specs/{spec_name}/rough-idea.md`
+      4. Create or append to `.ralph/specs/{spec_name}/idea-honing.md`
       5. Ensure and start the requirements phase runtime task with a stable key like `pdd:{spec_name}:requirements`
 
       ### Process
       1. Review context and previous Q&A
       2. Identify the most critical gap or ambiguity
       3. Ask ONE specific, answerable question
-      4. Record your question in `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
+      4. Record your question in `.ralph/specs/{spec_name}/idea-honing.md`
 
       ### Question Types (use strategically)
       - Scope: "What is explicitly OUT of scope?"
@@ -118,7 +118,7 @@ hats:
       then synthesize everything into a comprehensive design document.
 
       ### Storage Layout
-      Store design and implementation artifacts in `.agents/scratchpad/implementation/{spec_name}/`:
+      Store design and implementation artifacts in `.ralph/specs/{spec_name}/`:
       - `rough-idea.md` — Original prompt/idea
       - `idea-honing.md` — Question/answer transcript from idea honing
       - `requirements.md` — Consolidated requirements and assumptions
@@ -129,7 +129,7 @@ hats:
       2. Read the question carefully
       3. Research if needed (explore codebase, check patterns)
       4. Provide a clear, specific answer
-      5. Append the answer to `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
+      5. Append the answer to `.ralph/specs/{spec_name}/idea-honing.md`
       6. Publish `answer.proposed` with the active `task_id` and `task_key`
 
       ### When Triggered by requirements.complete
@@ -137,11 +137,11 @@ hats:
 
       1. Close the requirements-answering task if it is complete.
       2. Ensure and start the design-drafting runtime task with a stable key like `pdd:{spec_name}:design-draft`
-      3. Read `.agents/scratchpad/implementation/{spec_name}/rough-idea.md` and `.agents/scratchpad/implementation/{spec_name}/idea-honing.md`
-      4. Write consolidated requirements to `.agents/scratchpad/implementation/{spec_name}/requirements.md`
-      5. Then write the full design to `.agents/scratchpad/implementation/{spec_name}/design.md`
+      3. Read `.ralph/specs/{spec_name}/rough-idea.md` and `.ralph/specs/{spec_name}/idea-honing.md`
+      4. Write consolidated requirements to `.ralph/specs/{spec_name}/requirements.md`
+      5. Then write the full design to `.ralph/specs/{spec_name}/design.md`
 
-      Design Document Structure (write to `.agents/scratchpad/implementation/{spec_name}/design.md`):
+      Design Document Structure (write to `.ralph/specs/{spec_name}/design.md`):
       1. **Overview** — Problem statement and solution summary
       2. **Detailed Requirements** — Consolidated from Q&A, each requirement numbered
       3. **Architecture Overview** — High-level system design with Mermaid diagram (REQUIRED)
@@ -189,7 +189,7 @@ hats:
       A weak design that slips through costs far more to fix in code.
 
       ### Storage Layout
-      Read design artifacts from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read design artifacts from `.ralph/specs/{spec_name}/`:
       - `idea-honing.md` — Raw question/answer transcript
       - `design.md` — The design document to review
       - `requirements.md` — Requirements to validate against
@@ -253,17 +253,17 @@ hats:
       Find existing patterns, identify integration points, surface constraints.
 
       ### Storage Layout
-      Read design artifacts from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read design artifacts from `.ralph/specs/{spec_name}/`:
       - `design.md` — The detailed design to implement
       - `requirements.md` — The consolidated requirements
 
-      Write research findings to `.agents/scratchpad/implementation/{spec_name}/research/`:
+      Write research findings to `.ralph/specs/{spec_name}/research/`:
       - `existing-patterns.md` — Similar features and coding conventions found
       - `technologies.md` — Libraries, frameworks, dependencies available
       - `broken-windows.md` — Low-risk code smells in touched files
       - Additional topic-specific files as needed
 
-      Write implementation context to `.agents/scratchpad/implementation/{spec_name}/context.md`:
+      Write implementation context to `.ralph/specs/{spec_name}/context.md`:
       - Summary of research findings
       - Integration points and dependencies
       - Constraints and considerations
@@ -315,7 +315,7 @@ hats:
       - Performance optimizations requiring benchmarks
       - Anything requiring new tests to validate
 
-      Write findings to `.agents/scratchpad/implementation/{spec_name}/research/broken-windows.md`:
+      Write findings to `.ralph/specs/{spec_name}/research/broken-windows.md`:
       ```markdown
       ## Broken Windows
 
@@ -355,11 +355,11 @@ hats:
       TDD means tests come first — plan them thoroughly.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `design.md` — The approved design
       - `context.md` — Codebase patterns and integration points
 
-      Write the upstream code-assist implementation plan artifact to `.agents/scratchpad/implementation/{spec_name}/plan.md`:
+      Write the upstream code-assist implementation plan artifact to `.ralph/specs/{spec_name}/plan.md`:
       - Test strategy (unit, integration, E2E scenarios)
       - Numbered implementation steps in TDD order
       - Success criteria and demo outcome for each step
@@ -436,20 +436,20 @@ hats:
 
       You convert the implementation plan into discrete, well-structured code task files.
       Then you materialize ONLY the current numbered step's runtime-task wave.
-      The code task files are the spec artifacts; runtime tasks are the live queue.
+      The code task files are the task artifacts; runtime tasks are the live queue.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `plan.md` — Implementation steps and test strategy
       - `design.md` — Architecture and component details
       - `context.md` — Codebase patterns to follow
 
-      Write code task files to `.agents/scratchpad/implementation/{spec_name}/tasks/`:
+      Write code task files to `.ralph/tasks/{spec_name}/`:
       - `task-01-{kebab-case-title}.code-task.md`
       - `task-02-{kebab-case-title}.code-task.md`
       - etc.
 
-      Create the `tasks/` subdirectory if it doesn't exist.
+      Create `.ralph/tasks/{spec_name}/` if it doesn't exist.
 
       ### Code Task File Format
       Each task file MUST follow this exact structure:
@@ -471,11 +471,11 @@ hats:
 
       ## Reference Documentation
       **Required:**
-      - Design: .agents/scratchpad/implementation/{spec_name}/design.md
+      - Design: .ralph/specs/{spec_name}/design.md
 
       **Additional References:**
-      - .agents/scratchpad/implementation/{spec_name}/context.md (codebase patterns)
-      - .agents/scratchpad/implementation/{spec_name}/plan.md (overall strategy)
+      - .ralph/specs/{spec_name}/context.md (codebase patterns)
+      - .ralph/specs/{spec_name}/plan.md (overall strategy)
 
       **Note:** You MUST read the design document before beginning implementation.
 
@@ -511,15 +511,15 @@ hats:
 
       ### Process On `plan.ready`
       1. Ensure and start the task-writing runtime task with a stable key like `pdd:{spec_name}:task-writing`
-      2. Read the implementation plan from `.agents/scratchpad/implementation/{spec_name}/plan.md`
+      2. Read the implementation plan from `.ralph/specs/{spec_name}/plan.md`
       3. For each numbered step in the plan, create a code task file
       4. Extract acceptance criteria from the plan and convert to Given-When-Then format
       5. Include unit test requirements in each task (not as separate tasks)
       6. Ensure tasks are sequenced correctly with dependencies noted
-      7. Write all task files to `.agents/scratchpad/implementation/{spec_name}/tasks/`
+      7. Write all task files to `.ralph/tasks/{spec_name}/`
       8. Select Step 1 as the current implementation step
       9. Mirror ONLY Step 1's code task files into runtime tasks with stable keys like `pdd:{spec_name}:step-01:{task_slug}`
-      10. Record the current step and active wave in `.agents/scratchpad/implementation/{spec_name}/progress.md`
+      10. Record the current step and active wave in `.ralph/specs/{spec_name}/progress.md`
       11. Close the task-writing phase task
       12. Publish `tasks.ready` for exactly one Step 1 runtime task with:
           - the mirrored runtime `task_id`
@@ -564,19 +564,19 @@ hats:
       You do NOT decide overall completion. You hand each finished task to the Critic.
 
       ### Storage Layout
-      Read code task files from `.agents/scratchpad/implementation/{spec_name}/tasks/`:
+      Read code task files from `.ralph/tasks/{spec_name}/`:
       - `task-01-*.code-task.md`, `task-02-*.code-task.md`, etc.
 
       Also reference:
-      - `.agents/scratchpad/implementation/{spec_name}/design.md` — Architecture and component details
-      - `.agents/scratchpad/implementation/{spec_name}/context.md` — Codebase patterns to follow
+      - `.ralph/specs/{spec_name}/design.md` — Architecture and component details
+      - `.ralph/specs/{spec_name}/context.md` — Codebase patterns to follow
 
-      Track evidence in `.agents/scratchpad/implementation/{spec_name}/progress.md`:
+      Track evidence in `.ralph/specs/{spec_name}/progress.md`:
       - TDD cycle documentation (RED → GREEN → REFACTOR)
       - Build output summaries
       - Verification notes for the active runtime task
 
-      Save build/test logs to `.agents/scratchpad/implementation/{spec_name}/logs/`:
+      Save build/test logs to `.ralph/specs/{spec_name}/logs/`:
       - `build.log` — Latest build output
       - `test.log` — Latest test output
       Create the `logs/` directory if it doesn't exist.
@@ -651,7 +651,7 @@ hats:
       Refactor to align if any items fail. Code should not look "foreign" to the codebase.
 
       ### Broken Windows (Optional)
-      Check `.agents/scratchpad/implementation/{spec_name}/research/broken-windows.md` for low-risk fixes.
+      Check `.ralph/specs/{spec_name}/research/broken-windows.md` for low-risk fixes.
       During refactor, you MAY fix broken windows in files you're already touching:
       - Only fix issues in files modified by this task
       - Only fix if truly low-risk (no behavior change)
@@ -746,7 +746,7 @@ hats:
       ### What To Read
       - the reviewed `task_id`, `task_key`, and task path from the `review.passed` payload
       - the reviewed runtime task via `ralph tools task show <task_id> --format json`
-      - all `.agents/scratchpad/implementation/{spec_name}/tasks/*.code-task.md` files
+      - all `.ralph/tasks/{spec_name}/*.code-task.md` files
       - `design.md`, `plan.md`, and `progress.md` when needed to resolve ambiguity
 
       ### Decision Process
@@ -787,13 +787,13 @@ hats:
       Be thorough, be skeptical, verify everything yourself.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `plan.md` — E2E test scenario to execute manually
       - `design.md` — Requirements to validate against
       - `progress.md` — Build and verification evidence
-      - `tasks/*.code-task.md` — All task files (verify all have `status: completed`)
+      - `.ralph/tasks/{spec_name}/*.code-task.md` — All task files (verify all have `status: completed`)
 
-      Write validation results to `.agents/scratchpad/implementation/{spec_name}/validation.md`:
+      Write validation results to `.ralph/specs/{spec_name}/validation.md`:
       - Task completion verification (all tasks must be `status: completed`)
       - Test suite results
       - Build/lint verification
@@ -803,7 +803,7 @@ hats:
       ### Validation Checklist
 
       **0. All Code Tasks Complete**
-      Check every `*.code-task.md` file in `.agents/scratchpad/implementation/{spec_name}/tasks/`:
+      Check every `*.code-task.md` file in `.ralph/tasks/{spec_name}/`:
       - All must have `status: completed` in frontmatter
       - All must have valid `completed: YYYY-MM-DD` dates
       FAIL if any task is not marked completed.
@@ -911,10 +911,10 @@ hats:
       Follow conventional commit format and document the implementation.
 
       ### Storage Layout
-      Read from `.agents/scratchpad/implementation/{spec_name}/`:
+      Read from `.ralph/specs/{spec_name}/`:
       - `design.md` — For commit message context
       - `validation.md` — Confirmation of passing validation
-      - `tasks/*.code-task.md` — Update all to `status: completed`
+      - `.ralph/tasks/{spec_name}/*.code-task.md` — Update all to `status: completed`
 
       Ensure and start the commit runtime task with a stable key like `pdd:{spec_name}:commit`.
 
@@ -953,7 +953,7 @@ hats:
       error messages for common format issues. Supports international
       domains and includes performance optimization for bulk validation.
 
-      Spec: .agents/scratchpad/implementation/email-validator/design.md
+      Spec: .ralph/specs/email-validator/design.md
       ```
 
       ### Constraints

--- a/presets/research.yml
+++ b/presets/research.yml
@@ -20,7 +20,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   researcher:

--- a/presets/review.yml
+++ b/presets/review.yml
@@ -19,7 +19,7 @@ cli:
   backend: "claude"
 
 core:
-  specs_dir: ".agents/scratchpad/"
+  specs_dir: ".ralph/specs/"
 
 hats:
   reviewer:


### PR DESCRIPTION
## Summary
- clarifies canonical committed artifact boundaries under `.ralph/specs`, `.ralph/tasks`, and selected `.ralph/agent` files
- fixes gitignore re-inclusion for committed `.ralph` artifact paths
- updates active presets/docs away from legacy `.agents` artifact locations
- adds embedded preset checks for the canonical artifact layout

Closes #320

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `./scripts/sync-embedded-files.sh check`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-cli presets -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-cli check_embedded -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-core smoke_runner -j1` (0 tests selected in this checkout)
