### PR TITLE
feat(loops): publish remote review branches

### DIFF
--- a/.ralph/tasks/issue-220-remote-review-rebase.code-task.md
+++ b/.ralph/tasks/issue-220-remote-review-rebase.code-task.md
@@ -1,0 +1,23 @@
+---
+status: completed
+created: 2026-06-21
+started: 2026-06-21
+completed: 2026-06-21
+---
+# Task: Issue #220 Remote Review and Rebase Workflow
+
+## Description
+Add first-class CLI support for a remote review workflow for completed Ralph worktree loops without merging them into the base branch.
+
+## Scope
+- Add a `ralph loops publish-review` command that pushes a loop branch to a remote and writes a local review summary artifact.
+- Add a `ralph loops rebase` command that rebases one loop branch, or all queued/needs-review/manual Ralph worktree branches, onto a selected base branch without merging.
+- Reuse existing loop resolution, worktree branch naming, registry, and merge queue conventions.
+- Keep behavior CLI-level and avoid broad orchestration or merge queue refactors.
+- Update CLI help/docs for the new workflow.
+
+## Verification
+- Integration tests with temporary git repositories, remotes, and worktrees.
+- Focused `ralph-cli` tests for new loop commands.
+- `cargo test -p ralph-core smoke_runner`.
+- `cargo test` if feasible.

--- a/crates/ralph-cli/src/loops.rs
+++ b/crates/ralph-cli/src/loops.rs
@@ -13,7 +13,10 @@
 //! - `prune`: Clean up stale loops
 //! - `attach`: Open shell in worktree
 //! - `diff`: Show changes from merge-base
+//! - `publish-review`: Push a loop branch for remote review
+//! - `rebase`: Rebase loop branches onto a base branch without merging
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
@@ -65,6 +68,12 @@ pub enum LoopsCommands {
 
     /// Show diff of loop's changes from merge-base
     Diff(DiffArgs),
+
+    /// Push a completed loop branch to a remote and write a review summary
+    PublishReview(PublishReviewArgs),
+
+    /// Rebase reviewable loop branches onto a base branch without merging
+    Rebase(RebaseArgs),
 
     /// Merge a completed loop (or force retry)
     Merge(MergeArgs),
@@ -157,6 +166,50 @@ pub struct DiffArgs {
 }
 
 #[derive(Parser, Debug)]
+pub struct PublishReviewArgs {
+    /// Loop ID
+    pub loop_id: String,
+
+    /// Remote to push to
+    #[arg(long, default_value = "origin")]
+    pub remote: String,
+
+    /// Remote branch name (default: ralph/<loop-id>)
+    #[arg(long)]
+    pub remote_branch: Option<String>,
+
+    /// Base branch/ref to summarize against (default: origin HEAD/main, then local main/master)
+    #[arg(long)]
+    pub base: Option<String>,
+
+    /// Review summary path (default: .ralph/reviews/<loop-id>.md)
+    #[arg(long, value_name = "PATH")]
+    pub summary: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct RebaseArgs {
+    /// Loop ID. If omitted, rebases queued/needs-review loops and non-running ralph/* worktrees.
+    pub loop_id: Option<String>,
+
+    /// Base branch/ref to rebase onto (default: origin HEAD/main, then local main/master)
+    #[arg(long)]
+    pub base: Option<String>,
+
+    /// Remote to fetch from and push to
+    #[arg(long, default_value = "origin")]
+    pub remote: String,
+
+    /// Skip `git fetch <remote>` before rebasing
+    #[arg(long)]
+    pub no_fetch: bool,
+
+    /// Push rebased loop branches back to the remote with --force-with-lease
+    #[arg(long)]
+    pub push: bool,
+}
+
+#[derive(Parser, Debug)]
 pub struct MergeArgs {
     /// Loop ID
     pub loop_id: String,
@@ -192,6 +245,8 @@ pub fn execute(args: LoopsArgs, use_colors: bool) -> Result<()> {
         Some(LoopsCommands::Prune) => prune_stale(),
         Some(LoopsCommands::Attach(attach_args)) => attach_to_loop(attach_args),
         Some(LoopsCommands::Diff(diff_args)) => show_diff(diff_args),
+        Some(LoopsCommands::PublishReview(args)) => publish_review(args),
+        Some(LoopsCommands::Rebase(args)) => rebase_loops(args),
         Some(LoopsCommands::Merge(merge_args)) => merge_loop(merge_args),
         Some(LoopsCommands::Process) => process_queue(),
         Some(LoopsCommands::MergeButtonState(args)) => get_merge_button_state(args),
@@ -982,7 +1037,7 @@ fn show_diff(args: DiffArgs) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let (loop_id, _worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
 
-    let branch = format!("ralph/{}", loop_id);
+    let branch = loop_branch(&loop_id);
 
     // Check that branch exists.
     if !git_ref_exists(&cwd, &branch) {
@@ -1019,25 +1074,453 @@ fn show_diff(args: DiffArgs) -> Result<()> {
     Ok(())
 }
 
-fn default_diff_base_branch(cwd: &std::path::Path) -> String {
-    if let Some(output) = git_output(
-        cwd,
-        ["symbolic-ref", "-q", "--short", "refs/remotes/origin/HEAD"],
-    ) {
-        let value = output.trim();
-        if let Some(base) = value.split('/').next_back() {
-            let direct = base.to_string();
-            let with_remote = format!("origin/{}", direct);
-            if git_ref_exists(cwd, &direct) {
-                return direct;
-            }
-            if git_ref_exists(cwd, &with_remote) {
-                return with_remote;
+/// Push a loop branch for remote review and write a local summary artifact.
+fn publish_review(args: PublishReviewArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let (loop_id, worktree_path) = resolve_loop(&cwd, &args.loop_id)?;
+    ensure_loop_not_running(&cwd, &loop_id)?;
+
+    let branch = loop_branch(&loop_id);
+    if !git_ref_exists(&cwd, &branch) {
+        bail!("Branch '{}' not found", branch);
+    }
+
+    let base_branch = args
+        .base
+        .unwrap_or_else(|| default_review_base_branch(&cwd, &args.remote));
+    if !git_ref_exists(&cwd, &base_branch) {
+        bail!(
+            "Base branch '{}' not found in this repository. Pass --base <ref> to select a review base.",
+            base_branch
+        );
+    }
+
+    let remote_branch = args
+        .remote_branch
+        .as_deref()
+        .map(normalize_remote_branch)
+        .unwrap_or_else(|| branch.clone());
+    let summary_path = args
+        .summary
+        .unwrap_or_else(|| PathBuf::from(format!(".ralph/reviews/{loop_id}.md")));
+    let summary_path = absolutize(&cwd, summary_path);
+
+    push_branch_for_review(&cwd, &args.remote, &branch, &remote_branch)?;
+    write_review_summary(
+        &cwd,
+        &loop_id,
+        &branch,
+        &args.remote,
+        &remote_branch,
+        &base_branch,
+        worktree_path.as_deref().map(Path::new),
+        &summary_path,
+    )?;
+
+    println!(
+        "Published loop '{}' for review: {}/{}",
+        loop_id, args.remote, remote_branch
+    );
+    println!("Review summary: {}", summary_path.display());
+    Ok(())
+}
+
+/// Rebase one or more reviewable loop branches without merging them into the base branch.
+fn rebase_loops(args: RebaseArgs) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+
+    if !args.no_fetch {
+        fetch_remote(&cwd, &args.remote)?;
+    }
+
+    let base_branch = args
+        .base
+        .unwrap_or_else(|| default_review_base_branch(&cwd, &args.remote));
+    if !git_ref_exists(&cwd, &base_branch) {
+        bail!(
+            "Base branch '{}' not found in this repository. Pass --base <ref> or fetch the remote first.",
+            base_branch
+        );
+    }
+
+    let targets = if let Some(loop_id) = args.loop_id.as_deref() {
+        vec![reviewable_loop_for_id(&cwd, loop_id)?]
+    } else {
+        collect_reviewable_loops(&cwd)?
+    };
+
+    if targets.is_empty() {
+        println!("No reviewable loop branches found.");
+        return Ok(());
+    }
+
+    for target in &targets {
+        ensure_loop_not_running(&cwd, &target.loop_id)?;
+        rebase_loop_branch(&cwd, target, &base_branch)?;
+        if args.push {
+            push_rebased_branch(&cwd, &args.remote, &target.branch)?;
+        }
+    }
+
+    println!(
+        "Rebased {} loop branch(es) onto {}.",
+        targets.len(),
+        base_branch
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct ReviewableLoop {
+    loop_id: String,
+    branch: String,
+    worktree_path: Option<PathBuf>,
+}
+
+fn reviewable_loop_for_id(cwd: &Path, id: &str) -> Result<ReviewableLoop> {
+    let (loop_id, worktree_path) = resolve_loop(cwd, id)?;
+    let branch = loop_branch(&loop_id);
+    if !git_ref_exists(cwd, &branch) {
+        bail!("Branch '{}' not found", branch);
+    }
+
+    Ok(ReviewableLoop {
+        loop_id,
+        branch,
+        worktree_path: worktree_path.map(PathBuf::from),
+    })
+}
+
+fn collect_reviewable_loops(cwd: &Path) -> Result<Vec<ReviewableLoop>> {
+    let mut targets = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    let queue = MergeQueue::new(cwd);
+    if let Ok(entries) = queue.list() {
+        for entry in entries {
+            if matches!(entry.state, MergeState::Queued | MergeState::NeedsReview) {
+                let worktree_path = find_loop_worktree_path(cwd, &entry.loop_id);
+                add_reviewable_loop(cwd, &entry.loop_id, worktree_path, &mut targets, &mut seen);
             }
         }
     }
 
-    for candidate in ["origin/main", "main", "origin/master", "master"] {
+    let active_loop_ids: BTreeSet<String> = LoopRegistry::new(cwd)
+        .list()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|entry| entry.is_alive())
+        .map(|entry| entry.id)
+        .collect();
+
+    for worktree in list_ralph_worktrees(cwd).unwrap_or_default() {
+        if !worktree.branch.starts_with("ralph/") {
+            continue;
+        }
+
+        let loop_id = worktree.branch.trim_start_matches("ralph/");
+        if active_loop_ids.contains(loop_id) {
+            continue;
+        }
+
+        add_reviewable_loop(cwd, loop_id, Some(worktree.path), &mut targets, &mut seen);
+    }
+
+    Ok(targets)
+}
+
+fn find_loop_worktree_path(cwd: &Path, loop_id: &str) -> Option<PathBuf> {
+    let branch = loop_branch(loop_id);
+    list_ralph_worktrees(cwd)
+        .ok()?
+        .into_iter()
+        .find_map(|worktree| (worktree.branch == branch).then_some(worktree.path))
+}
+
+fn find_loop_worktree_path_string(cwd: &Path, loop_id: &str) -> Option<String> {
+    find_loop_worktree_path(cwd, loop_id).map(|path| path.to_string_lossy().to_string())
+}
+
+fn add_reviewable_loop(
+    cwd: &Path,
+    loop_id: &str,
+    worktree_path: Option<PathBuf>,
+    targets: &mut Vec<ReviewableLoop>,
+    seen: &mut BTreeSet<String>,
+) {
+    if !seen.insert(loop_id.to_string()) {
+        return;
+    }
+
+    let branch = loop_branch(loop_id);
+    if !git_ref_exists(cwd, &branch) {
+        return;
+    }
+
+    targets.push(ReviewableLoop {
+        loop_id: loop_id.to_string(),
+        branch,
+        worktree_path,
+    });
+}
+
+fn rebase_loop_branch(cwd: &Path, target: &ReviewableLoop, base_branch: &str) -> Result<()> {
+    println!(
+        "Rebasing loop '{}' ({}) onto {}...",
+        target.loop_id, target.branch, base_branch
+    );
+
+    if let Some(worktree_path) = &target.worktree_path {
+        let checked_out = current_branch(worktree_path);
+        if checked_out.as_deref() != Some(target.branch.as_str()) {
+            let actual = checked_out.unwrap_or_else(|| "<detached-or-unknown>".to_string());
+            bail!(
+                "Refusing to rebase loop '{}' in worktree {}: expected branch {}, found {}.",
+                target.loop_id,
+                worktree_path.display(),
+                target.branch,
+                actual
+            );
+        }
+
+        run_git_checked(
+            worktree_path,
+            &["rebase", base_branch],
+            &format!(
+                "Failed to rebase loop '{}' in worktree {}",
+                target.loop_id,
+                worktree_path.display()
+            ),
+        )
+    } else if current_branch(cwd).as_deref() == Some(target.branch.as_str()) {
+        run_git_checked(
+            cwd,
+            &["rebase", base_branch],
+            &format!("Failed to rebase loop '{}'", target.loop_id),
+        )
+    } else {
+        let rebase_root = cwd.join(".worktrees").join(".rebase");
+        std::fs::create_dir_all(&rebase_root)
+            .with_context(|| format!("Failed to create {}", rebase_root.display()))?;
+        let temp = tempfile::Builder::new()
+            .prefix(&format!("{}-", target.loop_id))
+            .tempdir_in(&rebase_root)
+            .context("Failed to create temporary rebase worktree directory")?;
+        let temp_path = temp.keep();
+        let temp_path_arg = temp_path.to_string_lossy().to_string();
+        run_git_checked(
+            cwd,
+            &["worktree", "add", &temp_path_arg, &target.branch],
+            &format!(
+                "Failed to create temporary worktree for loop '{}'",
+                target.loop_id
+            ),
+        )?;
+        if let Err(err) = run_git_checked(
+            &temp_path,
+            &["rebase", base_branch],
+            &format!("Failed to rebase loop '{}'", target.loop_id),
+        ) {
+            bail!(
+                "{err}\nTemporary rebase worktree left at {}. Resolve with `git rebase --continue` there or abort with `git rebase --abort`.",
+                temp_path.display()
+            );
+        }
+        run_git_checked(
+            cwd,
+            &["worktree", "remove", "--force", &temp_path_arg],
+            &format!(
+                "Failed to remove temporary worktree for loop '{}'",
+                target.loop_id
+            ),
+        )?;
+        Ok(())
+    }
+}
+
+fn fetch_remote(cwd: &Path, remote: &str) -> Result<()> {
+    if !git_remote_exists(cwd, remote) {
+        bail!(
+            "Remote '{}' not found. Pass --no-fetch for local-only rebase or --remote <name>.",
+            remote
+        );
+    }
+
+    run_git_checked(
+        cwd,
+        &["fetch", remote],
+        &format!("Failed to fetch remote '{}'", remote),
+    )
+}
+
+fn push_branch_for_review(
+    cwd: &Path,
+    remote: &str,
+    branch: &str,
+    remote_branch: &str,
+) -> Result<()> {
+    if !git_remote_exists(cwd, remote) {
+        bail!("Remote '{}' not found", remote);
+    }
+
+    let refspec = format!("{branch}:refs/heads/{remote_branch}");
+    run_git_checked(
+        cwd,
+        &["push", "--set-upstream", remote, &refspec],
+        &format!("Failed to push branch '{}' to remote '{}'", branch, remote),
+    )
+}
+
+fn push_rebased_branch(cwd: &Path, remote: &str, branch: &str) -> Result<()> {
+    if !git_remote_exists(cwd, remote) {
+        bail!("Remote '{}' not found", remote);
+    }
+
+    let remote_branch = rebased_push_remote_branch(cwd, remote, branch);
+    let refspec = format!("{branch}:refs/heads/{remote_branch}");
+    run_git_checked(
+        cwd,
+        &["push", "--force-with-lease", remote, &refspec],
+        &format!(
+            "Failed to push rebased branch '{}' to remote '{}/{}'",
+            branch, remote, remote_branch
+        ),
+    )
+}
+
+fn rebased_push_remote_branch(cwd: &Path, remote: &str, branch: &str) -> String {
+    let remote_key = format!("branch.{branch}.remote");
+    let merge_key = format!("branch.{branch}.merge");
+    let upstream_remote = git_output(cwd, &["config", "--get", &remote_key])
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+
+    if upstream_remote.as_deref() == Some(remote)
+        && let Some(merge_ref) = git_output(cwd, &["config", "--get", &merge_key])
+    {
+        let merge_ref = merge_ref.trim();
+        if let Some(remote_branch) = merge_ref.strip_prefix("refs/heads/") {
+            return normalize_remote_branch(remote_branch);
+        }
+    }
+
+    branch.to_string()
+}
+
+fn write_review_summary(
+    cwd: &Path,
+    loop_id: &str,
+    branch: &str,
+    remote: &str,
+    remote_branch: &str,
+    base_branch: &str,
+    worktree_path: Option<&Path>,
+    summary_path: &Path,
+) -> Result<()> {
+    if let Some(parent) = summary_path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create review summary directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let range = format!("{base_branch}..{branch}");
+    let diff_range = format!("{base_branch}...{branch}");
+    let commits = git_output_checked(cwd, &["log", "--oneline", &range])
+        .unwrap_or_else(|err| format!("Unavailable: {err}\n"));
+    let diff_stat = git_output_checked(cwd, &["diff", "--stat", &diff_range])
+        .unwrap_or_else(|err| format!("Unavailable: {err}\n"));
+    let head = git_output_checked(cwd, &["rev-parse", "--short", branch])
+        .unwrap_or_else(|_| "unknown\n".to_string());
+    let handoff_path = worktree_path
+        .map(|path| path.join(".ralph/agent/handoff.md"))
+        .filter(|path| path.exists());
+    let loop_summary_path = worktree_path
+        .map(|path| path.join(".ralph/agent/summary.md"))
+        .filter(|path| path.exists());
+
+    let mut content = String::new();
+    content.push_str(&format!("# Remote Review: {loop_id}\n\n"));
+    content.push_str(&format!(
+        "- **Local branch:** `{branch}`\n- **Remote branch:** `{remote}/{remote_branch}`\n- **Base:** `{base_branch}`\n- **HEAD:** `{}`\n- **Published:** `{}`\n",
+        head.trim(),
+        chrono::Utc::now().to_rfc3339()
+    ));
+    if let Some(path) = worktree_path {
+        content.push_str(&format!("- **Worktree:** `{}`\n", path.display()));
+    }
+    if let Some(path) = handoff_path {
+        content.push_str(&format!("- **Handoff:** `{}`\n", path.display()));
+    }
+    if let Some(path) = loop_summary_path {
+        content.push_str(&format!("- **Loop summary:** `{}`\n", path.display()));
+    }
+
+    content.push_str("\n## Review Commands\n\n");
+    content.push_str("```bash\n");
+    content.push_str(&format!("git fetch {remote}\n"));
+    content.push_str(&format!(
+        "git diff {base_branch}...{remote}/{remote_branch}\n"
+    ));
+    content.push_str(&format!(
+        "git log --oneline {base_branch}..{remote}/{remote_branch}\n"
+    ));
+    content.push_str("```\n\n");
+
+    content.push_str("## Commits\n\n");
+    if commits.trim().is_empty() {
+        content.push_str("_No commits beyond the selected base._\n");
+    } else {
+        content.push_str("```text\n");
+        content.push_str(commits.trim_end());
+        content.push_str("\n```\n");
+    }
+
+    content.push_str("\n## Changed Files\n\n");
+    if diff_stat.trim().is_empty() {
+        content.push_str("_No diff from the selected base._\n");
+    } else {
+        content.push_str("```text\n");
+        content.push_str(diff_stat.trim_end());
+        content.push_str("\n```\n");
+    }
+
+    std::fs::write(summary_path, content)
+        .with_context(|| format!("Failed to write review summary {}", summary_path.display()))
+}
+
+fn default_diff_base_branch(cwd: &std::path::Path) -> String {
+    default_review_base_branch(cwd, "origin")
+}
+
+fn default_review_base_branch(cwd: &std::path::Path, remote: &str) -> String {
+    let remote_head = format!("refs/remotes/{remote}/HEAD");
+    if let Some(output) = git_output(cwd, &["symbolic-ref", "-q", "--short", &remote_head]) {
+        let value = output.trim();
+        if git_ref_exists(cwd, value) {
+            return value.to_string();
+        }
+        if let Some(base) = value.split('/').next_back() {
+            let with_remote = format!("{remote}/{base}");
+            if git_ref_exists(cwd, &with_remote) {
+                return with_remote;
+            }
+            if git_ref_exists(cwd, base) {
+                return base.to_string();
+            }
+        }
+    }
+
+    let remote_main = format!("{remote}/main");
+    let remote_master = format!("{remote}/master");
+    for candidate in [
+        remote_main.as_str(),
+        "main",
+        remote_master.as_str(),
+        "master",
+    ] {
         if git_ref_exists(cwd, candidate) {
             return candidate.to_string();
         }
@@ -1050,11 +1533,27 @@ fn git_ref_exists(cwd: &std::path::Path, reference: &str) -> bool {
     Command::new("git")
         .args(["rev-parse", "--verify", "--quiet", reference])
         .current_dir(cwd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
         .status()
         .is_ok_and(|status| status.success())
 }
 
-fn git_output(cwd: &std::path::Path, args: [&str; 4]) -> Option<String> {
+fn git_remote_exists(cwd: &std::path::Path, remote: &str) -> bool {
+    Command::new("git")
+        .args(["remote", "get-url", remote])
+        .current_dir(cwd)
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn current_branch(cwd: &std::path::Path) -> Option<String> {
+    git_output(cwd, &["branch", "--show-current"])
+        .map(|output| output.trim().to_string())
+        .filter(|branch| !branch.is_empty())
+}
+
+fn git_output(cwd: &std::path::Path, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(cwd)
@@ -1066,6 +1565,71 @@ fn git_output(cwd: &std::path::Path, args: [&str; 4]) -> Option<String> {
     } else {
         None
     }
+}
+
+fn git_output_checked(cwd: &std::path::Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .with_context(|| format!("Failed to run git {}", args.join(" ")))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git {} failed: {}", args.join(" "), stderr.trim());
+    }
+}
+
+fn run_git_checked(cwd: &std::path::Path, args: &[&str], context: &str) -> Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .with_context(|| format!("{}: failed to run git {}", context, args.join(" ")))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = if stderr.trim().is_empty() {
+        stdout.trim()
+    } else {
+        stderr.trim()
+    };
+    bail!("{}: {}", context, detail);
+}
+
+fn loop_branch(loop_id: &str) -> String {
+    format!("ralph/{loop_id}")
+}
+
+fn normalize_remote_branch(branch: &str) -> String {
+    branch
+        .strip_prefix("refs/heads/")
+        .unwrap_or(branch)
+        .to_string()
+}
+
+fn absolutize(cwd: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn ensure_loop_not_running(cwd: &Path, loop_id: &str) -> Result<()> {
+    if let Ok(Some(entry)) = LoopRegistry::new(cwd).get(loop_id)
+        && entry.is_alive()
+    {
+        bail!("Loop '{}' is still running. Stop it first.", loop_id);
+    }
+
+    Ok(())
 }
 
 fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
@@ -1215,6 +1779,11 @@ fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<Strin
         return Ok((entry.id, entry.worktree_path));
     }
 
+    let exact_branch = loop_branch(id);
+    if git_ref_exists(cwd, &exact_branch) {
+        return Ok((id.to_string(), find_loop_worktree_path_string(cwd, id)));
+    }
+
     // Try partial match (e.g., "a3f2" matches "ralph-20250124-143052-a3f2")
     if let Ok(entries) = registry.list() {
         for entry in entries {
@@ -1226,31 +1795,29 @@ fn resolve_loop(cwd: &std::path::Path, id: &str) -> Result<(String, Option<Strin
 
     // Try merge queue
     if let Ok(Some(entry)) = merge_queue.get_entry(id) {
-        // Look up worktree from worktrees list
-        let worktrees = list_ralph_worktrees(cwd).unwrap_or_default();
-        let wt_path = worktrees
-            .iter()
-            .find(|wt| wt.branch.ends_with(&entry.loop_id))
-            .map(|wt| wt.path.to_string_lossy().to_string());
-
-        return Ok((entry.loop_id, wt_path));
+        return Ok((
+            entry.loop_id.clone(),
+            find_loop_worktree_path_string(cwd, &entry.loop_id),
+        ));
     }
 
     // Try partial match in merge queue
     if let Ok(entries) = merge_queue.list() {
         for entry in entries {
             if entry.loop_id.ends_with(id) || entry.loop_id.contains(id) {
-                let worktrees = list_ralph_worktrees(cwd).unwrap_or_default();
-                let wt_path = worktrees
-                    .iter()
-                    .find(|wt| wt.branch.ends_with(&entry.loop_id))
-                    .map(|wt| wt.path.to_string_lossy().to_string());
-                return Ok((entry.loop_id, wt_path));
+                return Ok((
+                    entry.loop_id.clone(),
+                    find_loop_worktree_path_string(cwd, &entry.loop_id),
+                ));
             }
         }
     }
 
     // Try worktrees directly
+    if let Some(path) = find_loop_worktree_path_string(cwd, id) {
+        return Ok((id.to_string(), Some(path)));
+    }
+
     let worktrees = list_ralph_worktrees(cwd).unwrap_or_default();
     for wt in worktrees {
         if wt.branch.ends_with(id) || wt.branch.contains(id) {

--- a/crates/ralph-cli/tests/integration_loops_remote_review.rs
+++ b/crates/ralph-cli/tests/integration_loops_remote_review.rs
@@ -1,0 +1,539 @@
+//! Integration tests for remote review and rebase loop workflows.
+
+use anyhow::{Context, Result, bail};
+use ralph_core::MergeQueue;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn git(path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .with_context(|| format!("git {}", args.join(" ")))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+fn git_succeeds(path: &Path, args: &[&str]) -> Result<bool> {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .status()
+        .with_context(|| format!("git {}", args.join(" ")))?;
+
+    Ok(status.success())
+}
+
+fn ralph_loops(path: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new(env!("CARGO_BIN_EXE_ralph"))
+        .arg("loops")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .with_context(|| format!("ralph loops {}", args.join(" ")))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        bail!(
+            "ralph loops {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+fn setup_repo_with_remote() -> Result<(TempDir, TempDir)> {
+    let remote = TempDir::new()?;
+    git(remote.path(), &["init", "--bare", "--initial-branch=main"])?;
+
+    let repo = TempDir::new()?;
+    git(repo.path(), &["init", "--initial-branch=main"])?;
+    git(repo.path(), &["config", "user.email", "test@example.com"])?;
+    git(repo.path(), &["config", "user.name", "Test User"])?;
+
+    fs::write(repo.path().join("README.md"), "# Test\n")?;
+    fs::write(repo.path().join(".gitignore"), ".worktrees/\n.ralph/\n")?;
+    git(repo.path(), &["add", "README.md", ".gitignore"])?;
+    git(repo.path(), &["commit", "-m", "Initial commit"])?;
+    git(
+        repo.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            &remote.path().display().to_string(),
+        ],
+    )?;
+    git(repo.path(), &["push", "-u", "origin", "main"])?;
+
+    Ok((repo, remote))
+}
+
+fn create_loop_worktree(repo: &Path, loop_id: &str) -> Result<std::path::PathBuf> {
+    let worktree = repo.join(".worktrees").join(loop_id);
+    fs::create_dir_all(repo.join(".worktrees"))?;
+    let branch = format!("ralph/{loop_id}");
+    git(
+        repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &branch,
+            &worktree.display().to_string(),
+        ],
+    )?;
+    git(&worktree, &["config", "user.email", "test@example.com"])?;
+    git(&worktree, &["config", "user.name", "Test User"])?;
+    Ok(worktree)
+}
+
+#[test]
+fn publish_review_pushes_loop_branch_and_writes_summary() -> Result<()> {
+    let (repo, remote) = setup_repo_with_remote()?;
+    let loop_id = "review-loop-001";
+    let worktree = create_loop_worktree(repo.path(), loop_id)?;
+
+    fs::write(worktree.join("feature.txt"), "ready for review\n")?;
+    fs::create_dir_all(worktree.join(".ralph/agent"))?;
+    fs::write(
+        worktree.join(".ralph/agent/handoff.md"),
+        "# Session Handoff\n",
+    )?;
+    git(&worktree, &["add", "feature.txt"])?;
+    git(&worktree, &["commit", "-m", "Add review feature"])?;
+
+    let summary_path = repo.path().join(".ralph/reviews/review-loop-001.md");
+    let summary_arg = summary_path.display().to_string();
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &[
+            "publish-review",
+            loop_id,
+            "--remote",
+            "origin",
+            "--base",
+            "origin/main",
+            "--summary",
+            &summary_arg,
+        ],
+    )?;
+
+    assert!(
+        stdout.contains("Published loop 'review-loop-001'"),
+        "unexpected stdout: {stdout}"
+    );
+
+    let remote_refs = git(
+        remote.path(),
+        &["show-ref", "--verify", "refs/heads/ralph/review-loop-001"],
+    )?;
+    assert!(
+        remote_refs.contains("refs/heads/ralph/review-loop-001"),
+        "remote branch was not pushed: {remote_refs}"
+    );
+
+    let summary = fs::read_to_string(summary_path)?;
+    assert!(summary.contains("# Remote Review: review-loop-001"));
+    assert!(summary.contains("origin/ralph/review-loop-001"));
+    assert!(summary.contains("Add review feature"));
+    assert!(summary.contains("feature.txt"));
+    assert!(summary.contains("handoff.md"));
+
+    Ok(())
+}
+
+#[test]
+fn rebase_loop_updates_branch_without_merging_to_main() -> Result<()> {
+    let (repo, _remote) = setup_repo_with_remote()?;
+    let loop_id = "rebase-loop-001";
+    let worktree = create_loop_worktree(repo.path(), loop_id)?;
+
+    fs::write(worktree.join("loop.txt"), "loop change\n")?;
+    git(&worktree, &["add", "loop.txt"])?;
+    git(&worktree, &["commit", "-m", "Add loop change"])?;
+
+    fs::write(repo.path().join("base.txt"), "base change\n")?;
+    git(repo.path(), &["add", "base.txt"])?;
+    git(repo.path(), &["commit", "-m", "Advance base"])?;
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &["rebase", loop_id, "--base", "main", "--no-fetch"],
+    )?;
+
+    assert!(
+        stdout.contains("Rebased 1 loop branch(es) onto main."),
+        "unexpected stdout: {stdout}"
+    );
+
+    git(
+        repo.path(),
+        &[
+            "merge-base",
+            "--is-ancestor",
+            "main",
+            "ralph/rebase-loop-001",
+        ],
+    )?;
+    assert!(
+        !repo.path().join("loop.txt").exists(),
+        "rebase must not merge loop changes into main"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rebase_without_loop_id_rebases_queued_worktree_branch() -> Result<()> {
+    let (repo, _remote) = setup_repo_with_remote()?;
+    let loop_id = "queued-rebase-loop-001";
+    let worktree = create_loop_worktree(repo.path(), loop_id)?;
+
+    fs::write(worktree.join("queued.txt"), "queued loop change\n")?;
+    git(&worktree, &["add", "queued.txt"])?;
+    git(&worktree, &["commit", "-m", "Add queued loop change"])?;
+
+    let queue = MergeQueue::new(repo.path());
+    queue.enqueue(loop_id, "queued prompt")?;
+
+    fs::write(repo.path().join("base-queued.txt"), "base change\n")?;
+    git(repo.path(), &["add", "base-queued.txt"])?;
+    git(repo.path(), &["commit", "-m", "Advance queued base"])?;
+
+    let stdout = ralph_loops(repo.path(), &["rebase", "--base", "main", "--no-fetch"])?;
+
+    assert!(
+        stdout.contains("Rebased 1 loop branch(es) onto main."),
+        "unexpected stdout: {stdout}"
+    );
+
+    git(
+        repo.path(),
+        &[
+            "merge-base",
+            "--is-ancestor",
+            "main",
+            "ralph/queued-rebase-loop-001",
+        ],
+    )?;
+    assert!(
+        !repo.path().join("queued.txt").exists(),
+        "bulk rebase must not merge queued loop changes into main"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rebase_push_updates_custom_remote_review_branch() -> Result<()> {
+    let (repo, remote) = setup_repo_with_remote()?;
+    let loop_id = "custom-review-loop-001";
+    let branch = format!("ralph/{loop_id}");
+    let remote_branch = "reviews/custom-review-loop-001";
+    let worktree = create_loop_worktree(repo.path(), loop_id)?;
+
+    fs::write(worktree.join("custom-review.txt"), "custom review\n")?;
+    git(&worktree, &["add", "custom-review.txt"])?;
+    git(&worktree, &["commit", "-m", "Add custom review"])?;
+
+    let summary_path = repo.path().join(".ralph/reviews/custom-review-loop-001.md");
+    let summary_arg = summary_path.display().to_string();
+    ralph_loops(
+        repo.path(),
+        &[
+            "publish-review",
+            loop_id,
+            "--remote",
+            "origin",
+            "--remote-branch",
+            remote_branch,
+            "--base",
+            "origin/main",
+            "--summary",
+            &summary_arg,
+        ],
+    )?;
+    let initial_remote_head = git(
+        remote.path(),
+        &["rev-parse", "refs/heads/reviews/custom-review-loop-001"],
+    )?;
+
+    fs::write(repo.path().join("base-custom-review.txt"), "base change\n")?;
+    git(repo.path(), &["add", "base-custom-review.txt"])?;
+    git(repo.path(), &["commit", "-m", "Advance custom-review base"])?;
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &[
+            "rebase",
+            loop_id,
+            "--base",
+            "main",
+            "--no-fetch",
+            "--push",
+            "--remote",
+            "origin",
+        ],
+    )?;
+
+    assert!(
+        stdout.contains("Rebased 1 loop branch(es) onto main."),
+        "unexpected stdout: {stdout}"
+    );
+    let local_head = git(repo.path(), &["rev-parse", &branch])?;
+    let custom_remote_head = git(
+        remote.path(),
+        &["rev-parse", "refs/heads/reviews/custom-review-loop-001"],
+    )?;
+    assert_eq!(custom_remote_head.trim(), local_head.trim());
+    assert_ne!(custom_remote_head.trim(), initial_remote_head.trim());
+    assert!(
+        !git_succeeds(
+            remote.path(),
+            &[
+                "show-ref",
+                "--verify",
+                "refs/heads/ralph/custom-review-loop-001",
+            ],
+        )?,
+        "rebase --push must not create the default remote branch when a custom review branch is configured"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rebase_branch_without_worktree_preserves_current_checkout() -> Result<()> {
+    let (repo, _remote) = setup_repo_with_remote()?;
+    let loop_id = "branch-only-rebase-loop-001";
+    let branch = format!("ralph/{loop_id}");
+
+    git(repo.path(), &["checkout", "-b", &branch])?;
+    fs::write(
+        repo.path().join("branch-only.txt"),
+        "branch-only loop change\n",
+    )?;
+    git(repo.path(), &["add", "branch-only.txt"])?;
+    git(
+        repo.path(),
+        &["commit", "-m", "Add branch-only loop change"],
+    )?;
+    git(repo.path(), &["checkout", "main"])?;
+
+    let queue = MergeQueue::new(repo.path());
+    queue.enqueue(loop_id, "branch-only prompt")?;
+
+    fs::write(repo.path().join("base-branch-only.txt"), "base change\n")?;
+    git(repo.path(), &["add", "base-branch-only.txt"])?;
+    git(repo.path(), &["commit", "-m", "Advance branch-only base"])?;
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &["rebase", loop_id, "--base", "main", "--no-fetch"],
+    )?;
+
+    assert!(
+        stdout.contains("Rebased 1 loop branch(es) onto main."),
+        "unexpected stdout: {stdout}"
+    );
+    git(
+        repo.path(),
+        &["merge-base", "--is-ancestor", "main", &branch],
+    )?;
+    assert_eq!(
+        git(repo.path(), &["branch", "--show-current"])?.trim(),
+        "main"
+    );
+    assert!(
+        !repo.path().join("branch-only.txt").exists(),
+        "branch-only rebase must not switch or merge into main"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rebase_branch_without_worktree_does_not_suffix_match_another_worktree() -> Result<()> {
+    let (repo, _remote) = setup_repo_with_remote()?;
+
+    let branch_only_loop = "loop";
+    let branch_only_branch = format!("ralph/{branch_only_loop}");
+    git(repo.path(), &["checkout", "-b", &branch_only_branch])?;
+    fs::write(repo.path().join("branch-only-loop.txt"), "branch loop\n")?;
+    git(repo.path(), &["add", "branch-only-loop.txt"])?;
+    git(repo.path(), &["commit", "-m", "Add branch-only loop"])?;
+    git(repo.path(), &["checkout", "main"])?;
+
+    let other_loop = "other-loop";
+    let other_worktree = create_loop_worktree(repo.path(), other_loop)?;
+    fs::write(other_worktree.join("other-loop.txt"), "other loop\n")?;
+    git(&other_worktree, &["add", "other-loop.txt"])?;
+    git(&other_worktree, &["commit", "-m", "Add other loop"])?;
+
+    let queue = MergeQueue::new(repo.path());
+    queue.enqueue(branch_only_loop, "branch-only prompt")?;
+
+    fs::write(repo.path().join("base-suffix.txt"), "base change\n")?;
+    git(repo.path(), &["add", "base-suffix.txt"])?;
+    git(repo.path(), &["commit", "-m", "Advance suffix base"])?;
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &["rebase", branch_only_loop, "--base", "main", "--no-fetch"],
+    )?;
+
+    assert!(
+        stdout.contains("Rebased 1 loop branch(es) onto main."),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        git_succeeds(
+            repo.path(),
+            &["merge-base", "--is-ancestor", "main", &branch_only_branch],
+        )?,
+        "requested branch-only loop should be rebased"
+    );
+    assert!(
+        !git_succeeds(
+            repo.path(),
+            &["merge-base", "--is-ancestor", "main", "ralph/other-loop"],
+        )?,
+        "suffix-matching worktree branch must not be rebased"
+    );
+    assert_eq!(
+        git(repo.path(), &["branch", "--show-current"])?.trim(),
+        "main"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rebase_explicit_branch_without_queue_does_not_suffix_match_another_worktree() -> Result<()> {
+    let (repo, _remote) = setup_repo_with_remote()?;
+
+    let branch_only_loop = "loop";
+    let branch_only_branch = format!("ralph/{branch_only_loop}");
+    git(repo.path(), &["checkout", "-b", &branch_only_branch])?;
+    fs::write(repo.path().join("branch-only-loop.txt"), "branch loop\n")?;
+    git(repo.path(), &["add", "branch-only-loop.txt"])?;
+    git(repo.path(), &["commit", "-m", "Add branch-only loop"])?;
+    git(repo.path(), &["checkout", "main"])?;
+
+    let other_worktree = create_loop_worktree(repo.path(), "other-loop")?;
+    fs::write(other_worktree.join("other-loop.txt"), "other loop\n")?;
+    git(&other_worktree, &["add", "other-loop.txt"])?;
+    git(&other_worktree, &["commit", "-m", "Add other loop"])?;
+
+    fs::write(repo.path().join("base-no-queue.txt"), "base change\n")?;
+    git(repo.path(), &["add", "base-no-queue.txt"])?;
+    git(repo.path(), &["commit", "-m", "Advance base without queue"])?;
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &["rebase", branch_only_loop, "--base", "main", "--no-fetch"],
+    )?;
+
+    assert!(
+        stdout.contains("Rebased 1 loop branch(es) onto main."),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        git_succeeds(
+            repo.path(),
+            &["merge-base", "--is-ancestor", "main", &branch_only_branch],
+        )?,
+        "requested branch-only loop should be rebased"
+    );
+    assert!(
+        !git_succeeds(
+            repo.path(),
+            &["merge-base", "--is-ancestor", "main", "ralph/other-loop"],
+        )?,
+        "suffix-matching worktree branch must not be rebased"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn publish_review_explicit_branch_without_queue_does_not_suffix_match_another_worktree()
+-> Result<()> {
+    let (repo, remote) = setup_repo_with_remote()?;
+
+    let branch_only_loop = "loop";
+    let branch_only_branch = format!("ralph/{branch_only_loop}");
+    git(repo.path(), &["checkout", "-b", &branch_only_branch])?;
+    fs::write(
+        repo.path().join("branch-only-review.txt"),
+        "branch review\n",
+    )?;
+    git(repo.path(), &["add", "branch-only-review.txt"])?;
+    git(repo.path(), &["commit", "-m", "Add branch-only review"])?;
+    git(repo.path(), &["checkout", "main"])?;
+
+    let other_worktree = create_loop_worktree(repo.path(), "other-loop")?;
+    fs::write(other_worktree.join("other-review.txt"), "other review\n")?;
+    git(&other_worktree, &["add", "other-review.txt"])?;
+    git(&other_worktree, &["commit", "-m", "Add other review"])?;
+
+    let summary_path = repo.path().join(".ralph/reviews/loop.md");
+    let summary_arg = summary_path.display().to_string();
+
+    let stdout = ralph_loops(
+        repo.path(),
+        &[
+            "publish-review",
+            branch_only_loop,
+            "--remote",
+            "origin",
+            "--base",
+            "origin/main",
+            "--summary",
+            &summary_arg,
+        ],
+    )?;
+
+    assert!(
+        stdout.contains("Published loop 'loop'"),
+        "unexpected stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("other-loop"),
+        "publish-review must not select suffix-matching worktree: {stdout}"
+    );
+
+    let remote_refs = git(
+        remote.path(),
+        &["show-ref", "--verify", "refs/heads/ralph/loop"],
+    )?;
+    assert!(
+        remote_refs.contains("refs/heads/ralph/loop"),
+        "requested branch was not pushed: {remote_refs}"
+    );
+    assert!(
+        git(remote.path(), &["show-ref"]).map_or(true, |refs| !refs.contains("other-loop")),
+        "suffix-matching branch must not be pushed"
+    );
+
+    let summary = fs::read_to_string(summary_path)?;
+    assert!(summary.contains("# Remote Review: loop"));
+    assert!(summary.contains("branch-only-review.txt"));
+    assert!(!summary.contains("other-review.txt"));
+
+    Ok(())
+}

--- a/docs/advanced/parallel-loops.md
+++ b/docs/advanced/parallel-loops.md
@@ -10,7 +10,7 @@ When you start a Ralph loop:
 2. **Additional loops** automatically spawn into `.worktrees/<loop-id>/`
 3. **Each loop** has isolated events, tasks, and scratchpad
 4. **Memories are shared** — symlinked back to the main repo's `.agent/memories.md`
-5. **On completion**, worktree loops automatically spawn a merge-ralph to integrate changes
+5. **On completion**, worktree loops are preserved for manual handling by default, or queued for merge-ralph when auto-merge is enabled
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -20,7 +20,7 @@ When you start a Ralph loop:
 │           ↓                    │           ↓                       │
 │     Primary loop               │  .worktrees/ralph-20250124-a3f2/  │
 │           ↓                    │           ↓                       │
-│     LOOP_COMPLETE              │     LOOP_COMPLETE → auto-merge    │
+│     LOOP_COMPLETE              │     LOOP_COMPLETE → review/merge  │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -98,6 +98,15 @@ ralph loops history <id> --json    # Raw JSONL
 ralph loops diff <id>              # Full diff
 ralph loops diff <id> --stat       # Summary only
 
+# Push branch for remote review and write .ralph/reviews/<id>.md
+ralph loops publish-review <id> --remote origin --base origin/main
+
+# Rebase one loop branch onto an updated base without merging
+ralph loops rebase <id> --base origin/main
+
+# Rebase all queued/needs-review and non-running ralph/* worktree branches
+ralph loops rebase --base origin/main
+
 # Open shell in worktree
 ralph loops attach <id>
 
@@ -153,6 +162,31 @@ The workflow handles conflicts intelligently:
 1. **No conflicts**: Merge → Run tests → Clean up → Done
 2. **With conflicts**: Detect → AI resolves → Run tests → Clean up → Done
 3. **Unresolvable**: Abort → Mark for review → Keep worktree for manual fix
+
+## Remote Review Workflow
+
+If you want humans or external automation to review completed worktree branches without merging them into the base branch, leave auto-merge disabled and publish the loop branch:
+
+```bash
+ralph loops publish-review <loop-id> --remote origin --base origin/main
+```
+
+This pushes `ralph/<loop-id>` to the remote and writes `.ralph/reviews/<loop-id>.md` with the remote branch, base ref, commits, changed files, and any local handoff/summary artifact paths.
+
+When the central branch advances, rebase pending review branches without merging them:
+
+```bash
+# One loop
+ralph loops rebase <loop-id> --base origin/main
+
+# All reviewable loop branches
+ralph loops rebase --base origin/main
+
+# Also update the remote review branches after rewriting history
+ralph loops rebase --base origin/main --push
+```
+
+`ralph loops rebase` skips running registry entries. If a conflict occurs, Git leaves the affected worktree in rebase state for manual resolution with `git rebase --continue` or `git rebase --abort`.
 
 ## Conflict Resolution
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -295,12 +295,16 @@ ralph loops [OPTIONS] [COMMAND]
 - `prune`
 - `attach <loop-id>`
 - `diff <loop-id> [--stat]`
+- `publish-review <loop-id> [--remote <remote>] [--remote-branch <branch>] [--base <ref>] [--summary <path>]`
+- `rebase [loop-id] [--base <ref>] [--remote <remote>] [--no-fetch] [--push]`
 - `merge <loop-id> [--force]`
 - `process`
 - `merge-button-state <loop-id>`
 
 `ralph loops resume <loop-id>` writes a resume signal for suspended loops. It is idempotent:
 re-running the command reports that resume was already requested (or that the loop is not suspended).
+
+`ralph loops publish-review <loop-id>` pushes `ralph/<loop-id>` to a remote review branch and writes a local `.ralph/reviews/<loop-id>.md` summary. `ralph loops rebase` rebases one loop branch, or all queued/needs-review and non-running `ralph/*` worktree branches, onto the selected base without merging to that base.
 
 ### ralph hats
 


### PR DESCRIPTION
## Summary
- add `ralph loops publish-review <id>` to push a loop/worktree branch for remote review without merging to main
- add `ralph loops rebase [loop-id]` to refresh review branches from the default base, including branches whose worktree no longer exists
- document the remote-review workflow and add integration coverage for publish/rebase behavior

Closes #220

## Verification
- `CARGO_TARGET_DIR=/tmp/ralph-shared-target CARGO_INCREMENTAL=0 cargo test`
- `CARGO_TARGET_DIR=/tmp/ralph-shared-target CARGO_INCREMENTAL=0 cargo test -p ralph-cli --test integration_loops_remote_review -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/ralph-shared-target CARGO_INCREMENTAL=0 cargo test -p ralph-cli loops`
- `CARGO_TARGET_DIR=/tmp/ralph-shared-target CARGO_INCREMENTAL=0 cargo test -p ralph-core smoke_runner`
- `cargo fmt --all -- --check`
- `git diff --check`
