### PR TITLE
feat(robot): add file-backed web mode

### DIFF
--- a/.ralph/tasks/issue-242-web-robot.code-task.md
+++ b/.ralph/tasks/issue-242-web-robot.code-task.md
@@ -1,0 +1,24 @@
+---
+status: complete
+created: 2026-06-21
+started: 2026-06-21
+completed: 2026-06-21
+---
+# Task: Implement File-Backed Web RObot Service
+
+## Description
+Implement issue #242 by adding loop-side `RObot.mode: web` selection and a
+file-backed `WebRobotService` for API-driven human interaction.
+
+## Scope
+- Keep `telegram` as the default `RObot.mode` and preserve existing Telegram behavior.
+- Add `web` mode without requiring Telegram token configuration.
+- Write questions, responses, and check-ins via `.ralph/api/robot-question.json`,
+  `.ralph/api/robot-response.json`, and `.ralph/api/robot-checkin.json`.
+- Treat `timeout_seconds: 0` as an indefinite wait that still honors shutdown.
+- Do not implement the public `robot.*` API from issue #243.
+
+## Verification
+- Focused config and web robot service tests.
+- `cargo test -p ralph-core smoke_runner`.
+- `cargo test` if feasible.

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -41,6 +41,7 @@ use crate::display::{
 };
 use crate::process_management;
 use crate::rpc_stdin::{GuidanceMessage, RpcDispatcher, run_stdin_reader, run_stdout_emitter};
+use crate::web_robot_service::WebRobotService;
 use crate::{ColorMode, Verbosity};
 
 /// Outcome of executing a prompt via PTY or CLI executor.
@@ -5072,7 +5073,7 @@ pub async fn start_loop(
     .await
 }
 
-/// Creates a robot service (Telegram) for human-in-the-loop communication.
+/// Creates a robot service for human-in-the-loop communication.
 ///
 /// Called by `run_loop_impl` when `robot.enabled` is true and this is the primary loop.
 /// Returns `None` if the service cannot be created or started.
@@ -5081,13 +5082,27 @@ fn create_robot_service(
     context: &LoopContext,
 ) -> Option<Box<dyn ralph_proto::RobotService>> {
     let workspace_root = context.workspace().to_path_buf();
-    let bot_token = config.robot.resolve_bot_token();
-    let api_url = config.robot.resolve_api_url();
     let timeout_secs = config.robot.timeout_seconds.unwrap_or(300);
     let loop_id = context
         .loop_id()
         .map(String::from)
         .unwrap_or_else(|| "main".to_string());
+
+    if config.robot.mode.is_web() {
+        let service = WebRobotService::new(workspace_root, timeout_secs, loop_id);
+        if let Err(e) = service.start() {
+            warn!(error = %e, "Failed to start web robot service");
+            return None;
+        }
+        info!(
+            timeout_secs = service.timeout_secs(),
+            "Web robot human-in-the-loop service active"
+        );
+        return Some(Box::new(service));
+    }
+
+    let bot_token = config.robot.resolve_bot_token();
+    let api_url = config.robot.resolve_api_url();
 
     match ralph_telegram::TelegramService::new(
         workspace_root,
@@ -6427,6 +6442,29 @@ mod tests {
             "--continue without marker should fall back to generating new ID, got: {}",
             id
         );
+    }
+
+    #[test]
+    fn test_create_robot_service_uses_web_mode_without_telegram_token() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let ctx = ralph_core::LoopContext::primary(temp.path().to_path_buf());
+        let mut config = RalphConfig::default();
+        config.robot.enabled = true;
+        config.robot.mode = ralph_core::RobotMode::Web;
+        config.robot.timeout_seconds = Some(0);
+
+        let service = create_robot_service(&config, &ctx).expect("web robot service");
+        let question_id = service
+            .send_question("Need approval?")
+            .expect("send question through trait object");
+
+        assert_eq!(question_id, 1);
+        assert!(
+            temp.path().join(".ralph/api/robot-question.json").exists(),
+            "web mode should write question file"
+        );
+
+        service.stop();
     }
 
     #[test]

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -41,6 +41,7 @@ mod test_support;
 mod tools;
 mod wave;
 mod web;
+mod web_robot_service;
 
 use anyhow::{Context, Result};
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};

--- a/crates/ralph-cli/src/web_robot_service.rs
+++ b/crates/ralph-cli/src/web_robot_service.rs
@@ -1,0 +1,833 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, anyhow};
+use chrono::Utc;
+use ralph_proto::{CheckinContext, RobotService};
+use serde_json::{Map, Value, json};
+use tracing::{debug, info};
+
+/// File-backed RObot service used by `RObot.mode: web`.
+///
+/// This is intentionally loop-side only: another process can observe and write
+/// files under `.ralph/api/`, but this module does not expose HTTP routes.
+pub(crate) struct WebRobotService {
+    workspace_root: PathBuf,
+    api_dir: PathBuf,
+    timeout_secs: u64,
+    loop_id: String,
+    shutdown: Arc<AtomicBool>,
+    next_question_id: AtomicI32,
+    active_question: Mutex<Option<ActiveQuestion>>,
+}
+
+#[derive(Clone, Debug)]
+struct ActiveQuestion {
+    id: i32,
+    response_token: String,
+}
+
+enum ResponseRead {
+    Ready(String),
+    Incomplete,
+    Stale,
+    Invalid(anyhow::Error),
+}
+
+impl WebRobotService {
+    const QUESTION_FILE: &'static str = "robot-question.json";
+    const RESPONSE_FILE: &'static str = "robot-response.json";
+    const CHECKIN_FILE: &'static str = "robot-checkin.json";
+    const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+    pub(crate) fn new(workspace_root: PathBuf, timeout_secs: u64, loop_id: String) -> Self {
+        let api_dir = workspace_root.join(".ralph/api");
+        Self {
+            workspace_root,
+            api_dir,
+            timeout_secs,
+            loop_id,
+            shutdown: Arc::new(AtomicBool::new(false)),
+            next_question_id: AtomicI32::new(1),
+            active_question: Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn start(&self) -> Result<()> {
+        fs::create_dir_all(&self.api_dir)
+            .with_context(|| format!("failed to create {}", self.api_dir.display()))?;
+        info!(
+            workspace = %self.workspace_root.display(),
+            api_dir = %self.api_dir.display(),
+            timeout_secs = self.timeout_secs,
+            loop_id = %self.loop_id,
+            "Web robot service active"
+        );
+        Ok(())
+    }
+
+    pub(crate) fn timeout_secs(&self) -> u64 {
+        self.timeout_secs
+    }
+
+    fn get_active_question(&self) -> Result<Option<ActiveQuestion>> {
+        if let Some(active_question) = self
+            .active_question
+            .lock()
+            .map_err(|err| anyhow!("web robot active question lock poisoned: {err}"))?
+            .clone()
+        {
+            return Ok(Some(active_question));
+        }
+
+        let Some(active_question) = self.hydrate_active_question_from_file()? else {
+            return Ok(None);
+        };
+        self.next_question_id
+            .fetch_max(active_question.id.saturating_add(1), Ordering::Relaxed);
+        *self
+            .active_question
+            .lock()
+            .map_err(|err| anyhow!("web robot active question lock poisoned: {err}"))? =
+            Some(active_question.clone());
+        Ok(Some(active_question))
+    }
+
+    fn hydrate_active_question_from_file(&self) -> Result<Option<ActiveQuestion>> {
+        let question_path = self.question_path();
+        if !question_path.exists() {
+            return Ok(None);
+        }
+
+        let raw = fs::read_to_string(&question_path)
+            .with_context(|| format!("failed to read {}", question_path.display()))?;
+        let value: Value = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse {}", question_path.display()))?;
+        let Value::Object(map) = value else {
+            return Ok(None);
+        };
+        if Self::response_str(&map, &["loop_id"]) != Some(self.loop_id.as_str()) {
+            return Ok(None);
+        }
+        let Some(id) = Self::response_i64(&map, &["id"]) else {
+            return Ok(None);
+        };
+        let Ok(id) = i32::try_from(id) else {
+            return Ok(None);
+        };
+        let Some(response_token) = Self::response_str(&map, &["response_token", "token"]) else {
+            return Ok(None);
+        };
+
+        Ok(Some(ActiveQuestion {
+            id,
+            response_token: response_token.to_string(),
+        }))
+    }
+
+    fn question_path(&self) -> PathBuf {
+        self.api_dir.join(Self::QUESTION_FILE)
+    }
+
+    fn response_path(&self) -> PathBuf {
+        self.api_dir.join(Self::RESPONSE_FILE)
+    }
+
+    fn checkin_path(&self) -> PathBuf {
+        self.api_dir.join(Self::CHECKIN_FILE)
+    }
+
+    fn send_question(&self, payload: &str) -> Result<i32> {
+        fs::create_dir_all(&self.api_dir)
+            .with_context(|| format!("failed to create {}", self.api_dir.display()))?;
+
+        if let Some(active_question) = self.get_active_question()? {
+            info!(
+                question_id = active_question.id,
+                loop_id = %self.loop_id,
+                "Reusing existing web robot question"
+            );
+            return Ok(active_question.id);
+        }
+
+        let question_id = self.next_question_id.fetch_add(1, Ordering::Relaxed);
+        let response_token = format!(
+            "{}-{}-{}",
+            self.loop_id,
+            question_id,
+            Utc::now().timestamp_micros()
+        );
+        let payload_json = serde_json::from_str::<Value>(payload).ok();
+        let hat = payload_json
+            .as_ref()
+            .and_then(|value| {
+                Self::first_json_path(
+                    value,
+                    &[
+                        &["hat"],
+                        &["current_hat"],
+                        &["context", "hat"],
+                        &["context", "current_hat"],
+                        &["metadata", "hat"],
+                        &["metadata", "current_hat"],
+                    ],
+                )
+            })
+            .cloned()
+            .unwrap_or(Value::Null);
+        let iteration = payload_json
+            .as_ref()
+            .and_then(|value| {
+                Self::first_json_path(
+                    value,
+                    &[
+                        &["iteration"],
+                        &["context", "iteration"],
+                        &["metadata", "iteration"],
+                    ],
+                )
+            })
+            .cloned()
+            .unwrap_or(Value::Null);
+
+        let mut question = Map::new();
+        question.insert("id".to_string(), Value::from(question_id));
+        question.insert(
+            "response_token".to_string(),
+            Value::String(response_token.clone()),
+        );
+        question.insert("payload".to_string(), Value::String(payload.to_string()));
+        question.insert(
+            "payload_json".to_string(),
+            payload_json.unwrap_or(Value::Null),
+        );
+        question.insert("hat".to_string(), hat);
+        question.insert("iteration".to_string(), iteration);
+        question.insert("loop_id".to_string(), Value::String(self.loop_id.clone()));
+        question.insert(
+            "timestamp".to_string(),
+            Value::String(Utc::now().to_rfc3339()),
+        );
+        question.insert(
+            "timeout_seconds".to_string(),
+            Value::from(self.timeout_secs),
+        );
+
+        Self::write_json_atomic(&self.question_path(), &Value::Object(question))?;
+        *self
+            .active_question
+            .lock()
+            .map_err(|err| anyhow!("web robot active question lock poisoned: {err}"))? =
+            Some(ActiveQuestion {
+                id: question_id,
+                response_token,
+            });
+
+        info!(
+            question_id,
+            loop_id = %self.loop_id,
+            "Wrote web robot question"
+        );
+        Ok(question_id)
+    }
+
+    fn first_json_path<'a>(value: &'a Value, paths: &[&[&str]]) -> Option<&'a Value> {
+        paths.iter().find_map(|path| {
+            path.iter()
+                .try_fold(value, |current, key| current.get(*key))
+        })
+    }
+
+    fn wait_for_response(&self) -> Result<Option<String>> {
+        let deadline = if self.timeout_secs == 0 {
+            None
+        } else {
+            Some(Instant::now() + Duration::from_secs(self.timeout_secs))
+        };
+        let active_question = self
+            .get_active_question()?
+            .ok_or_else(|| anyhow!("no active web robot question"))?;
+
+        info!(
+            loop_id = %self.loop_id,
+            timeout_secs = self.timeout_secs,
+            response_path = %self.response_path().display(),
+            "Waiting for web robot response"
+        );
+
+        loop {
+            if let Some(response) = self.read_response_file(&active_question)? {
+                self.cleanup_question_and_response()?;
+                info!(loop_id = %self.loop_id, "Received web robot response");
+                return Ok(Some(response));
+            }
+
+            if self.shutdown.load(Ordering::Relaxed) {
+                debug!(loop_id = %self.loop_id, "Web robot wait interrupted");
+                self.cleanup_question_and_response()?;
+                return Ok(None);
+            }
+
+            if let Some(deadline) = deadline
+                && Instant::now() >= deadline
+            {
+                self.cleanup_question_and_response()?;
+                return Ok(None);
+            }
+
+            std::thread::sleep(Self::POLL_INTERVAL);
+        }
+    }
+
+    fn send_checkin(
+        &self,
+        iteration: u32,
+        elapsed: Duration,
+        context: Option<&CheckinContext>,
+    ) -> Result<i32> {
+        fs::create_dir_all(&self.api_dir)
+            .with_context(|| format!("failed to create {}", self.api_dir.display()))?;
+
+        let context_json = context.map_or(Value::Null, |ctx| {
+            json!({
+                "current_hat": ctx.current_hat,
+                "open_tasks": ctx.open_tasks,
+                "closed_tasks": ctx.closed_tasks,
+                "cumulative_cost": ctx.cumulative_cost,
+            })
+        });
+
+        let checkin = json!({
+            "iteration": iteration,
+            "elapsed_seconds": elapsed.as_secs(),
+            "elapsed_millis": elapsed.as_millis(),
+            "loop_id": self.loop_id,
+            "timestamp": Utc::now().to_rfc3339(),
+            "context": context_json,
+        });
+
+        Self::write_json_atomic(&self.checkin_path(), &checkin)?;
+        debug!(iteration, loop_id = %self.loop_id, "Wrote web robot check-in");
+        Ok(0)
+    }
+
+    fn read_response_file(&self, active_question: &ActiveQuestion) -> Result<Option<String>> {
+        let response_path = self.response_path();
+        if !response_path.exists() {
+            return Ok(None);
+        }
+
+        let raw = fs::read_to_string(&response_path)
+            .with_context(|| format!("failed to read {}", response_path.display()))?;
+        let value: Value = match serde_json::from_str(&raw) {
+            Ok(value) => value,
+            Err(err) => {
+                debug!(
+                    error = %err,
+                    response_path = %response_path.display(),
+                    "Ignoring incomplete web robot response file"
+                );
+                return Ok(None);
+            }
+        };
+        match Self::extract_correlated_response(value, active_question, &self.loop_id) {
+            ResponseRead::Ready(response) => Ok(Some(response)),
+            ResponseRead::Incomplete => {
+                debug!(
+                    response_path = %response_path.display(),
+                    question_id = active_question.id,
+                    "Ignoring incomplete web robot response file"
+                );
+                Ok(None)
+            }
+            ResponseRead::Stale => {
+                debug!(
+                    response_path = %response_path.display(),
+                    question_id = active_question.id,
+                    "Removing stale web robot response file"
+                );
+                self.remove_response_file()?;
+                Ok(None)
+            }
+            ResponseRead::Invalid(err) => {
+                debug!(
+                    error = %err,
+                    response_path = %response_path.display(),
+                    "Removing invalid web robot response file"
+                );
+                self.remove_response_file()?;
+                Ok(None)
+            }
+        }
+    }
+
+    fn extract_correlated_response(
+        value: Value,
+        active_question: &ActiveQuestion,
+        loop_id: &str,
+    ) -> ResponseRead {
+        let Value::Object(map) = value else {
+            return ResponseRead::Stale;
+        };
+
+        match Self::response_i64(&map, &["id", "question_id"]) {
+            Some(id) if id == i64::from(active_question.id) => {}
+            Some(_) => return ResponseRead::Stale,
+            None => return ResponseRead::Incomplete,
+        }
+        match Self::response_str(&map, &["loop_id"]) {
+            Some(response_loop_id) if response_loop_id == loop_id => {}
+            Some(_) => return ResponseRead::Stale,
+            None => return ResponseRead::Incomplete,
+        }
+        match Self::response_str(&map, &["response_token", "token"]) {
+            Some(token) if token == active_question.response_token.as_str() => {}
+            Some(_) => return ResponseRead::Stale,
+            None => return ResponseRead::Incomplete,
+        }
+
+        if !["response", "message", "text", "payload"]
+            .iter()
+            .any(|key| map.get(*key).is_some_and(|value| !value.is_null()))
+        {
+            return ResponseRead::Incomplete;
+        }
+
+        match Self::extract_response(Value::Object(map)) {
+            Ok(response) => ResponseRead::Ready(response),
+            Err(err) => ResponseRead::Invalid(err),
+        }
+    }
+
+    fn response_i64(map: &Map<String, Value>, keys: &[&str]) -> Option<i64> {
+        keys.iter().find_map(|key| map.get(*key)?.as_i64())
+    }
+
+    fn response_str<'a>(map: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+        keys.iter().find_map(|key| map.get(*key)?.as_str())
+    }
+
+    fn extract_response(value: Value) -> Result<String> {
+        match value {
+            Value::String(response) => Ok(response),
+            Value::Object(map) => {
+                for key in ["response", "message", "text", "payload"] {
+                    if let Some(value) = map.get(key) {
+                        return match value {
+                            Value::String(response) => Ok(response.clone()),
+                            Value::Object(_) | Value::Array(_) => Ok(value.to_string()),
+                            Value::Null => Err(anyhow!("response field '{key}' is null")),
+                            other => Ok(other.to_string()),
+                        };
+                    }
+                }
+                Err(anyhow!(
+                    "robot response must contain one of: response, message, text, payload"
+                ))
+            }
+            other => Ok(other.to_string()),
+        }
+    }
+
+    fn cleanup_question_and_response(&self) -> Result<()> {
+        self.remove_question_file()?;
+        self.remove_response_file()?;
+        *self
+            .active_question
+            .lock()
+            .map_err(|err| anyhow!("web robot active question lock poisoned: {err}"))? = None;
+        Ok(())
+    }
+
+    fn remove_question_file(&self) -> Result<()> {
+        Self::remove_file_if_exists(&self.question_path())
+    }
+
+    fn remove_response_file(&self) -> Result<()> {
+        Self::remove_file_if_exists(&self.response_path())
+    }
+
+    fn remove_file_if_exists(path: &Path) -> Result<()> {
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err).with_context(|| format!("failed to remove {}", path.display())),
+        }
+    }
+
+    fn write_json_atomic(path: &Path, value: &Value) -> Result<()> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow!("path has no parent: {}", path.display()))?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+
+        let tmp_path = path.with_extension("json.tmp");
+        let bytes = serde_json::to_vec_pretty(value)?;
+        fs::write(&tmp_path, bytes)
+            .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+        fs::rename(&tmp_path, path)
+            .with_context(|| format!("failed to replace {}", path.display()))?;
+        Ok(())
+    }
+
+    fn stop(self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        debug!(loop_id = %self.loop_id, "Web robot service stopped");
+    }
+}
+
+impl RobotService for WebRobotService {
+    fn send_question(&self, payload: &str) -> Result<i32> {
+        WebRobotService::send_question(self, payload)
+    }
+
+    fn wait_for_response(&self, events_path: &Path) -> Result<Option<String>> {
+        let _ = events_path;
+        WebRobotService::wait_for_response(self)
+    }
+
+    fn response_events_are_durable(&self) -> bool {
+        false
+    }
+
+    fn send_checkin(
+        &self,
+        iteration: u32,
+        elapsed: Duration,
+        context: Option<&CheckinContext>,
+    ) -> Result<i32> {
+        WebRobotService::send_checkin(self, iteration, elapsed, context)
+    }
+
+    fn timeout_secs(&self) -> u64 {
+        self.timeout_secs
+    }
+
+    fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        self.shutdown.clone()
+    }
+
+    fn stop(self: Box<Self>) {
+        WebRobotService::stop(*self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ralph_proto::RobotService;
+    use tempfile::TempDir;
+
+    fn service(dir: &TempDir, timeout_secs: u64) -> WebRobotService {
+        let service =
+            WebRobotService::new(dir.path().to_path_buf(), timeout_secs, "loop-1".to_string());
+        service.start().expect("start service");
+        service
+    }
+
+    fn read_json(path: &Path) -> Value {
+        serde_json::from_str(&fs::read_to_string(path).expect("read json")).expect("parse json")
+    }
+
+    fn response_path(dir: &TempDir) -> PathBuf {
+        dir.path().join(".ralph/api/robot-response.json")
+    }
+
+    fn events_path(dir: &TempDir) -> PathBuf {
+        dir.path().join(".ralph/events.jsonl")
+    }
+
+    fn correlated_response(dir: &TempDir, key: &str, value: &str) -> Value {
+        let question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
+        json!({
+            "id": question["id"],
+            "loop_id": question["loop_id"],
+            "response_token": question["response_token"],
+            key: value,
+        })
+    }
+
+    fn write_correlated_response(dir: &TempDir, key: &str, value: &str) {
+        let response = correlated_response(dir, key, value);
+        fs::write(
+            response_path(dir),
+            serde_json::to_string(&response).unwrap(),
+        )
+        .expect("write response");
+    }
+
+    #[test]
+    fn send_question_writes_question_file_and_preserves_uncorrelated_response() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 300);
+        let response_path = response_path(&dir);
+        fs::write(&response_path, r#"{"response":"already answered"}"#)
+            .expect("write uncorrelated response");
+
+        let id = service
+            .send_question(r#"{"question":"Proceed?","hat":"planner","iteration":7}"#)
+            .expect("send question");
+
+        assert_eq!(id, 1);
+        assert!(
+            response_path.exists(),
+            "preexisting response must survive send_question"
+        );
+        let question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
+        assert_eq!(question["id"], json!(1));
+        assert_eq!(question["payload_json"]["question"], json!("Proceed?"));
+        assert_eq!(question["hat"], json!("planner"));
+        assert_eq!(question["iteration"], json!(7));
+        assert_eq!(question["loop_id"], json!("loop-1"));
+        assert!(question["response_token"].as_str().is_some());
+        assert_eq!(question["timeout_seconds"], json!(300));
+        assert!(question["timestamp"].as_str().is_some());
+    }
+
+    #[test]
+    fn wait_for_response_consumes_correlated_preexisting_response() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 300);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+        write_correlated_response(&dir, "response", "approved");
+        let response_path = response_path(&dir);
+
+        let response = RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"))
+            .expect("wait for response");
+
+        assert_eq!(response, Some("approved".to_string()));
+        assert!(
+            !dir.path().join(".ralph/api/robot-question.json").exists(),
+            "question file should be removed"
+        );
+        assert!(!response_path.exists(), "response file should be removed");
+    }
+
+    #[test]
+    fn restart_reuses_existing_question_and_accepts_preexisting_response() {
+        let dir = TempDir::new().expect("temp dir");
+        let initial_service = service(&dir, 300);
+        let original_id = initial_service
+            .send_question("Need approval?")
+            .expect("send question");
+        let original_question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
+        write_correlated_response(&dir, "response", "approved while down");
+        drop(initial_service);
+
+        let restarted = service(&dir, 300);
+        let reused_id = restarted
+            .send_question("Need approval after restart?")
+            .expect("reuse question");
+        let reused_question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
+        let response =
+            RobotService::wait_for_response(&restarted, Path::new("unused-events.jsonl"))
+                .expect("wait for response");
+
+        assert_eq!(reused_id, original_id);
+        assert_eq!(
+            reused_question["response_token"],
+            original_question["response_token"]
+        );
+        assert_eq!(response, Some("approved while down".to_string()));
+        assert!(
+            !response_path(&dir).exists(),
+            "response file should be removed"
+        );
+    }
+
+    #[test]
+    fn send_question_extracts_nested_human_interact_context() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 300);
+
+        service
+            .send_question(
+                r#"{"question":"Proceed?","context":{"current_hat":"planner","iteration":7}}"#,
+            )
+            .expect("send question");
+
+        let question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
+        assert_eq!(question["payload_json"]["question"], json!("Proceed?"));
+        assert_eq!(question["hat"], json!("planner"));
+        assert_eq!(question["iteration"], json!(7));
+    }
+
+    #[test]
+    fn send_checkin_writes_checkin_file() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 300);
+        let context = CheckinContext {
+            current_hat: Some("executor".to_string()),
+            open_tasks: 2,
+            closed_tasks: 3,
+            cumulative_cost: 1.25,
+        };
+
+        service
+            .send_checkin(4, Duration::from_millis(1_234), Some(&context))
+            .expect("send checkin");
+
+        let checkin = read_json(&dir.path().join(".ralph/api/robot-checkin.json"));
+        assert_eq!(checkin["iteration"], json!(4));
+        assert_eq!(checkin["elapsed_seconds"], json!(1));
+        assert_eq!(checkin["elapsed_millis"], json!(1234));
+        assert_eq!(checkin["loop_id"], json!("loop-1"));
+        assert_eq!(checkin["context"]["current_hat"], json!("executor"));
+        assert_eq!(checkin["context"]["open_tasks"], json!(2));
+        assert_eq!(checkin["context"]["closed_tasks"], json!(3));
+        assert_eq!(checkin["context"]["cumulative_cost"], json!(1.25));
+    }
+
+    #[test]
+    fn wait_for_response_removes_stale_uncorrelated_response() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 300);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+        let response_path = response_path(&dir);
+        fs::write(
+            &response_path,
+            r#"{"id":999,"loop_id":"loop-1","response_token":"stale","response":"old"}"#,
+        )
+        .expect("write stale response");
+        let active_question = service.active_question.lock().unwrap().clone().unwrap();
+
+        let response = service
+            .read_response_file(&active_question)
+            .expect("read stale response");
+
+        assert_eq!(response, None);
+        assert!(
+            !response_path.exists(),
+            "stale response file should be removed"
+        );
+    }
+
+    #[test]
+    fn wait_for_response_times_out_and_cleans_question() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 1);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+
+        let response = RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"))
+            .expect("wait for response");
+
+        assert_eq!(response, None);
+        assert!(
+            !dir.path().join(".ralph/api/robot-question.json").exists(),
+            "question file should be removed on timeout"
+        );
+    }
+
+    #[test]
+    fn timeout_zero_waits_until_response_without_timing_out() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 0);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+        let response_path = response_path(&dir);
+        let response = correlated_response(&dir, "message", "continue");
+
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            fs::write(&response_path, serde_json::to_string(&response).unwrap())
+                .expect("write response");
+        });
+
+        let start = Instant::now();
+        let response = RobotService::wait_for_response(&service, &events_path(&dir))
+            .expect("wait for response");
+        writer.join().expect("join writer");
+
+        assert_eq!(response, Some("continue".to_string()));
+        assert!(
+            start.elapsed() >= Duration::from_millis(250),
+            "timeout_seconds=0 should not return immediately"
+        );
+    }
+
+    #[test]
+    fn timeout_zero_still_honors_shutdown() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 0);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+        service.shutdown_flag().store(true, Ordering::Relaxed);
+
+        let start = Instant::now();
+        let response = RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"))
+            .expect("wait for response");
+
+        assert_eq!(response, None);
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn wait_for_response_retries_partial_json_until_correlated_response_arrives() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 1);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+        let response_path = response_path(&dir);
+        let response = correlated_response(&dir, "response", "ready");
+        fs::write(&response_path, r#"{"response":"par"#).expect("write partial response");
+
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            fs::write(&response_path, serde_json::to_string(&response).unwrap())
+                .expect("write complete response");
+        });
+
+        let response = RobotService::wait_for_response(&service, &events_path(&dir))
+            .expect("wait for response");
+        writer.join().expect("join writer");
+
+        assert_eq!(response, Some("ready".to_string()));
+    }
+
+    #[test]
+    fn wait_for_response_retries_valid_incomplete_json_until_response_arrives() {
+        let dir = TempDir::new().expect("temp dir");
+        let service = service(&dir, 1);
+        service
+            .send_question("Need approval?")
+            .expect("send question");
+        let response_path = response_path(&dir);
+        let question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
+        let response = correlated_response(&dir, "response", "complete");
+        fs::write(
+            &response_path,
+            serde_json::to_string(&json!({
+                "id": question["id"],
+                "loop_id": question["loop_id"],
+            }))
+            .unwrap(),
+        )
+        .expect("write incomplete response");
+
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            fs::write(&response_path, serde_json::to_string(&response).unwrap())
+                .expect("write complete response");
+        });
+
+        let response = RobotService::wait_for_response(&service, &events_path(&dir))
+            .expect("wait for response");
+        writer.join().expect("join writer");
+
+        assert_eq!(response, Some("complete".to_string()));
+    }
+}

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -1973,17 +1973,41 @@ impl HatConfig {
     }
 }
 
+/// RObot communication channel.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RobotMode {
+    /// Use the Telegram-backed RObot service.
+    #[default]
+    Telegram,
+    /// Use JSON files in `.ralph/api/` for API-driven interaction.
+    Web,
+}
+
+impl RobotMode {
+    /// Returns true when the Telegram service should be used.
+    pub fn is_telegram(self) -> bool {
+        matches!(self, Self::Telegram)
+    }
+
+    /// Returns true when the file-backed web service should be used.
+    pub fn is_web(self) -> bool {
+        matches!(self, Self::Web)
+    }
+}
+
 /// RObot (Ralph-Orchestrator bot) configuration.
 ///
 /// Enables bidirectional communication between AI agents and humans
 /// during orchestration loops. When enabled, agents can emit `human.interact`
 /// events to request clarification (blocking the loop), and humans can
-/// send proactive guidance via Telegram.
+/// send proactive guidance.
 ///
 /// Example configuration:
 /// ```yaml
 /// RObot:
 ///   enabled: true
+///   mode: telegram
 ///   timeout_seconds: 300
 ///   checkin_interval_seconds: 120  # Optional: send status every 2 min
 ///   telegram:
@@ -1995,8 +2019,13 @@ pub struct RobotConfig {
     #[serde(default)]
     pub enabled: bool,
 
+    /// Communication channel to use. Defaults to Telegram for existing configs.
+    #[serde(default)]
+    pub mode: RobotMode,
+
     /// Timeout in seconds for waiting on human responses.
     /// Required when enabled (no default — must be explicit).
+    /// A value of 0 means wait indefinitely.
     pub timeout_seconds: Option<u64>,
 
     /// Interval in seconds between periodic check-in messages sent via Telegram.
@@ -2023,8 +2052,8 @@ impl RobotConfig {
             });
         }
 
-        // Bot token must be available from config, keychain, or env var
-        if self.resolve_bot_token().is_none() {
+        // Telegram mode needs a bot token from config, keychain, or env var.
+        if self.mode.is_telegram() && self.resolve_bot_token().is_none() {
             return Err(ConfigError::RobotMissingField {
                 field: "RObot.telegram.bot_token".to_string(),
                 hint: "Run `ralph bot onboard --telegram`, set RALPH_TELEGRAM_BOT_TOKEN env var, or set RObot.telegram.bot_token in config"
@@ -3511,6 +3540,7 @@ hooks:
     fn test_robot_config_defaults_disabled() {
         let config = RalphConfig::default();
         assert!(!config.robot.enabled);
+        assert_eq!(config.robot.mode, RobotMode::Telegram);
         assert!(config.robot.timeout_seconds.is_none());
         assert!(config.robot.telegram.is_none());
     }
@@ -3523,6 +3553,7 @@ agent: claude
 ";
         let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(!config.robot.enabled);
+        assert_eq!(config.robot.mode, RobotMode::Telegram);
         assert!(config.robot.timeout_seconds.is_none());
     }
 
@@ -3537,11 +3568,28 @@ RObot:
 "#;
         let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
         assert!(config.robot.enabled);
+        assert_eq!(config.robot.mode, RobotMode::Telegram);
         assert_eq!(config.robot.timeout_seconds, Some(300));
         let telegram = config.robot.telegram.as_ref().unwrap();
         assert_eq!(telegram.bot_token, Some("123456:ABC-DEF".to_string()));
 
         // Validation should pass
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_robot_config_web_mode_does_not_require_telegram() {
+        let yaml = r"
+RObot:
+  enabled: true
+  mode: web
+  timeout_seconds: 0
+";
+        let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.robot.enabled);
+        assert_eq!(config.robot.mode, RobotMode::Web);
+        assert_eq!(config.robot.timeout_seconds, Some(0));
+        assert!(config.robot.telegram.is_none());
         assert!(config.validate().is_ok());
     }
 
@@ -3582,6 +3630,7 @@ RObot:
         // Both timeout and token are missing, but timeout is checked first
         let robot = RobotConfig {
             enabled: true,
+            mode: RobotMode::Telegram,
             timeout_seconds: None,
             checkin_interval_seconds: None,
             telegram: None,
@@ -3604,6 +3653,7 @@ RObot:
         // forbid(unsafe_code) prevents env var manipulation in unit tests)
         let config = RobotConfig {
             enabled: true,
+            mode: RobotMode::Telegram,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
             telegram: Some(TelegramBotConfig {
@@ -3625,6 +3675,7 @@ RObot:
         // No config token and no telegram section
         let config = RobotConfig {
             enabled: true,
+            mode: RobotMode::Telegram,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
             telegram: None,
@@ -3643,6 +3694,7 @@ RObot:
         // Validation passes when bot_token is in config
         let robot = RobotConfig {
             enabled: true,
+            mode: RobotMode::Telegram,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
             telegram: Some(TelegramBotConfig {
@@ -3663,6 +3715,7 @@ RObot:
 
         let robot = RobotConfig {
             enabled: true,
+            mode: RobotMode::Telegram,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
             telegram: None,
@@ -3688,6 +3741,7 @@ RObot:
 
         let robot = RobotConfig {
             enabled: true,
+            mode: RobotMode::Telegram,
             timeout_seconds: Some(300),
             checkin_interval_seconds: None,
             telegram: Some(TelegramBotConfig {

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -22,7 +22,7 @@ use ralph_proto::{CheckinContext, Event, EventBus, Hat, HatId, RobotService};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
-use std::io::BufRead;
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -2506,7 +2506,7 @@ impl EventLoop {
 
         // Validate and transform events (apply backpressure for build.done)
         let mut validated_events = Vec::new();
-        let completion_topic = self.config.event_loop.completion_promise.as_str();
+        let completion_topic = self.config.event_loop.completion_promise.clone();
         let cancellation_topic = self.config.event_loop.cancellation_promise.clone();
         let total_events = events.len();
         for (index, event) in events.into_iter().enumerate() {
@@ -2523,13 +2523,13 @@ impl EventLoop {
                 continue;
             }
 
-            if event.topic == "human.guidance" {
+            if event.topic.as_str() == "human.guidance" {
                 self.state.unacknowledged_guidance.push(payload.clone());
                 validated_events.push(Event::new(event.topic.as_str(), &payload));
                 continue;
             }
 
-            if event.topic == "human.guidance.ack" {
+            if event.topic.as_str() == "human.guidance.ack" {
                 info!(
                     payload = %payload,
                     guidance_count = self.state.unacknowledged_guidance.len(),
@@ -2540,7 +2540,7 @@ impl EventLoop {
                 continue;
             }
 
-            if event.topic == completion_topic {
+            if event.topic.as_str() == completion_topic {
                 if index + 1 == total_events {
                     self.state.completion_requested = true;
                     self.diagnostics.log_orchestration(
@@ -2817,6 +2817,7 @@ impl EventLoop {
         // send the question and block until human.response or timeout.
         let mut response_event = None;
         let mut human_interact_context = None;
+        let mut events_arrived_during_robot_wait = Vec::new();
         let ask_human_idx = validated_events
             .iter()
             .position(|e| e.topic == "human.interact".into());
@@ -2829,15 +2830,27 @@ impl EventLoop {
                 Value::Object(map) => map,
                 _ => Map::new(),
             };
+            context
+                .entry("iteration".to_string())
+                .or_insert_with(|| Value::from(self.state.iteration));
+            context.entry("hat".to_string()).or_insert_with(|| {
+                ask_event
+                    .source
+                    .as_ref()
+                    .or(ask_event.target.as_ref())
+                    .map(|hat| Value::String(hat.as_str().to_string()))
+                    .unwrap_or_else(|| Value::String(self.get_active_hat_id().as_str().to_string()))
+            });
 
             if let Some(ref robot_service) = self.robot_service {
+                let robot_payload = Value::Object(context.clone()).to_string();
                 info!(
                     payload = %payload,
                     "human.interact event detected — sending question via robot service"
                 );
 
                 // Send the question (includes retry with exponential backoff)
-                let send_ok = match robot_service.send_question(&payload) {
+                let send_ok = match robot_service.send_question(&robot_payload) {
                     Ok(_message_id) => true,
                     Err(e) => {
                         warn!(
@@ -2885,7 +2898,7 @@ impl EventLoop {
                             self.loop_context
                                 .as_ref()
                                 .map(|ctx| ctx.events_path())
-                                .unwrap_or_else(|| PathBuf::from(".ralph/events.jsonl"))
+                                .unwrap_or_else(|| self.event_reader.path().to_path_buf())
                         });
 
                     match robot_service.wait_for_response(&events_path) {
@@ -2899,8 +2912,29 @@ impl EventLoop {
                                 Value::String("response".to_string()),
                             );
                             context.insert("response".to_string(), Value::String(response.clone()));
-                            // Create a human.response event to inject into the bus
-                            response_event = Some(Event::new("human.response", &response));
+                            let event = Event::new("human.response", &response);
+                            if robot_service.response_events_are_durable() {
+                                events_arrived_during_robot_wait.extend(
+                                    self.skip_consumed_robot_response_event(
+                                        &events_path,
+                                        &response,
+                                    ),
+                                );
+                            } else {
+                                match self.append_robot_response_event(&events_path, &event) {
+                                    Ok(events) => {
+                                        events_arrived_during_robot_wait.extend(events);
+                                    }
+                                    Err(error) => {
+                                        warn!(
+                                            error = %error,
+                                            path = %events_path.display(),
+                                            "Failed to record human.response event"
+                                        );
+                                    }
+                                }
+                            }
+                            response_event = Some(event);
                         }
                         Ok(None) => {
                             warn!(
@@ -2957,6 +2991,64 @@ impl EventLoop {
             }
 
             human_interact_context = Some(Value::Object(context));
+        }
+
+        let intervening_count = events_arrived_during_robot_wait.len();
+        for (index, event) in events_arrived_during_robot_wait.into_iter().enumerate() {
+            let payload = event.payload.clone();
+
+            if !cancellation_topic.is_empty() && event.topic.as_str() == cancellation_topic {
+                info!(
+                    payload = %payload,
+                    "loop.cancel event detected during robot wait — scheduling graceful termination"
+                );
+                self.state.cancellation_requested = true;
+                continue;
+            }
+
+            if event.topic.as_str() == "human.guidance" {
+                self.state.unacknowledged_guidance.push(payload);
+                validated_events.push(event);
+                continue;
+            }
+
+            if event.topic.as_str() == "human.guidance.ack" {
+                info!(
+                    payload = %payload,
+                    guidance_count = self.state.unacknowledged_guidance.len(),
+                    "human.guidance acknowledged during robot wait"
+                );
+                self.state.unacknowledged_guidance.clear();
+                validated_events.push(event);
+                continue;
+            }
+
+            if event.topic.as_str() == completion_topic {
+                if index + 1 == intervening_count {
+                    self.state.completion_requested = true;
+                    self.diagnostics.log_orchestration(
+                        self.state.iteration,
+                        "jsonl",
+                        crate::diagnostics::OrchestrationEvent::EventPublished {
+                            topic: event.topic.to_string(),
+                        },
+                    );
+                    info!(
+                        topic = %event.topic,
+                        "Completion event detected during robot wait"
+                    );
+                } else {
+                    warn!(
+                        topic = %event.topic,
+                        index = index,
+                        total_events = intervening_count,
+                        "Completion event during robot wait ignored because it was not the last event"
+                    );
+                }
+                continue;
+            }
+
+            validated_events.push(event);
         }
 
         let restart_requested = validated_events.iter().any(Self::is_restart_request_event)
@@ -3016,6 +3108,131 @@ impl EventLoop {
             human_interact_context,
             has_orphans,
         })
+    }
+
+    fn append_robot_response_event(
+        &mut self,
+        events_path: &Path,
+        event: &Event,
+    ) -> std::io::Result<Vec<Event>> {
+        if let Some(parent) = events_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let reader_position = self.event_reader.position();
+        let before_len = std::fs::metadata(events_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let line = Self::serialize_jsonl_event(event)?;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(events_path)?;
+        writeln!(file, "{line}")?;
+        file.flush()?;
+        let after_len = std::fs::metadata(events_path)?.len();
+
+        if self.event_reader.path() == events_path && self.event_reader.position() == before_len {
+            self.event_reader.set_position(after_len);
+            return Ok(Vec::new());
+        }
+
+        if self.event_reader.path() == events_path && reader_position < before_len {
+            let intervening_events =
+                Self::read_jsonl_events_between(events_path, reader_position, before_len)?;
+            self.event_reader.set_position(after_len);
+            return Ok(intervening_events);
+        }
+
+        Ok(Vec::new())
+    }
+
+    fn serialize_jsonl_event(event: &Event) -> std::io::Result<String> {
+        let mut value = serde_json::json!({
+            "topic": event.topic.as_str(),
+            "payload": event.payload,
+            "ts": chrono::Utc::now().to_rfc3339(),
+        });
+
+        if let Some(wave_id) = &event.wave_id {
+            value["wave_id"] = Value::String(wave_id.clone());
+        }
+        if let Some(wave_index) = event.wave_index {
+            value["wave_index"] = Value::from(wave_index);
+        }
+        if let Some(wave_total) = event.wave_total {
+            value["wave_total"] = Value::from(wave_total);
+        }
+
+        serde_json::to_string(&value).map_err(std::io::Error::other)
+    }
+
+    fn skip_consumed_robot_response_event(
+        &mut self,
+        events_path: &Path,
+        response: &str,
+    ) -> Vec<Event> {
+        if self.event_reader.path() != events_path {
+            return Vec::new();
+        }
+
+        let Ok(mut file) = std::fs::File::open(events_path) else {
+            return Vec::new();
+        };
+        let mut current_pos = self.event_reader.position();
+        if file.seek(SeekFrom::Start(current_pos)).is_err() {
+            return Vec::new();
+        }
+
+        let mut intervening_events = Vec::new();
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let Ok(line) = line else {
+                return intervening_events;
+            };
+            current_pos += line.len() as u64 + 1;
+
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let Ok(event) = serde_json::from_str::<crate::event_reader::Event>(&line) else {
+                continue;
+            };
+            if event.topic == "human.response" && event.payload.as_deref() == Some(response) {
+                self.event_reader.set_position(current_pos);
+                return intervening_events;
+            }
+            intervening_events.push(event.into());
+        }
+        intervening_events
+    }
+
+    fn read_jsonl_events_between(
+        events_path: &Path,
+        start: u64,
+        end: u64,
+    ) -> std::io::Result<Vec<Event>> {
+        let mut file = std::fs::File::open(events_path)?;
+        file.seek(SeekFrom::Start(start))?;
+
+        let reader = BufReader::new(file);
+        let mut current_pos = start;
+        let mut events = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            current_pos += line.len() as u64 + 1;
+            if current_pos > end {
+                break;
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(event) = serde_json::from_str::<crate::event_reader::Event>(&line) {
+                events.push(event.into());
+            }
+        }
+        Ok(events)
     }
 
     /// Process events from JSONL, partitioning wave events from regular events.

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -4798,6 +4798,79 @@ impl ralph_proto::RobotService for RestartRequestRobotService {
     fn stop(self: Box<Self>) {}
 }
 
+struct DurableResponseRobotService {
+    write_guidance_after_response: bool,
+}
+
+impl ralph_proto::RobotService for DurableResponseRobotService {
+    fn send_question(&self, _payload: &str) -> anyhow::Result<i32> {
+        Ok(1)
+    }
+
+    fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>> {
+        write_event_to_jsonl(events_path, "human.response", "approved");
+        if self.write_guidance_after_response {
+            write_event_to_jsonl(events_path, "human.guidance", "keep going");
+        }
+        Ok(Some("approved".to_string()))
+    }
+
+    fn response_events_are_durable(&self) -> bool {
+        true
+    }
+
+    fn send_checkin(
+        &self,
+        _: u32,
+        _: Duration,
+        _: Option<&ralph_proto::CheckinContext>,
+    ) -> anyhow::Result<i32> {
+        Ok(0)
+    }
+
+    fn timeout_secs(&self) -> u64 {
+        5
+    }
+
+    fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(false))
+    }
+
+    fn stop(self: Box<Self>) {}
+}
+
+struct NonDurableResponseWithGuidanceRobotService;
+
+impl ralph_proto::RobotService for NonDurableResponseWithGuidanceRobotService {
+    fn send_question(&self, _payload: &str) -> anyhow::Result<i32> {
+        Ok(1)
+    }
+
+    fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>> {
+        write_event_to_jsonl(events_path, "human.guidance", "keep going");
+        Ok(Some("approved".to_string()))
+    }
+
+    fn send_checkin(
+        &self,
+        _: u32,
+        _: Duration,
+        _: Option<&ralph_proto::CheckinContext>,
+    ) -> anyhow::Result<i32> {
+        Ok(0)
+    }
+
+    fn timeout_secs(&self) -> u64 {
+        5
+    }
+
+    fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(false))
+    }
+
+    fn stop(self: Box<Self>) {}
+}
+
 #[test]
 fn test_human_timeout_injects_timeout_event() {
     use tempfile::TempDir;
@@ -4822,6 +4895,193 @@ fn test_human_timeout_injects_timeout_event() {
     assert!(
         event_loop.has_pending_events(),
         "human.timeout event should be published on timeout"
+    );
+}
+
+#[test]
+fn test_robot_response_is_persisted_without_replay() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let config = RalphConfig::default();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.set_robot_service(Box::new(MockRobotService {
+        timeout: 5,
+        should_timeout: false,
+    }));
+
+    write_event_to_jsonl(&events_path, "human.interact", "Please review this plan");
+    let _ = event_loop.process_events_from_jsonl();
+
+    let first_events = event_loop.bus().take_human_pending();
+    let response_events: Vec<_> = first_events
+        .iter()
+        .filter(|event| event.topic.as_str() == "human.response")
+        .collect();
+    assert_eq!(response_events.len(), 1);
+    assert_eq!(response_events[0].payload, "approved");
+
+    let persisted = std::fs::read_to_string(&events_path).expect("read events");
+    let persisted_responses = persisted
+        .lines()
+        .filter_map(|line| serde_json::from_str::<crate::event_reader::Event>(line).ok())
+        .filter(|event| event.topic.as_str() == "human.response")
+        .count();
+    assert_eq!(persisted_responses, 1);
+
+    let _ = event_loop.process_events_from_jsonl();
+    let replayed_events = event_loop.bus().take_human_pending();
+    assert!(
+        replayed_events.is_empty(),
+        "persisted robot response should not be replayed: {:?}",
+        replayed_events
+    );
+}
+
+#[test]
+fn test_non_durable_robot_response_skip_preserves_intervening_guidance() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let config = RalphConfig::default();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.set_robot_service(Box::new(NonDurableResponseWithGuidanceRobotService));
+
+    write_event_to_jsonl(&events_path, "human.interact", "Please review this plan");
+    let _ = event_loop.process_events_from_jsonl();
+
+    let first_events = event_loop.bus().take_human_pending();
+    assert!(
+        first_events
+            .iter()
+            .any(|event| event.topic.as_str() == "human.guidance" && event.payload == "keep going"),
+        "guidance appended during robot wait should be published: {:?}",
+        first_events
+    );
+    assert_eq!(
+        first_events
+            .iter()
+            .filter(|event| event.topic.as_str() == "human.response")
+            .count(),
+        1,
+        "robot response should be published exactly once initially: {:?}",
+        first_events
+    );
+    assert_eq!(
+        event_loop.state.unacknowledged_guidance,
+        vec!["keep going".to_string()],
+        "guidance arriving during robot wait must enter guidance backpressure"
+    );
+
+    let _ = event_loop.process_events_from_jsonl();
+    let replayed_events = event_loop.bus().take_human_pending();
+    assert!(
+        !replayed_events
+            .iter()
+            .any(|event| event.topic.as_str() == "human.response"),
+        "orchestrator-appended response should not be replayed: {:?}",
+        replayed_events
+    );
+    assert!(
+        replayed_events.is_empty(),
+        "intervening guidance should have been consumed exactly once: {:?}",
+        replayed_events
+    );
+
+    write_event_to_jsonl(&events_path, "LOOP_COMPLETE", "done");
+    let _ = event_loop.process_events_from_jsonl();
+    assert_eq!(
+        event_loop.check_completion_event(),
+        None,
+        "completion must stay blocked until guidance from robot wait is acknowledged"
+    );
+}
+
+#[test]
+fn test_durable_robot_response_is_not_duplicated_or_replayed() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let config = RalphConfig::default();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.set_robot_service(Box::new(DurableResponseRobotService {
+        write_guidance_after_response: false,
+    }));
+
+    write_event_to_jsonl(&events_path, "human.interact", "Please review this plan");
+    let _ = event_loop.process_events_from_jsonl();
+
+    let first_events = event_loop.bus().take_human_pending();
+    let response_events: Vec<_> = first_events
+        .iter()
+        .filter(|event| event.topic.as_str() == "human.response")
+        .collect();
+    assert_eq!(response_events.len(), 1);
+    assert_eq!(response_events[0].payload, "approved");
+
+    let persisted = std::fs::read_to_string(&events_path).expect("read events");
+    let persisted_responses = persisted
+        .lines()
+        .filter_map(|line| serde_json::from_str::<crate::event_reader::Event>(line).ok())
+        .filter(|event| event.topic.as_str() == "human.response")
+        .count();
+    assert_eq!(persisted_responses, 1);
+
+    let _ = event_loop.process_events_from_jsonl();
+    let replayed_events = event_loop.bus().take_human_pending();
+    assert!(
+        replayed_events.is_empty(),
+        "durably written robot response should not be replayed: {:?}",
+        replayed_events
+    );
+}
+
+#[test]
+fn test_durable_robot_response_skip_preserves_later_guidance() {
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let events_path = temp_dir.path().join("events.jsonl");
+
+    let config = RalphConfig::default();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
+    event_loop.set_robot_service(Box::new(DurableResponseRobotService {
+        write_guidance_after_response: true,
+    }));
+
+    write_event_to_jsonl(&events_path, "human.interact", "Please review this plan");
+    let _ = event_loop.process_events_from_jsonl();
+    let _ = event_loop.bus().take_human_pending();
+
+    let _ = event_loop.process_events_from_jsonl();
+    let later_events = event_loop.bus().take_human_pending();
+    assert!(
+        later_events
+            .iter()
+            .any(|event| event.topic.as_str() == "human.guidance" && event.payload == "keep going"),
+        "guidance appended after durable response should remain unread: {:?}",
+        later_events
+    );
+    assert!(
+        !later_events
+            .iter()
+            .any(|event| event.topic.as_str() == "human.response"),
+        "durable response should not be replayed: {:?}",
+        later_events
     );
 }
 

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -63,8 +63,9 @@ pub mod worktree;
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
     CliConfig, ConfigError, CoreConfig, EventLoopConfig, EventMetadata, FeaturesConfig, HatBackend,
-    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, ScratchpadConfig,
-    SkillOverride, SkillsConfig, resolve_context_window, resolve_context_window_for_backend,
+    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, RobotMode,
+    ScratchpadConfig, SkillOverride, SkillsConfig, resolve_context_window,
+    resolve_context_window_for_backend,
 };
 // Re-export loop_name types (also available via FeaturesConfig.loop_naming)
 pub use diagnostics::DiagnosticsCollector;

--- a/crates/ralph-core/src/preflight.rs
+++ b/crates/ralph-core/src/preflight.rs
@@ -402,6 +402,10 @@ impl PreflightCheck for TelegramTokenCheck {
             return CheckResult::pass(self.name(), "RObot disabled (skipping)");
         }
 
+        if config.robot.mode.is_web() {
+            return CheckResult::pass(self.name(), "RObot web mode (skipping Telegram)");
+        }
+
         let Some(token) = config.robot.resolve_bot_token() else {
             return CheckResult::fail(
                 self.name(),
@@ -1306,6 +1310,20 @@ mod tests {
 
         assert_eq!(result.status, CheckStatus::Pass);
         assert!(result.label.contains("skipping"));
+    }
+
+    #[tokio::test]
+    async fn telegram_check_skips_in_web_mode() {
+        let mut config = RalphConfig::default();
+        config.robot.enabled = true;
+        config.robot.mode = crate::config::RobotMode::Web;
+        config.robot.timeout_seconds = Some(0);
+        let check = TelegramTokenCheck;
+
+        let result = check.run(&config).await;
+
+        assert_eq!(result.status, CheckStatus::Pass);
+        assert!(result.label.contains("web mode"));
     }
 
     #[tokio::test]

--- a/crates/ralph-proto/src/robot.rs
+++ b/crates/ralph-proto/src/robot.rs
@@ -46,6 +46,12 @@ pub trait RobotService: Send + Sync {
     /// Returns `Ok(Some(response))` on response, `Ok(None)` on timeout.
     fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>>;
 
+    /// Whether `wait_for_response` consumes responses that are already durably
+    /// written to the active events file.
+    fn response_events_are_durable(&self) -> bool {
+        false
+    }
+
     /// Send a periodic check-in message.
     ///
     /// Returns `Ok(0)` if no recipient is configured (skipped silently),

--- a/crates/ralph-telegram/src/service.rs
+++ b/crates/ralph-telegram/src/service.rs
@@ -420,14 +420,15 @@ impl TelegramService {
     /// is configured (question is logged but not sent).
     pub fn send_question(&self, payload: &str) -> TelegramResult<i32> {
         let mut state = self.state_manager.load_or_default()?;
+        let question = display_question_payload(payload);
 
         let message_id = if let Some(chat_id) = state.chat_id {
-            self.send_with_retry(chat_id, payload)?
+            self.send_with_retry(chat_id, &question)?
         } else {
             warn!(
                 loop_id = %self.loop_id,
                 "No chat ID configured — human.interact question logged but not sent: {}",
-                payload
+                question
             );
             0
         };
@@ -626,9 +627,12 @@ impl TelegramService {
     /// returns the response message. On timeout, removes the pending question
     /// and returns `None`.
     pub fn wait_for_response(&self, events_path: &Path) -> TelegramResult<Option<String>> {
-        let timeout = Duration::from_secs(self.timeout_secs);
         let poll_interval = Duration::from_millis(250);
-        let deadline = Instant::now() + timeout;
+        let deadline = if self.timeout_secs == 0 {
+            None
+        } else {
+            Some(Instant::now() + Duration::from_secs(self.timeout_secs))
+        };
 
         // Track file position to only read new lines
         let initial_pos = if events_path.exists() {
@@ -646,7 +650,9 @@ impl TelegramService {
         );
 
         loop {
-            if Instant::now() >= deadline {
+            if let Some(deadline) = deadline
+                && Instant::now() >= deadline
+            {
                 warn!(
                     loop_id = %self.loop_id,
                     timeout_secs = self.timeout_secs,
@@ -754,6 +760,30 @@ impl TelegramService {
     }
 }
 
+fn display_question_payload(payload: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(payload) else {
+        return payload.to_string();
+    };
+
+    if let Some(text) = value.as_str() {
+        return text.to_string();
+    }
+
+    if let Some(map) = value.as_object() {
+        for key in ["question", "message", "text", "payload"] {
+            if let Some(value) = map.get(key) {
+                return match value {
+                    serde_json::Value::String(text) => text.clone(),
+                    serde_json::Value::Null => payload.to_string(),
+                    other => other.to_string(),
+                };
+            }
+        }
+    }
+
+    payload.to_string()
+}
+
 impl ralph_proto::RobotService for TelegramService {
     fn send_question(&self, payload: &str) -> anyhow::Result<i32> {
         Ok(TelegramService::send_question(self, payload)?)
@@ -761,6 +791,10 @@ impl ralph_proto::RobotService for TelegramService {
 
     fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>> {
         Ok(TelegramService::wait_for_response(self, events_path)?)
+    }
+
+    fn response_events_are_durable(&self) -> bool {
+        true
     }
 
     fn send_checkin(
@@ -838,6 +872,16 @@ mod tests {
     }
 
     #[test]
+    fn robot_service_reports_response_events_as_durable() {
+        let dir = TempDir::new().unwrap();
+        let service = test_service(&dir);
+
+        assert!(ralph_proto::RobotService::response_events_are_durable(
+            &service
+        ));
+    }
+
+    #[test]
     fn new_without_token_fails() {
         // Only run this test when the env var is not set,
         // to avoid needing unsafe remove_var
@@ -887,6 +931,18 @@ mod tests {
         )
         .unwrap();
         assert_eq!(service.loop_id(), "feature-auth");
+    }
+
+    #[test]
+    fn display_question_payload_extracts_structured_question() {
+        assert_eq!(
+            display_question_payload(r#"{"question":"Which plan?","hat":"planner"}"#),
+            "Which plan?"
+        );
+        assert_eq!(
+            display_question_payload("Plain question?"),
+            "Plain question?"
+        );
     }
 
     #[test]
@@ -1079,6 +1135,48 @@ mod tests {
         assert!(
             !state.pending_questions.contains_key("main"),
             "pending question should be removed after response"
+        );
+    }
+
+    #[test]
+    fn wait_for_response_zero_timeout_waits_until_response() {
+        let dir = TempDir::new().unwrap();
+        let service = TelegramService::new(
+            dir.path().to_path_buf(),
+            Some("token".to_string()),
+            None,
+            0,
+            "main".to_string(),
+        )
+        .unwrap();
+
+        let events_path = dir.path().join("events.jsonl");
+        std::fs::File::create(&events_path).unwrap();
+        service.send_question("Which plan?").unwrap();
+
+        let writer_path = events_path.clone();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&writer_path)
+                .unwrap();
+            writeln!(
+                file,
+                r#"{{"topic":"human.response","payload":"Keep going","ts":"2026-01-30T00:00:00Z"}}"#
+            )
+            .unwrap();
+            file.flush().unwrap();
+        });
+
+        let start = Instant::now();
+        let result = service.wait_for_response(&events_path).unwrap();
+        writer.join().unwrap();
+
+        assert_eq!(result, Some("Keep going".to_string()));
+        assert!(
+            start.elapsed() >= Duration::from_millis(150),
+            "zero timeout should not return immediately"
         );
     }
 


### PR DESCRIPTION
## Summary
- add `RObot.mode: web` for file-backed human-in-the-loop interaction
- write/read `.ralph/api/robot-question.json`, `robot-response.json`, and `robot-checkin.json`
- allow `timeout_seconds: 0` to wait indefinitely and skip Telegram preflight in web mode

Closes #242

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p ralph-core robot_config -- --nocapture`
- `cargo test -p ralph-core telegram_check_skips_in_web_mode -- --nocapture`
- `cargo test -p ralph-cli web_robot_service -- --nocapture`
- `cargo test -p ralph-cli test_create_robot_service_uses_web_mode_without_telegram_token -- --nocapture`
- `cargo test -p ralph-core smoke_runner`
- `CARGO_TARGET_DIR=/tmp/ralph-shared-target CARGO_INCREMENTAL=0 cargo test`
- tmux smoke: `ralph-242-web-robot-smoke` ran `cargo test -p ralph-cli web_robot_service -- --nocapture` and printed `SMOKE_EXIT=0`

Note: public `robot.*` RPC methods and stream topics remain scoped to #243.
