### PR TITLE
feat(backends): add Forge CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Use this mode from an MCP client configuration rather than an interactive termin
 
 Ralph implements the [Ralph Wiggum technique](https://ghuntley.com/ralph/) — autonomous task completion through continuous iteration. It supports:
 
-- **Multi-Backend Support** — Claude Code, Kiro, Gemini CLI, Codex, Amp, Copilot CLI, OpenCode
+- **Multi-Backend Support** — Claude Code, Kiro, Gemini CLI, Codex, Forge, Amp, Copilot CLI, OpenCode
 - **Hat System** — Specialized personas coordinating through events
 - **Backpressure** — Gates that reject incomplete work (tests, lint, typecheck)
 - **Memories & Tasks** — Persistent learning and runtime work tracking
@@ -217,7 +217,7 @@ ralph run -p "Implement the feature in specs/user-authentication/"
 ```
 
 **What backends does Ralph support?**
-Claude Code, Kiro, Gemini CLI, Codex, Amp, Copilot CLI, and OpenCode.
+Claude Code, Kiro, Gemini CLI, Codex, Forge, Amp, Copilot CLI, and OpenCode.
 
 **What is the "hat system"?**
 Ralph uses specialized personas (hats) that coordinate through events. Each hat has a specific role — code-assist, debug, research, review, and pdd-to-code-assist — enabling structured multi-step task execution.

--- a/crates/ralph-adapters/src/auto_detect.rs
+++ b/crates/ralph-adapters/src/auto_detect.rs
@@ -9,7 +9,8 @@ use tracing::debug;
 
 /// Default priority order for backend detection.
 pub const DEFAULT_PRIORITY: &[&str] = &[
-    "claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi", "roo",
+    "claude", "kiro", "kiro-acp", "gemini", "codex", "forge", "amp", "copilot", "opencode", "pi",
+    "roo",
 ];
 
 /// Maps backend config names to their actual CLI command names.
@@ -53,6 +54,10 @@ impl std::fmt::Display for NoBackendError {
         writeln!(f, "  • Kiro CLI:     https://kiro.dev")?;
         writeln!(f, "  • Gemini CLI:   https://cloud.google.com/gemini")?;
         writeln!(f, "  • Codex CLI:    https://openai.com/codex")?;
+        writeln!(
+            f,
+            "  • Forge CLI:    https://github.com/tailcallhq/forgecode"
+        )?;
         writeln!(f, "  • Amp CLI:      https://amp.dev")?;
         writeln!(f, "  • Copilot CLI:  https://docs.github.com/copilot")?;
         writeln!(f, "  • OpenCode CLI: https://opencode.ai")?;
@@ -209,6 +214,7 @@ mod tests {
         assert_eq!(detection_command("claude"), "claude");
         assert_eq!(detection_command("gemini"), "gemini");
         assert_eq!(detection_command("codex"), "codex");
+        assert_eq!(detection_command("forge"), "forge");
         assert_eq!(detection_command("amp"), "amp");
         assert_eq!(detection_command("pi"), "pi");
         assert_eq!(detection_command("roo"), "roo");
@@ -219,6 +225,33 @@ mod tests {
         assert!(
             DEFAULT_PRIORITY.contains(&"pi"),
             "DEFAULT_PRIORITY should include 'pi'"
+        );
+    }
+
+    #[test]
+    fn test_default_priority_includes_forge_near_plain_text_backends() {
+        let codex_pos = DEFAULT_PRIORITY
+            .iter()
+            .position(|backend| *backend == "codex")
+            .expect("codex should be in DEFAULT_PRIORITY");
+        let forge_pos = DEFAULT_PRIORITY
+            .iter()
+            .position(|backend| *backend == "forge")
+            .expect("forge should be in DEFAULT_PRIORITY");
+        let amp_pos = DEFAULT_PRIORITY
+            .iter()
+            .position(|backend| *backend == "amp")
+            .expect("amp should be in DEFAULT_PRIORITY");
+
+        assert_eq!(
+            forge_pos,
+            codex_pos + 1,
+            "Forge should be immediately after Codex in DEFAULT_PRIORITY"
+        );
+        assert_eq!(
+            amp_pos,
+            forge_pos + 1,
+            "Amp should follow Forge in DEFAULT_PRIORITY"
         );
     }
 

--- a/crates/ralph-adapters/src/cli_backend.rs
+++ b/crates/ralph-adapters/src/cli_backend.rs
@@ -43,6 +43,8 @@ pub enum PromptMode {
     Arg,
     /// Write prompt to stdin.
     Stdin,
+    /// Do not pass a prompt to the command.
+    NoPrompt,
 }
 
 /// A CLI backend configuration for executing prompts.
@@ -74,6 +76,7 @@ impl CliBackend {
             "kiro-acp" => Self::kiro_acp(),
             "gemini" => Self::gemini(),
             "codex" => Self::codex(),
+            "forge" => Self::forge(),
             "amp" => Self::amp(),
             "copilot" => Self::copilot(),
             "opencode" => Self::opencode(),
@@ -248,6 +251,7 @@ impl CliBackend {
             "kiro-acp" => Ok(Self::kiro_acp()),
             "gemini" => Ok(Self::gemini()),
             "codex" => Ok(Self::codex()),
+            "forge" => Ok(Self::forge()),
             "amp" => Ok(Self::amp()),
             "copilot" => Ok(Self::copilot()),
             "opencode" => Ok(Self::opencode()),
@@ -325,6 +329,23 @@ impl CliBackend {
         }
     }
 
+    /// Creates the Forge backend for autonomous mode.
+    ///
+    /// Uses Forge's one-shot prompt mode:
+    /// ```bash
+    /// forge -p "prompt text here"
+    /// ```
+    pub fn forge() -> Self {
+        Self {
+            command: "forge".to_string(),
+            args: vec![],
+            prompt_mode: PromptMode::Arg,
+            prompt_flag: Some("-p".to_string()),
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        }
+    }
+
     /// Creates the Copilot backend for autonomous mode.
     ///
     /// Uses GitHub Copilot CLI with `--allow-all-tools` for automated tool approval.
@@ -395,6 +416,7 @@ impl CliBackend {
     /// | Kiro    | removes `--no-interactive` |
     /// | Gemini  | uses `-i` instead of `-p` |
     /// | Codex   | no `exec` subcommand |
+    /// | Forge   | no-arg TUI; prompt injection unsupported |
     /// | Amp     | removes `--dangerously-allow-all` |
     /// | Copilot | removes `--allow-all-tools` |
     /// | OpenCode| `run` subcommand with positional prompt |
@@ -410,6 +432,7 @@ impl CliBackend {
             "kiro" | "kiro-acp" => Ok(Self::kiro_interactive()),
             "gemini" => Ok(Self::gemini_interactive()),
             "codex" => Ok(Self::codex_interactive()),
+            "forge" => Ok(Self::forge_interactive()),
             "amp" => Ok(Self::amp_interactive()),
             "copilot" => Ok(Self::copilot_interactive()),
             "opencode" => Ok(Self::opencode_interactive()),
@@ -474,6 +497,22 @@ impl CliBackend {
             args: vec![],
             prompt_mode: PromptMode::Arg,
             prompt_flag: Some("-x".to_string()),
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        }
+    }
+
+    /// Forge in interactive TUI mode.
+    ///
+    /// Forge's interactive mode is `forge` with no arguments. It does not have
+    /// a supported initial prompt injection mode, so Ralph must not append the
+    /// SOP prompt as a positional argument.
+    pub fn forge_interactive() -> Self {
+        Self {
+            command: "forge".to_string(),
+            args: vec![],
+            prompt_mode: PromptMode::NoPrompt,
+            prompt_flag: None,
             output_format: OutputFormat::Text,
             env_vars: vec![],
         }
@@ -749,6 +788,7 @@ impl CliBackend {
                 }
             }
             PromptMode::Stdin => (Some(prompt.to_string()), None),
+            PromptMode::NoPrompt => (None, None),
         };
 
         // Log the full command being built
@@ -977,6 +1017,18 @@ mod tests {
         assert_eq!(cmd, "codex");
         assert_eq!(args, vec!["exec", "--yolo", "test prompt"]);
         assert!(stdin.is_none());
+    }
+
+    #[test]
+    fn test_forge_backend() {
+        let backend = CliBackend::forge();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "forge");
+        assert_eq!(args, vec!["-p", "test prompt"]);
+        assert!(stdin.is_none());
+        assert_eq!(backend.output_format, OutputFormat::Text);
+        assert_eq!(backend.prompt_flag, Some("-p".to_string()));
     }
 
     #[test]
@@ -1290,6 +1342,14 @@ mod tests {
     }
 
     #[test]
+    fn test_from_name_forge() {
+        let backend = CliBackend::from_name("forge").unwrap();
+        assert_eq!(backend.command, "forge");
+        assert_eq!(backend.prompt_mode, PromptMode::Arg);
+        assert_eq!(backend.prompt_flag, Some("-p".to_string()));
+    }
+
+    #[test]
     fn test_from_name_amp() {
         let backend = CliBackend::from_name("amp").unwrap();
         assert_eq!(backend.command, "amp");
@@ -1489,6 +1549,21 @@ mod tests {
     }
 
     #[test]
+    fn test_for_interactive_prompt_forge_uses_no_arg_tui() {
+        let backend = CliBackend::for_interactive_prompt("forge").unwrap();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", true);
+
+        assert_eq!(cmd, "forge");
+        assert!(
+            args.is_empty(),
+            "Forge interactive mode is no-arg; prompt injection must not become positional args"
+        );
+        assert!(stdin.is_none());
+        assert_eq!(backend.prompt_mode, PromptMode::NoPrompt);
+        assert_eq!(backend.output_format, OutputFormat::Text);
+    }
+
+    #[test]
     fn test_for_interactive_prompt_amp() {
         let backend = CliBackend::for_interactive_prompt("amp").unwrap();
         let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
@@ -1516,6 +1591,23 @@ mod tests {
     fn test_for_interactive_prompt_invalid() {
         let result = CliBackend::for_interactive_prompt("invalid_backend");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_config_forge_with_agent_arg() {
+        let config = CliConfig {
+            backend: "forge".to_string(),
+            command: None,
+            prompt_mode: "arg".to_string(),
+            args: vec!["--agent".to_string(), "reviewer".to_string()],
+            ..Default::default()
+        };
+        let backend = CliBackend::from_config(&config).unwrap();
+        let (cmd, args, stdin, _temp) = backend.build_command("test prompt", false);
+
+        assert_eq!(cmd, "forge");
+        assert_eq!(args, vec!["--agent", "reviewer", "-p", "test prompt"]);
+        assert!(stdin.is_none());
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -1809,6 +1901,7 @@ mod tests {
         assert!(CliBackend::kiro().env_vars.is_empty());
         assert!(CliBackend::gemini().env_vars.is_empty());
         assert!(CliBackend::codex().env_vars.is_empty());
+        assert!(CliBackend::forge().env_vars.is_empty());
         assert!(CliBackend::amp().env_vars.is_empty());
         assert!(CliBackend::copilot().env_vars.is_empty());
         assert!(CliBackend::opencode().env_vars.is_empty());

--- a/crates/ralph-adapters/src/lib.rs
+++ b/crates/ralph-adapters/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Claude (Anthropic)
 //! - Gemini (Google)
 //! - Codex (OpenAI)
+//! - Forge
 //! - Pi (pi-coding-agent)
 //! - Roo (Roo Code)
 //! - Amp

--- a/crates/ralph-cli/src/backend_support.rs
+++ b/crates/ralph-cli/src/backend_support.rs
@@ -2,12 +2,13 @@
 
 /// Supported LLM backend identifiers in ralph-cli.
 pub const VALID_BACKENDS: &[&str] = &[
-    "claude", "kiro", "kiro-acp", "gemini", "codex", "amp", "copilot", "opencode", "pi", "custom",
+    "claude", "kiro", "kiro-acp", "gemini", "codex", "forge", "amp", "copilot", "opencode", "pi",
+    "custom",
 ];
 
 /// Human-readable list for CLI messages and docs.
 pub const VALID_BACKENDS_LABEL: &str =
-    "claude, kiro, kiro-acp, gemini, codex, amp, copilot, opencode, pi, custom";
+    "claude, kiro, kiro-acp, gemini, codex, forge, amp, copilot, opencode, pi, custom";
 
 /// Returns `true` if the backend identifier is known.
 pub fn is_known_backend(name: &str) -> bool {
@@ -20,4 +21,21 @@ pub fn unknown_backend_message(name: &str) -> String {
         "Unknown backend: {}\n\nValid backends: {}",
         name, VALID_BACKENDS_LABEL
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forge_is_known_backend() {
+        assert!(is_known_backend("forge"));
+        assert!(VALID_BACKENDS.contains(&"forge"));
+    }
+
+    #[test]
+    fn unknown_backend_message_lists_forge() {
+        let message = unknown_backend_message("bogus");
+        assert!(message.contains("forge"));
+    }
 }

--- a/crates/ralph-cli/src/doctor.rs
+++ b/crates/ralph-cli/src/doctor.rs
@@ -440,6 +440,7 @@ fn canonical_backend_name(backend: &str, command: Option<&str>) -> String {
         "claude" => "claude".to_string(),
         "gemini" => "gemini".to_string(),
         "codex" => "codex".to_string(),
+        "forge" => "forge".to_string(),
         "amp" => "amp".to_string(),
         "copilot" => "copilot".to_string(),
         "opencode" => "opencode".to_string(),

--- a/crates/ralph-cli/src/hats.rs
+++ b/crates/ralph-cli/src/hats.rs
@@ -37,7 +37,7 @@ pub enum HatsCommands {
         /// Output format (unicode, ascii, compact, mermaid)
         #[arg(long, default_value = "unicode")]
         format: GraphFormat,
-        /// Backend for AI-generated diagrams (claude, kiro, gemini, codex, amp, copilot, opencode, pi, custom)
+        /// Backend for AI-generated diagrams (claude, kiro, gemini, codex, forge, amp, copilot, opencode, pi, custom)
         #[arg(short = 'b', long = "backend")]
         backend: Option<String>,
     },

--- a/crates/ralph-cli/src/init.rs
+++ b/crates/ralph-cli/src/init.rs
@@ -91,7 +91,7 @@ fn check_file_exists(force: bool) -> Result<(), InitError> {
 /// Initializes ralph.yml from a minimal backend template.
 ///
 /// # Arguments
-/// * `backend` - The backend name (claude, kiro, gemini, codex, amp, copilot, opencode, custom)
+/// * `backend` - The backend name (claude, kiro, gemini, codex, forge, amp, copilot, opencode, pi, custom)
 /// * `force` - If true, overwrite existing ralph.yml
 ///
 /// # Errors
@@ -230,6 +230,12 @@ mod tests {
     fn test_generate_template_kiro() {
         let template = generate_template("kiro");
         assert!(template.contains("backend: \"kiro\""));
+    }
+
+    #[test]
+    fn test_generate_template_forge() {
+        let template = generate_template("forge");
+        assert!(template.contains("backend: \"forge\""));
     }
 
     #[test]

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -709,7 +709,7 @@ enum Commands {
 /// Arguments for the init subcommand.
 #[derive(Parser, Debug)]
 struct InitArgs {
-    /// Backend to use (claude, kiro, gemini, codex, amp, copilot, opencode, pi, custom).
+    /// Backend to use (claude, kiro, gemini, codex, forge, amp, copilot, opencode, pi, custom).
     /// Generates core config only.
     #[arg(long, conflicts_with = "list_presets")]
     backend: Option<String>,

--- a/crates/ralph-cli/src/sop_runner.rs
+++ b/crates/ralph-cli/src/sop_runner.rs
@@ -122,6 +122,15 @@ pub fn run_sop(config: SopRunConfig) -> Result<(), SopRunError> {
         );
     }
 
+    if backend_name == "forge" {
+        tracing::info!(
+            "forge interactive mode has no supported initial prompt injection; launching no-arg `forge`"
+        );
+        eprintln!(
+            "note: forge interactive mode does not support initial prompt injection; launching `forge`"
+        );
+    }
+
     let mut addendums: Vec<(&str, &str)> = Vec::new();
 
     if config.agent_teams {
@@ -359,6 +368,7 @@ mod tests {
         assert!(validate_backend_name("kiro").is_ok());
         assert!(validate_backend_name("gemini").is_ok());
         assert!(validate_backend_name("codex").is_ok());
+        assert!(validate_backend_name("forge").is_ok());
         assert!(validate_backend_name("amp").is_ok());
         assert!(validate_backend_name("copilot").is_ok());
         assert!(validate_backend_name("opencode").is_ok());

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -182,7 +182,8 @@ pub struct RalphConfig {
     // These map to nested v2 fields for backwards compatibility.
     // ─────────────────────────────────────────────────────────────────────────
     /// V1 field: Backend CLI (maps to cli.backend).
-    /// Values: "claude", "kiro", "gemini", "codex", "amp", "pi", "auto", or "custom".
+    /// Values include "auto", "claude", "kiro", "kiro-acp", "gemini",
+    /// "codex", "forge", "amp", "copilot", "opencode", "pi", "roo", or "custom".
     #[serde(default)]
     pub agent: Option<String>,
 
@@ -816,7 +817,10 @@ impl RalphConfig {
     /// If empty, returns the default priority order.
     pub fn get_agent_priority(&self) -> Vec<&str> {
         if self.agent_priority.is_empty() {
-            vec!["claude", "kiro", "gemini", "codex", "amp"]
+            vec![
+                "claude", "kiro", "kiro-acp", "gemini", "codex", "forge", "amp", "copilot",
+                "opencode", "pi", "roo",
+            ]
         } else {
             self.agent_priority.iter().map(String::as_str).collect()
         }
@@ -1104,7 +1108,8 @@ impl CoreConfig {
 /// CLI backend configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliConfig {
-    /// Backend to use: "claude", "kiro", "gemini", "codex", "amp", "pi", or "custom".
+    /// Backend to use: "auto", "claude", "kiro", "kiro-acp", "gemini",
+    /// "codex", "forge", "amp", "copilot", "opencode", "pi", "roo", or "custom".
     #[serde(default = "default_backend")]
     pub backend: String,
 
@@ -2334,7 +2339,13 @@ agent_priority: [gemini, claude, codex]
     fn test_default_agent_priority() {
         let config = RalphConfig::default();
         let priority = config.get_agent_priority();
-        assert_eq!(priority, vec!["claude", "kiro", "gemini", "codex", "amp"]);
+        assert_eq!(
+            priority,
+            vec![
+                "claude", "kiro", "kiro-acp", "gemini", "codex", "forge", "amp", "copilot",
+                "opencode", "pi", "roo"
+            ]
+        );
     }
 
     #[test]

--- a/crates/ralph-core/src/preflight.rs
+++ b/crates/ralph-core/src/preflight.rs
@@ -1009,7 +1009,7 @@ fn backend_command(backend: &str, override_cmd: Option<&str>) -> Option<String> 
     }
 
     match backend {
-        "kiro" => Some("kiro-cli".to_string()),
+        "kiro" | "kiro-acp" => Some("kiro-cli".to_string()),
         _ => Some(backend.to_string()),
     }
 }

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -72,6 +72,7 @@ CLI backend integrations.
 - Kiro
 - Gemini CLI
 - Codex
+- Forge
 - Amp
 - Copilot CLI
 - OpenCode

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -12,7 +12,7 @@ Key types:
 
 ## Backend Detection
 
-Detect an available backend in PATH (Claude, Kiro, Gemini, Codex, Amp, Copilot, OpenCode):
+Detect an available backend in PATH (Claude, Kiro, Gemini, Codex, Forge, Amp, Copilot, OpenCode):
 
 ```rust
 use ralph_adapters::{detect_backend_default, is_backend_available};

--- a/docs/api/ralph-adapters.md
+++ b/docs/api/ralph-adapters.md
@@ -19,6 +19,7 @@ CLI backend integrations for various AI tools.
 | Kiro | `kiro` | Full support |
 | Gemini CLI | `gemini` | Full support |
 | Codex | `codex` | Full support |
+| Forge | `forge` | Full support |
 | Amp | `amp` | Full support |
 | Copilot CLI | `copilot` | Full support |
 | OpenCode | `opencode` | Full support |
@@ -40,6 +41,7 @@ pub struct CliBackend {
 pub enum PromptMode {
     Arg,    // cli -p "prompt"
     Stdin,  // echo "prompt" | cli
+    NoPrompt, // interactive CLI without prompt injection
 }
 
 pub enum OutputFormat {
@@ -82,9 +84,10 @@ let available = auto_detect::is_available("claude");
 2. Kiro
 3. Gemini
 4. Codex
-5. Amp
-6. Copilot
-7. OpenCode
+5. Forge
+6. Amp
+7. Copilot
+8. OpenCode
 
 ### PtyExecutor
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -18,6 +18,7 @@ Before you begin, ensure you have:
     - [Kiro](https://kiro.dev/)
     - [Gemini CLI](https://github.com/google-gemini/gemini-cli)
     - [Codex](https://github.com/openai/codex)
+    - [Forge](https://github.com/tailcallhq/forgecode)
     - [Amp](https://github.com/sourcegraph/amp)
     - [Copilot CLI](https://docs.github.com/copilot)
     - [OpenCode](https://opencode.ai/)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -35,6 +35,12 @@ Ralph needs at least one AI CLI tool to function. Install one of the following:
     # Visit https://github.com/openai/codex
     ```
 
+=== "Forge"
+
+    ```bash
+    curl -fsSL https://forgecode.dev/cli | sh
+    ```
+
 === "Amp"
 
     ```bash

--- a/docs/guide/backends.md
+++ b/docs/guide/backends.md
@@ -10,6 +10,7 @@ Ralph supports multiple AI CLI backends. This guide covers setup and selection.
 | Kiro | `kiro-cli` | Amazon/AWS |
 | Gemini CLI | `gemini` | Google |
 | Codex | `codex` | OpenAI |
+| Forge | `forge` | Multi-provider terminal agent |
 | Amp | `amp` | Sourcegraph |
 | Copilot CLI | `copilot` | GitHub |
 | OpenCode | `opencode` | Community |
@@ -29,10 +30,11 @@ Detection order (first available wins):
 2. Kiro
 3. Gemini
 4. Codex
-5. Amp
-6. Copilot
-7. OpenCode
-8. Pi
+5. Forge
+6. Amp
+7. Copilot
+8. OpenCode
+9. Pi
 
 ## Explicit Selection
 
@@ -57,7 +59,7 @@ Each backend below includes:
 - **Hat YAML** configuration
 - **`ralph doctor`** validation notes
 
-Backend names (used in YAML and CLI flags): `claude`, `kiro`, `gemini`, `codex`, `amp`, `copilot`, `opencode`, `pi`.
+Backend names (used in YAML and CLI flags): `claude`, `kiro`, `gemini`, `codex`, `forge`, `amp`, `copilot`, `opencode`, `pi`.
 
 ### Claude Code (`claude`)
 
@@ -187,6 +189,48 @@ hats:
 **Doctor checks:**
 - `codex --version` must succeed
 - Warns if neither `OPENAI_API_KEY` nor `CODEX_API_KEY` is set
+
+### Forge (`forge`)
+
+Multi-provider terminal AI agent.
+
+```bash
+# Install
+curl -fsSL https://forgecode.dev/cli | sh
+
+# Authenticate
+forge provider login
+
+# Verify
+forge --version
+```
+
+**Auth & env vars:**
+- Configure providers through `forge provider login` or Forge's provider configuration
+- No auth env vars are checked by `ralph doctor` for Forge
+
+**Hat YAML:**
+```yaml
+hats:
+  coder:
+    backend: "forge"
+```
+
+**Forge agent selection (optional):**
+```yaml
+hats:
+  reviewer:
+    backend:
+      type: "forge"
+      args: ["--agent", "sage"]
+```
+
+**Doctor checks:**
+- `forge --version` must succeed
+
+**Execution modes:**
+- Headless Ralph runs call `forge -p "<prompt>"`
+- Interactive Forge is launched as `forge`; Forge does not support initial prompt injection in no-arg interactive mode
 
 ### Amp (`amp`)
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -115,7 +115,7 @@ ralph init [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--backend <NAME>` | Backend: `claude`, `kiro`, `gemini`, `codex`, `amp`, `copilot`, `opencode`, `pi`, `custom` |
+| `--backend <NAME>` | Backend: `claude`, `kiro`, `gemini`, `codex`, `forge`, `amp`, `copilot`, `opencode`, `pi`, `custom` |
 | `--preset <NAME>` | Removed (monolithic presets no longer supported) |
 | `--list-presets` | List available built-in hat collections |
 | `--force` | Overwrite existing config |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -222,6 +222,7 @@ Backend configuration.
 - `kiro` — Kiro
 - `gemini` — Gemini CLI
 - `codex` — Codex
+- `forge` — Forge
 - `amp` — Amp
 - `copilot` — Copilot CLI
 - `opencode` — OpenCode

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Ralph implements the [Ralph Wiggum technique](https://ghuntley.com/ralph/) — a
 
 -   :material-robot: **Multi-Backend Support**
 
-    Works with Claude Code, Kiro, Gemini CLI, Codex, Amp, Copilot CLI, and OpenCode
+    Works with Claude Code, Kiro, Gemini CLI, Codex, Forge, Amp, Copilot CLI, and OpenCode
 
 -   :material-hat-fedora: **Hat System**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,6 +52,6 @@ ralph --version
 
 ## Next Steps
 
-- Install at least one supported AI backend CLI (Claude Code, Gemini CLI, Copilot CLI, etc.)
+- Install at least one supported AI backend CLI (Claude Code, Gemini CLI, Forge, Copilot CLI, etc.)
 - Configure your backend API keys or auth
 - Follow the quick start guide: `getting-started/quick-start.md`


### PR DESCRIPTION
## Summary
- adds Forge as a plain-text CLI backend using `forge -p/--prompt`
- includes Forge in auto-detection, backend validation, init templates, doctor/help text, config priority, SOP support, and docs
- keeps interactive Forge as no-arg TUI mode rather than assuming positional prompt support

Closes #281

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-adapters cli_backend -j1`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-adapters auto_detect -j1`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-cli backend_support -j1`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-cli init -j1`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-core test_default_agent_priority -j1`
- `CARGO_INCREMENTAL=0 cargo test -p ralph-core smoke_runner -j1` (0 tests selected in this checkout)

Note: `forge` is not installed locally, so live Forge execution was not run; command construction is covered by tests.
