### PR TITLE
feat(api): add robot RPC domain

### DIFF
--- a/crates/ralph-api/data/rpc-v1-events.json
+++ b/crates/ralph-api/data/rpc-v1-events.json
@@ -27,6 +27,10 @@
         "config.updated",
         "collection.updated",
         "preset.refreshed",
+        "robot.question.asked",
+        "robot.response.received",
+        "robot.guidance.sent",
+        "robot.checkin.updated",
         "error.raised",
         "stream.keepalive"
       ]
@@ -45,6 +49,7 @@
             "config",
             "collection",
             "preset",
+            "robot",
             "stream"
           ]
         },
@@ -301,6 +306,53 @@
         "count"
       ]
     },
+    "robotQuestionAskedPayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "question_id": { "type": "integer" },
+        "payload": {},
+        "hat": {},
+        "iteration": {}
+      },
+      "required": [
+        "question_id",
+        "payload"
+      ]
+    },
+    "robotResponseReceivedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "question_id": { "type": "integer" },
+        "response": { "type": "string" }
+      },
+      "required": [
+        "question_id",
+        "response"
+      ]
+    },
+    "robotGuidanceSentPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": { "type": "string" }
+      },
+      "required": [
+        "text"
+      ]
+    },
+    "robotCheckinUpdatedPayload": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "iteration": { "type": "integer" },
+        "elapsed_secs": { "type": "integer" },
+        "elapsed_seconds": { "type": "integer" },
+        "hat": {},
+        "current_hat": {}
+      }
+    },
     "errorRaisedPayload": {
       "type": "object",
       "additionalProperties": false,
@@ -348,6 +400,10 @@
         { "properties": { "topic": { "const": "config.updated" }, "payload": { "$ref": "#/$defs/configUpdatedPayload" } }, "required": ["topic", "payload"] },
         { "properties": { "topic": { "const": "collection.updated" }, "payload": { "$ref": "#/$defs/collectionUpdatedPayload" } }, "required": ["topic", "payload"] },
         { "properties": { "topic": { "const": "preset.refreshed" }, "payload": { "$ref": "#/$defs/presetRefreshedPayload" } }, "required": ["topic", "payload"] },
+        { "properties": { "topic": { "const": "robot.question.asked" }, "payload": { "$ref": "#/$defs/robotQuestionAskedPayload" } }, "required": ["topic", "payload"] },
+        { "properties": { "topic": { "const": "robot.response.received" }, "payload": { "$ref": "#/$defs/robotResponseReceivedPayload" } }, "required": ["topic", "payload"] },
+        { "properties": { "topic": { "const": "robot.guidance.sent" }, "payload": { "$ref": "#/$defs/robotGuidanceSentPayload" } }, "required": ["topic", "payload"] },
+        { "properties": { "topic": { "const": "robot.checkin.updated" }, "payload": { "$ref": "#/$defs/robotCheckinUpdatedPayload" } }, "required": ["topic", "payload"] },
         { "properties": { "topic": { "const": "error.raised" }, "payload": { "$ref": "#/$defs/errorRaisedPayload" } }, "required": ["topic", "payload"] },
         { "properties": { "topic": { "const": "stream.keepalive" }, "payload": { "$ref": "#/$defs/keepalivePayload" } }, "required": ["topic", "payload"] }
       ]

--- a/crates/ralph-api/data/rpc-v1-schema.json
+++ b/crates/ralph-api/data/rpc-v1-schema.json
@@ -68,8 +68,7 @@
         "robot.checkin",
         "stream.subscribe",
         "stream.unsubscribe",
-        "stream.ack",
-        "_internal.publish"
+        "stream.ack"
       ]
     },
     "mutatingMethodName": {
@@ -768,22 +767,6 @@
         { "required": ["payload"] }
       ]
     },
-    "internalPublishParams": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "topic": { "type": "string", "minLength": 1 },
-        "resourceType": { "type": "string", "minLength": 1 },
-        "resourceId": { "type": "string", "minLength": 1 },
-        "payload": { "type": "object" }
-      },
-      "required": [
-        "topic",
-        "resourceType",
-        "resourceId",
-        "payload"
-      ]
-    },
     "requestByMethod": {
       "oneOf": [
         { "properties": { "method": { "const": "system.health" }, "params": { "$ref": "#/$defs/emptyParams" } }, "required": ["method", "params"] },
@@ -846,9 +829,7 @@
 
         { "properties": { "method": { "const": "stream.subscribe" }, "params": { "$ref": "#/$defs/streamSubscribeParams" } }, "required": ["method", "params"] },
         { "properties": { "method": { "const": "stream.unsubscribe" }, "params": { "$ref": "#/$defs/streamUnsubscribeParams" } }, "required": ["method", "params"] },
-        { "properties": { "method": { "const": "stream.ack" }, "params": { "$ref": "#/$defs/streamAckParams" } }, "required": ["method", "params"] },
-
-        { "properties": { "method": { "const": "_internal.publish" }, "params": { "$ref": "#/$defs/internalPublishParams" } }, "required": ["method", "params"] }
+        { "properties": { "method": { "const": "stream.ack" }, "params": { "$ref": "#/$defs/streamAckParams" } }, "required": ["method", "params"] }
       ]
     },
     "requestEnvelope": {
@@ -1215,9 +1196,7 @@
 
         { "properties": { "method": { "const": "stream.subscribe" }, "result": { "$ref": "#/$defs/streamSubscribeResult" } }, "required": ["method", "result"] },
         { "properties": { "method": { "const": "stream.unsubscribe" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] },
-        { "properties": { "method": { "const": "stream.ack" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] },
-
-        { "properties": { "method": { "const": "_internal.publish" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] }
+        { "properties": { "method": { "const": "stream.ack" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] }
       ]
     },
     "responseEnvelope": {

--- a/crates/ralph-api/data/rpc-v1-schema.json
+++ b/crates/ralph-api/data/rpc-v1-schema.json
@@ -62,9 +62,14 @@
         "collection.import",
         "collection.export",
         "collection.run",
+        "robot.question",
+        "robot.respond",
+        "robot.guidance",
+        "robot.checkin",
         "stream.subscribe",
         "stream.unsubscribe",
-        "stream.ack"
+        "stream.ack",
+        "_internal.publish"
       ]
     },
     "mutatingMethodName": {
@@ -96,7 +101,9 @@
         "collection.create",
         "collection.update",
         "collection.delete",
-        "collection.import"
+        "collection.import",
+        "robot.respond",
+        "robot.guidance"
       ]
     },
     "authMeta": {
@@ -715,6 +722,68 @@
         "cursor"
       ]
     },
+    "robotRespondParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "questionId": { "type": "integer" },
+        "question_id": { "type": "integer" },
+        "id": { "type": "integer" },
+        "loopId": { "type": "string", "minLength": 1 },
+        "loop_id": { "type": "string", "minLength": 1 },
+        "responseToken": { "type": "string", "minLength": 1 },
+        "response_token": { "type": "string", "minLength": 1 },
+        "token": { "type": "string", "minLength": 1 },
+        "response": {
+          "type": ["string", "object", "array", "number", "boolean"]
+        },
+        "message": {
+          "type": ["string", "object", "array", "number", "boolean"]
+        },
+        "text": {
+          "type": ["string", "object", "array", "number", "boolean"]
+        },
+        "payload": {
+          "type": ["string", "object", "array", "number", "boolean"]
+        }
+      },
+      "allOf": [
+        { "anyOf": [ { "required": ["questionId"] }, { "required": ["question_id"] }, { "required": ["id"] } ] },
+        { "anyOf": [ { "required": ["loopId"] }, { "required": ["loop_id"] } ] },
+        { "anyOf": [ { "required": ["responseToken"] }, { "required": ["response_token"] }, { "required": ["token"] } ] },
+        { "anyOf": [ { "required": ["response"] }, { "required": ["message"] }, { "required": ["text"] }, { "required": ["payload"] } ] }
+      ]
+    },
+    "robotGuidanceParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": { "type": "string", "minLength": 1 },
+        "message": { "type": "string", "minLength": 1 },
+        "payload": { "type": "string", "minLength": 1 }
+      },
+      "anyOf": [
+        { "required": ["text"] },
+        { "required": ["message"] },
+        { "required": ["payload"] }
+      ]
+    },
+    "internalPublishParams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "topic": { "type": "string", "minLength": 1 },
+        "resourceType": { "type": "string", "minLength": 1 },
+        "resourceId": { "type": "string", "minLength": 1 },
+        "payload": { "type": "object" }
+      },
+      "required": [
+        "topic",
+        "resourceType",
+        "resourceId",
+        "payload"
+      ]
+    },
     "requestByMethod": {
       "oneOf": [
         { "properties": { "method": { "const": "system.health" }, "params": { "$ref": "#/$defs/emptyParams" } }, "required": ["method", "params"] },
@@ -770,9 +839,16 @@
         { "properties": { "method": { "const": "collection.export" }, "params": { "$ref": "#/$defs/idOnlyParams" } }, "required": ["method", "params"] },
         { "properties": { "method": { "const": "collection.run" }, "params": { "$ref": "#/$defs/collectionRunParams" } }, "required": ["method", "params"] },
 
+        { "properties": { "method": { "const": "robot.question" }, "params": { "$ref": "#/$defs/emptyParams" } }, "required": ["method", "params"] },
+        { "properties": { "method": { "const": "robot.respond" }, "params": { "$ref": "#/$defs/robotRespondParams" } }, "required": ["method", "params"] },
+        { "properties": { "method": { "const": "robot.guidance" }, "params": { "$ref": "#/$defs/robotGuidanceParams" } }, "required": ["method", "params"] },
+        { "properties": { "method": { "const": "robot.checkin" }, "params": { "$ref": "#/$defs/emptyParams" } }, "required": ["method", "params"] },
+
         { "properties": { "method": { "const": "stream.subscribe" }, "params": { "$ref": "#/$defs/streamSubscribeParams" } }, "required": ["method", "params"] },
         { "properties": { "method": { "const": "stream.unsubscribe" }, "params": { "$ref": "#/$defs/streamUnsubscribeParams" } }, "required": ["method", "params"] },
-        { "properties": { "method": { "const": "stream.ack" }, "params": { "$ref": "#/$defs/streamAckParams" } }, "required": ["method", "params"] }
+        { "properties": { "method": { "const": "stream.ack" }, "params": { "$ref": "#/$defs/streamAckParams" } }, "required": ["method", "params"] },
+
+        { "properties": { "method": { "const": "_internal.publish" }, "params": { "$ref": "#/$defs/internalPublishParams" } }, "required": ["method", "params"] }
       ]
     },
     "requestEnvelope": {
@@ -1038,6 +1114,45 @@
       },
       "required": ["subscriptionId", "acceptedTopics", "cursor"]
     },
+    "robotQuestionResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "question": {
+          "type": ["object", "null"]
+        }
+      },
+      "required": ["question"]
+    },
+    "robotRespondResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "success": { "type": "boolean" },
+        "questionId": { "type": "integer" },
+        "response": { "type": "string" }
+      },
+      "required": ["success", "questionId", "response"]
+    },
+    "robotGuidanceResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "success": { "type": "boolean" },
+        "text": { "type": "string" }
+      },
+      "required": ["success", "text"]
+    },
+    "robotCheckinResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "checkin": {
+          "type": ["object", "null"]
+        }
+      },
+      "required": ["checkin"]
+    },
     "responseByMethod": {
       "oneOf": [
         { "properties": { "method": { "const": "system.health" }, "result": { "$ref": "#/$defs/systemHealthResult" } }, "required": ["method", "result"] },
@@ -1093,9 +1208,16 @@
         { "properties": { "method": { "const": "collection.export" }, "result": { "$ref": "#/$defs/collectionExportResult" } }, "required": ["method", "result"] },
         { "properties": { "method": { "const": "collection.run" }, "result": { "$ref": "#/$defs/collectionRunResult" } }, "required": ["method", "result"] },
 
+        { "properties": { "method": { "const": "robot.question" }, "result": { "$ref": "#/$defs/robotQuestionResult" } }, "required": ["method", "result"] },
+        { "properties": { "method": { "const": "robot.respond" }, "result": { "$ref": "#/$defs/robotRespondResult" } }, "required": ["method", "result"] },
+        { "properties": { "method": { "const": "robot.guidance" }, "result": { "$ref": "#/$defs/robotGuidanceResult" } }, "required": ["method", "result"] },
+        { "properties": { "method": { "const": "robot.checkin" }, "result": { "$ref": "#/$defs/robotCheckinResult" } }, "required": ["method", "result"] },
+
         { "properties": { "method": { "const": "stream.subscribe" }, "result": { "$ref": "#/$defs/streamSubscribeResult" } }, "required": ["method", "result"] },
         { "properties": { "method": { "const": "stream.unsubscribe" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] },
-        { "properties": { "method": { "const": "stream.ack" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] }
+        { "properties": { "method": { "const": "stream.ack" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] },
+
+        { "properties": { "method": { "const": "_internal.publish" }, "result": { "$ref": "#/$defs/successResult" } }, "required": ["method", "result"] }
       ]
     },
     "responseEnvelope": {

--- a/crates/ralph-api/src/lib.rs
+++ b/crates/ralph-api/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mcp;
 pub mod planning_domain;
 pub mod preset_domain;
 pub mod protocol;
+pub mod robot_domain;
 pub mod runtime;
 pub mod stream_domain;
 pub mod task_domain;

--- a/crates/ralph-api/src/protocol.rs
+++ b/crates/ralph-api/src/protocol.rs
@@ -64,7 +64,6 @@ pub const KNOWN_METHODS: &[&str] = &[
     "stream.subscribe",
     "stream.unsubscribe",
     "stream.ack",
-    "_internal.publish",
 ];
 
 pub const MUTATING_METHODS: &[&str] = &[

--- a/crates/ralph-api/src/protocol.rs
+++ b/crates/ralph-api/src/protocol.rs
@@ -57,9 +57,14 @@ pub const KNOWN_METHODS: &[&str] = &[
     "collection.import",
     "collection.export",
     "collection.run",
+    "robot.question",
+    "robot.respond",
+    "robot.guidance",
+    "robot.checkin",
     "stream.subscribe",
     "stream.unsubscribe",
     "stream.ack",
+    "_internal.publish",
 ];
 
 pub const MUTATING_METHODS: &[&str] = &[
@@ -91,6 +96,8 @@ pub const MUTATING_METHODS: &[&str] = &[
     "collection.delete",
     "collection.import",
     "collection.run",
+    "robot.respond",
+    "robot.guidance",
 ];
 
 pub const STREAM_TOPICS: &[&str] = &[
@@ -107,6 +114,10 @@ pub const STREAM_TOPICS: &[&str] = &[
     "config.updated",
     "collection.updated",
     "preset.refreshed",
+    "robot.question.asked",
+    "robot.response.received",
+    "robot.guidance.sent",
+    "robot.checkin.updated",
     "error.raised",
     "stream.keepalive",
 ];

--- a/crates/ralph-api/src/robot_domain.rs
+++ b/crates/ralph-api/src/robot_domain.rs
@@ -1,0 +1,216 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::{Map, Value, json};
+
+use crate::errors::ApiError;
+use crate::loop_support::now_ts;
+
+#[derive(Clone)]
+pub struct RobotDomain {
+    workspace_root: PathBuf,
+}
+
+pub struct RobotResponseWrite {
+    pub question_id: i64,
+    pub response: String,
+}
+
+pub struct RobotGuidanceWrite {
+    pub text: String,
+}
+
+impl RobotDomain {
+    pub fn new(workspace_root: impl AsRef<Path>) -> Self {
+        Self {
+            workspace_root: workspace_root.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn question(&self) -> Result<Option<Value>, ApiError> {
+        self.read_optional_json(&self.api_dir().join("robot-question.json"))
+    }
+
+    pub fn checkin(&self) -> Result<Option<Value>, ApiError> {
+        self.read_optional_json(&self.api_dir().join("robot-checkin.json"))
+    }
+
+    pub fn respond(&self, params: &Value) -> Result<RobotResponseWrite, ApiError> {
+        let map = object_params(params, "robot.respond")?;
+        let question_id = required_i64(map, &["questionId", "question_id", "id"])?;
+        let loop_id = required_string(map, &["loopId", "loop_id"])?;
+        let response_token = required_string(map, &["responseToken", "response_token", "token"])?;
+        let response = required_response(map)?;
+
+        let payload = json!({
+            "id": question_id,
+            "loop_id": loop_id,
+            "response_token": response_token,
+            "response": response,
+            "timestamp": now_ts(),
+        });
+        self.write_json_atomic(&self.api_dir().join("robot-response.json"), &payload)?;
+
+        Ok(RobotResponseWrite {
+            question_id,
+            response,
+        })
+    }
+
+    pub fn guidance(&self, params: &Value) -> Result<RobotGuidanceWrite, ApiError> {
+        let map = object_params(params, "robot.guidance")?;
+        let text = required_string(map, &["text", "message", "payload"])?;
+        let events_path = self.active_events_path()?;
+        append_simple_event(&events_path, "human.guidance", &text)?;
+
+        Ok(RobotGuidanceWrite { text })
+    }
+
+    fn api_dir(&self) -> PathBuf {
+        self.workspace_root.join(".ralph/api")
+    }
+
+    fn active_events_path(&self) -> Result<PathBuf, ApiError> {
+        let marker_path = self.workspace_root.join(".ralph/current-events");
+        let marker = fs::read_to_string(&marker_path).map_err(|err| {
+            ApiError::not_found(format!(
+                "failed to read active events marker {}: {err}",
+                marker_path.display()
+            ))
+        })?;
+        let marker = marker.trim();
+        if marker.is_empty() {
+            return Err(ApiError::invalid_params("active events marker is empty"));
+        }
+
+        let marker_path = Path::new(marker);
+        if marker_path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(ApiError::invalid_params(
+                "active events marker must not contain parent directory components",
+            ));
+        }
+
+        let resolved = if marker_path.is_absolute() {
+            marker_path.to_path_buf()
+        } else {
+            self.workspace_root.join(marker_path)
+        };
+
+        if !resolved.starts_with(&self.workspace_root) {
+            return Err(ApiError::invalid_params(
+                "active events marker resolves outside workspace",
+            ));
+        }
+
+        Ok(resolved)
+    }
+
+    fn read_optional_json(&self, path: &Path) -> Result<Option<Value>, ApiError> {
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let raw = fs::read_to_string(path).map_err(|err| {
+            ApiError::internal(format!("failed to read {}: {err}", path.display()))
+        })?;
+        serde_json::from_str(&raw)
+            .map(Some)
+            .map_err(|err| ApiError::internal(format!("failed to parse {}: {err}", path.display())))
+    }
+
+    fn write_json_atomic(&self, path: &Path, value: &Value) -> Result<(), ApiError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                ApiError::internal(format!("failed to create {}: {err}", parent.display()))
+            })?;
+        }
+
+        let tmp_path = path.with_extension("json.tmp");
+        let bytes = serde_json::to_vec_pretty(value)
+            .map_err(|err| ApiError::internal(format!("failed to serialize robot JSON: {err}")))?;
+        fs::write(&tmp_path, bytes).map_err(|err| {
+            ApiError::internal(format!("failed to write {}: {err}", tmp_path.display()))
+        })?;
+        fs::rename(&tmp_path, path).map_err(|err| {
+            ApiError::internal(format!(
+                "failed to move {} to {}: {err}",
+                tmp_path.display(),
+                path.display()
+            ))
+        })
+    }
+}
+
+fn object_params<'a>(params: &'a Value, method: &str) -> Result<&'a Map<String, Value>, ApiError> {
+    params
+        .as_object()
+        .ok_or_else(|| ApiError::invalid_params(format!("{method} params must be an object")))
+}
+
+fn required_i64(map: &Map<String, Value>, keys: &[&str]) -> Result<i64, ApiError> {
+    keys.iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_i64))
+        .ok_or_else(|| {
+            ApiError::invalid_params(format!(
+                "missing or invalid integer field '{}'",
+                keys.join("'/'")
+            ))
+        })
+}
+
+fn required_string(map: &Map<String, Value>, keys: &[&str]) -> Result<String, ApiError> {
+    keys.iter()
+        .find_map(|key| map.get(*key).and_then(Value::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| {
+            ApiError::invalid_params(format!(
+                "missing or invalid string field '{}'",
+                keys.join("'/'")
+            ))
+        })
+}
+
+fn required_response(map: &Map<String, Value>) -> Result<String, ApiError> {
+    let value = ["response", "message", "text", "payload"]
+        .iter()
+        .find_map(|key| map.get(*key))
+        .ok_or_else(|| {
+            ApiError::invalid_params("robot.respond requires response, message, text, or payload")
+        })?;
+
+    match value {
+        Value::String(response) if !response.is_empty() => Ok(response.clone()),
+        Value::String(_) => Err(ApiError::invalid_params("robot response cannot be empty")),
+        Value::Null => Err(ApiError::invalid_params("robot response cannot be null")),
+        Value::Object(_) | Value::Array(_) => Ok(value.to_string()),
+        other => Ok(other.to_string()),
+    }
+}
+
+fn append_simple_event(path: &Path, topic: &str, payload: &str) -> Result<(), ApiError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            ApiError::internal(format!("failed to create {}: {err}", parent.display()))
+        })?;
+    }
+
+    let event = json!({
+        "topic": topic,
+        "payload": payload,
+        "ts": now_ts(),
+    });
+    let line = serde_json::to_string(&event)
+        .map_err(|err| ApiError::internal(format!("failed to serialize event: {err}")))?;
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|err| ApiError::internal(format!("failed to open {}: {err}", path.display())))?;
+    writeln!(file, "{line}")
+        .map_err(|err| ApiError::internal(format!("failed to append {}: {err}", path.display())))
+}

--- a/crates/ralph-api/src/runtime.rs
+++ b/crates/ralph-api/src/runtime.rs
@@ -280,6 +280,10 @@ impl RpcRuntime {
                 .with_context(request_id.clone(), None)
         })?;
 
+        if method == "_internal.publish" {
+            return self.parse_and_validate_internal_publish_request(raw, request_id, method);
+        }
+
         if !is_known_method(&method) {
             return Err(
                 ApiError::method_not_found(method.clone()).with_context(request_id, Some(method))
@@ -304,6 +308,30 @@ impl RpcRuntime {
             ))
             .with_context(request.id, Some(request.method)));
         }
+
+        Ok(request)
+    }
+
+    fn parse_and_validate_internal_publish_request(
+        &self,
+        raw: Value,
+        request_id: String,
+        method: String,
+    ) -> Result<RpcRequestEnvelope, ApiError> {
+        let request = parse_request(&raw)
+            .map_err(|error| error.with_context(request_id.clone(), Some(method.clone())))?;
+
+        if request.api_version != API_VERSION {
+            return Err(ApiError::invalid_request(format!(
+                "unsupported apiVersion '{}'; expected '{API_VERSION}'",
+                request.api_version
+            ))
+            .with_context(request.id, Some(request.method)));
+        }
+
+        validate_internal_publish_params(&request.params).map_err(|error| {
+            error.with_context(request.id.clone(), Some(request.method.clone()))
+        })?;
 
         Ok(request)
     }
@@ -422,4 +450,49 @@ impl RpcRuntime {
         error.status = StatusCode::from_u16(response.status).unwrap_or(error.status);
         Err(error)
     }
+}
+
+fn validate_internal_publish_params(params: &Value) -> Result<(), ApiError> {
+    let object = params
+        .as_object()
+        .ok_or_else(|| ApiError::invalid_params("_internal.publish params must be an object"))?;
+
+    for key in object.keys() {
+        if !matches!(
+            key.as_str(),
+            "topic" | "resourceType" | "resourceId" | "payload"
+        ) {
+            return Err(ApiError::invalid_params(format!(
+                "_internal.publish does not accept '{key}'"
+            )));
+        }
+    }
+
+    let topic = required_non_empty_string(object.get("topic"), "topic")?;
+    if !STREAM_TOPICS.contains(&topic) {
+        return Err(ApiError::invalid_params(format!(
+            "_internal.publish topic '{topic}' is not registered"
+        )));
+    }
+
+    required_non_empty_string(object.get("resourceType"), "resourceType")?;
+    required_non_empty_string(object.get("resourceId"), "resourceId")?;
+
+    if !matches!(object.get("payload"), Some(Value::Object(_))) {
+        return Err(ApiError::invalid_params(
+            "_internal.publish requires object 'payload'",
+        ));
+    }
+
+    Ok(())
+}
+
+fn required_non_empty_string<'a>(
+    value: Option<&'a Value>,
+    field: &str,
+) -> Result<&'a str, ApiError> {
+    value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ApiError::invalid_params(format!("_internal.publish requires '{field}'")))
 }

--- a/crates/ralph-api/src/runtime.rs
+++ b/crates/ralph-api/src/runtime.rs
@@ -25,6 +25,7 @@ use crate::protocol::{
     is_mutating_method, parse_json_value, parse_request, request_context, success_envelope,
     validate_request_schema,
 };
+use crate::robot_domain::RobotDomain;
 use crate::stream_domain::StreamDomain;
 use crate::task_domain::TaskDomain;
 
@@ -46,6 +47,7 @@ pub struct RpcRuntime {
     streams: StreamDomain,
     config_domain: ConfigDomain,
     preset_domain: PresetDomain,
+    robot_domain: RobotDomain,
 }
 
 enum ExecutionOutcome {
@@ -81,6 +83,7 @@ impl RpcRuntime {
         let streams = StreamDomain::new();
         let config_domain = ConfigDomain::new(&config.workspace_root);
         let preset_domain = PresetDomain::new(&config.workspace_root);
+        let robot_domain = RobotDomain::new(&config.workspace_root);
 
         Self {
             config,
@@ -93,6 +96,7 @@ impl RpcRuntime {
             streams,
             config_domain,
             preset_domain,
+            robot_domain,
         }
     }
 
@@ -238,6 +242,10 @@ impl RpcRuntime {
 
     pub(crate) fn preset_domain(&self) -> &PresetDomain {
         &self.preset_domain
+    }
+
+    pub(crate) fn robot_domain(&self) -> &RobotDomain {
+        &self.robot_domain
     }
 
     pub(crate) fn parse_params<T>(&self, request: &RpcRequestEnvelope) -> Result<T, ApiError>

--- a/crates/ralph-api/src/runtime.rs
+++ b/crates/ralph-api/src/runtime.rs
@@ -262,6 +262,12 @@ impl RpcRuntime {
 
     fn parse_and_validate_request(&self, body: &[u8]) -> Result<RpcRequestEnvelope, ApiError> {
         let raw = parse_json_value(body)?;
+        let (request_id, method) = request_context(&raw);
+        if method.as_deref() == Some("_internal.publish") {
+            return Err(ApiError::method_not_found("_internal.publish")
+                .with_context(request_id, Some("_internal.publish".to_string())));
+        }
+
         self.parse_and_validate_request_value(raw)
     }
 

--- a/crates/ralph-api/src/runtime/dispatch.rs
+++ b/crates/ralph-api/src/runtime/dispatch.rs
@@ -36,6 +36,7 @@ impl RpcRuntime {
             method if method.starts_with("config.") => self.dispatch_config(request),
             method if method.starts_with("preset.") => self.dispatch_preset(request),
             method if method.starts_with("collection.") => self.dispatch_collection(request),
+            method if method.starts_with("robot.") => self.dispatch_robot(request),
             method if method.starts_with("stream.") => self.dispatch_stream(request, principal),
             "_internal.publish" => self.dispatch_internal_publish(request),
             _ => {
@@ -347,6 +348,38 @@ impl RpcRuntime {
                 let params: StreamAckParams = self.parse_params(request)?;
                 self.stream_domain().ack(params)?;
                 Ok(json!({ "success": true }))
+            }
+            _ => Err(ApiError::service_unavailable(format!(
+                "method '{}' is recognized but not implemented",
+                request.method
+            ))),
+        }
+    }
+
+    fn dispatch_robot(&self, request: &RpcRequestEnvelope) -> Result<Value, ApiError> {
+        match request.method.as_str() {
+            "robot.question" => {
+                let question = self.robot_domain().question()?;
+                Ok(json!({ "question": question }))
+            }
+            "robot.respond" => {
+                let result = self.robot_domain().respond(&request.params)?;
+                Ok(json!({
+                    "success": true,
+                    "questionId": result.question_id,
+                    "response": result.response,
+                }))
+            }
+            "robot.guidance" => {
+                let result = self.robot_domain().guidance(&request.params)?;
+                Ok(json!({
+                    "success": true,
+                    "text": result.text,
+                }))
+            }
+            "robot.checkin" => {
+                let checkin = self.robot_domain().checkin()?;
+                Ok(json!({ "checkin": checkin }))
             }
             _ => Err(ApiError::service_unavailable(format!(
                 "method '{}' is recognized but not implemented",

--- a/crates/ralph-api/src/stream_domain/rpc_side_effects.rs
+++ b/crates/ralph-api/src/stream_domain/rpc_side_effects.rs
@@ -161,6 +161,29 @@ pub(super) fn publish_rpc_side_effect(
                 );
             }
         }
+        "robot.respond" => {
+            if let Some(question_id) = result.get("questionId").and_then(Value::as_i64) {
+                streams.publish(
+                    "robot.response.received",
+                    "robot",
+                    &question_id.to_string(),
+                    json!({
+                        "question_id": question_id,
+                        "response": result.get("response").cloned().unwrap_or(Value::Null)
+                    }),
+                );
+            }
+        }
+        "robot.guidance" => {
+            if let Some(text) = result.get("text").and_then(Value::as_str) {
+                streams.publish(
+                    "robot.guidance.sent",
+                    "robot",
+                    "guidance",
+                    json!({ "text": text }),
+                );
+            }
+        }
         _ => {}
     }
 }

--- a/crates/ralph-api/tests/mcp_server.rs
+++ b/crates/ralph-api/tests/mcp_server.rs
@@ -44,6 +44,7 @@ async fn mcp_lists_expected_tools() -> Result<()> {
     assert!(names.contains(&"robot_guidance"));
     assert!(names.contains(&"robot_checkin"));
     assert!(names.contains(&"stream_next"));
+    assert!(!names.contains(&"_internal_publish"));
 
     client.cancel().await?;
     server_handle.await??;

--- a/crates/ralph-api/tests/mcp_server.rs
+++ b/crates/ralph-api/tests/mcp_server.rs
@@ -39,6 +39,10 @@ async fn mcp_lists_expected_tools() -> Result<()> {
     assert!(names.contains(&"loop_status"));
     assert!(names.contains(&"planning_start"));
     assert!(names.contains(&"config_get"));
+    assert!(names.contains(&"robot_question"));
+    assert!(names.contains(&"robot_respond"));
+    assert!(names.contains(&"robot_guidance"));
+    assert!(names.contains(&"robot_checkin"));
     assert!(names.contains(&"stream_next"));
 
     client.cancel().await?;

--- a/crates/ralph-api/tests/rpc_v1_robot.rs
+++ b/crates/ralph-api/tests/rpc_v1_robot.rs
@@ -20,6 +20,7 @@ struct TestServer {
     base_url: String,
     shutdown: Option<oneshot::Sender<()>>,
     join: tokio::task::JoinHandle<anyhow::Result<()>>,
+    runtime: RpcRuntime,
     workspace: TempDir,
 }
 
@@ -35,6 +36,7 @@ impl TestServer {
             .local_addr()
             .expect("listener local addr should exist");
         let runtime = RpcRuntime::new(config).expect("runtime should initialize");
+        let runtime_handle = runtime.clone();
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let join = tokio::spawn(async move {
@@ -48,6 +50,7 @@ impl TestServer {
             base_url: format!("http://{local_addr}"),
             shutdown: Some(shutdown_tx),
             join,
+            runtime: runtime_handle,
             workspace,
         }
     }
@@ -370,24 +373,27 @@ async fn robot_stream_topics_accept_rpc_side_effects_and_internal_publish() -> R
     assert_eq!(response_event["payload"]["question_id"], 9);
     assert_eq!(response_event["resource"]["type"], "robot");
 
-    let publish = rpc_request(
-        "robot-stream-internal",
-        "_internal.publish",
-        json!({
-            "topic": "robot.question.asked",
-            "resourceType": "robot",
-            "resourceId": "9",
-            "payload": {
-                "question_id": 9,
-                "payload": "Need approval?",
-                "hat": "executor",
-                "iteration": 4
-            }
-        }),
-        None,
-    );
-    let (status, _) = post_rpc(&client, &server, &publish).await?;
-    assert_eq!(status, 200);
+    let publish_result = server
+        .runtime
+        .invoke_method(
+            "robot-stream-internal",
+            "_internal.publish",
+            json!({
+                "topic": "robot.question.asked",
+                "resourceType": "robot",
+                "resourceId": "9",
+                "payload": {
+                    "question_id": 9,
+                    "payload": "Need approval?",
+                    "hat": "executor",
+                    "iteration": 4
+                }
+            }),
+            "internal",
+            None,
+        )
+        .expect("private internal publish should succeed");
+    assert_eq!(publish_result["success"], true);
 
     let question_event = recv_topic_event(&mut stream, "robot.question.asked").await;
     assert_eq!(question_event["payload"]["question_id"], 9);
@@ -399,9 +405,33 @@ async fn robot_stream_topics_accept_rpc_side_effects_and_internal_publish() -> R
 }
 
 #[tokio::test]
-async fn robot_internal_publish_rejects_malformed_private_requests() -> Result<()> {
+async fn robot_internal_publish_is_not_public_http_method() -> Result<()> {
     let server = TestServer::start(ApiConfig::default()).await;
     let client = Client::new();
+
+    let request = rpc_request(
+        "robot-stream-internal-public",
+        "_internal.publish",
+        json!({
+            "topic": "robot.question.asked",
+            "resourceType": "robot",
+            "resourceId": "9",
+            "payload": {}
+        }),
+        None,
+    );
+    let (status, payload) = post_rpc(&client, &server, &request).await?;
+
+    assert_eq!(status, 404);
+    assert_eq!(payload["error"]["code"], "METHOD_NOT_FOUND");
+
+    server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn robot_internal_publish_rejects_malformed_private_requests() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
 
     let cases = [
         json!({
@@ -426,15 +456,17 @@ async fn robot_internal_publish_rejects_malformed_private_requests() -> Result<(
     ];
 
     for (index, params) in cases.into_iter().enumerate() {
-        let request = rpc_request(
-            &format!("robot-stream-internal-invalid-{index}"),
-            "_internal.publish",
-            params,
-            None,
-        );
-        let (status, payload) = post_rpc(&client, &server, &request).await?;
-        assert_eq!(status, 400);
-        assert_eq!(payload["error"]["code"], "INVALID_PARAMS");
+        let error = server
+            .runtime
+            .invoke_method(
+                format!("robot-stream-internal-invalid-{index}"),
+                "_internal.publish",
+                params,
+                "internal",
+                None,
+            )
+            .expect_err("malformed private publish should fail");
+        assert_eq!(error.code.as_str(), "INVALID_PARAMS");
     }
 
     server.stop().await;

--- a/crates/ralph-api/tests/rpc_v1_robot.rs
+++ b/crates/ralph-api/tests/rpc_v1_robot.rs
@@ -397,3 +397,46 @@ async fn robot_stream_topics_accept_rpc_side_effects_and_internal_publish() -> R
     server.stop().await;
     Ok(())
 }
+
+#[tokio::test]
+async fn robot_internal_publish_rejects_malformed_private_requests() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    let cases = [
+        json!({
+            "topic": "robot.question.asked",
+            "resourceType": "robot",
+            "resourceId": "9",
+            "payload": "not-object"
+        }),
+        json!({
+            "topic": "robot.unknown",
+            "resourceType": "robot",
+            "resourceId": "9",
+            "payload": {}
+        }),
+        json!({
+            "topic": "robot.question.asked",
+            "resourceType": "robot",
+            "resourceId": "9",
+            "payload": {},
+            "extra": true
+        }),
+    ];
+
+    for (index, params) in cases.into_iter().enumerate() {
+        let request = rpc_request(
+            &format!("robot-stream-internal-invalid-{index}"),
+            "_internal.publish",
+            params,
+            None,
+        );
+        let (status, payload) = post_rpc(&client, &server, &request).await?;
+        assert_eq!(status, 400);
+        assert_eq!(payload["error"]["code"], "INVALID_PARAMS");
+    }
+
+    server.stop().await;
+    Ok(())
+}

--- a/crates/ralph-api/tests/rpc_v1_robot.rs
+++ b/crates/ralph-api/tests/rpc_v1_robot.rs
@@ -1,0 +1,399 @@
+use std::fs;
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::StreamExt;
+use reqwest::Client;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+
+use ralph_api::{ApiConfig, RpcRuntime, serve_with_listener};
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+struct TestServer {
+    base_url: String,
+    shutdown: Option<oneshot::Sender<()>>,
+    join: tokio::task::JoinHandle<anyhow::Result<()>>,
+    workspace: TempDir,
+}
+
+impl TestServer {
+    async fn start(mut config: ApiConfig) -> Self {
+        let workspace = tempfile::tempdir().expect("workspace tempdir should be created");
+        config.workspace_root = workspace.path().to_path_buf();
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let local_addr = listener
+            .local_addr()
+            .expect("listener local addr should exist");
+        let runtime = RpcRuntime::new(config).expect("runtime should initialize");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let join = tokio::spawn(async move {
+            serve_with_listener(listener, runtime, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        });
+
+        Self {
+            base_url: format!("http://{local_addr}"),
+            shutdown: Some(shutdown_tx),
+            join,
+            workspace,
+        }
+    }
+
+    fn path(&self, relative: &str) -> std::path::PathBuf {
+        self.workspace.path().join(relative)
+    }
+
+    fn ws_url(&self) -> String {
+        self.base_url.replacen("http://", "ws://", 1)
+    }
+
+    async fn stop(mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        let result = self.join.await.expect("server task should join");
+        result.expect("server should shutdown cleanly");
+    }
+}
+
+async fn post_rpc(client: &Client, server: &TestServer, body: &Value) -> Result<(u16, Value)> {
+    let response = client
+        .post(format!("{}/rpc/v1", server.base_url))
+        .header("content-type", "application/json")
+        .json(body)
+        .send()
+        .await?;
+
+    let status = response.status().as_u16();
+    let payload = response.json::<Value>().await?;
+    Ok((status, payload))
+}
+
+fn rpc_request(id: &str, method: &str, params: Value, idempotency_key: Option<&str>) -> Value {
+    let mut request = json!({
+        "apiVersion": "v1",
+        "id": id,
+        "method": method,
+        "params": params,
+    });
+
+    if let Some(idempotency_key) = idempotency_key {
+        request["meta"] = json!({
+            "idempotencyKey": idempotency_key,
+        });
+    }
+
+    request
+}
+
+fn write_json(path: &std::path::Path, value: &Value) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(value)?)?;
+    Ok(())
+}
+
+async fn open_stream(server: &TestServer, subscription_id: &str) -> Result<WsStream> {
+    let url = format!(
+        "{}/rpc/v1/stream?subscriptionId={subscription_id}",
+        server.ws_url()
+    );
+    let (stream, _) = connect_async(url).await?;
+    Ok(stream)
+}
+
+async fn recv_topic_event(stream: &mut WsStream, topic: &str) -> Value {
+    loop {
+        let maybe_message = timeout(Duration::from_secs(4), stream.next())
+            .await
+            .expect("timed out waiting for websocket message");
+
+        let Some(message) = maybe_message else {
+            panic!("websocket closed before receiving expected topic");
+        };
+
+        let message = message.expect("websocket message should be ok");
+        let Message::Text(text) = message else {
+            continue;
+        };
+
+        let payload: Value =
+            serde_json::from_str(&text).expect("websocket event should be valid json");
+        if payload["topic"] == topic {
+            return payload;
+        }
+    }
+}
+
+#[tokio::test]
+async fn robot_question_and_checkin_return_null_or_file_payload() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    let question = rpc_request("robot-question-empty", "robot.question", json!({}), None);
+    let (status, payload) = post_rpc(&client, &server, &question).await?;
+    assert_eq!(status, 200);
+    assert!(payload["result"]["question"].is_null());
+
+    let checkin = rpc_request("robot-checkin-empty", "robot.checkin", json!({}), None);
+    let (status, payload) = post_rpc(&client, &server, &checkin).await?;
+    assert_eq!(status, 200);
+    assert!(payload["result"]["checkin"].is_null());
+
+    write_json(
+        &server.path(".ralph/api/robot-question.json"),
+        &json!({
+            "id": 7,
+            "loop_id": "loop-1",
+            "response_token": "token-7",
+            "payload": "Need review?",
+            "hat": "executor",
+            "iteration": 3
+        }),
+    )?;
+    write_json(
+        &server.path(".ralph/api/robot-checkin.json"),
+        &json!({
+            "iteration": 3,
+            "elapsed_seconds": 12,
+            "context": { "current_hat": "executor" }
+        }),
+    )?;
+
+    let (status, payload) = post_rpc(&client, &server, &question).await?;
+    assert_eq!(status, 200);
+    assert_eq!(payload["result"]["question"]["id"], 7);
+    assert_eq!(payload["result"]["question"]["response_token"], "token-7");
+
+    let (status, payload) = post_rpc(&client, &server, &checkin).await?;
+    assert_eq!(status, 200);
+    assert_eq!(payload["result"]["checkin"]["iteration"], 3);
+
+    server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn robot_respond_writes_web_robot_compatible_response_and_replays() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    let request = rpc_request(
+        "robot-respond-1",
+        "robot.respond",
+        json!({
+            "id": 7,
+            "loop_id": "loop-1",
+            "response_token": "token-7",
+            "response": "Approved"
+        }),
+        Some("idem-robot-respond-1"),
+    );
+
+    let (status, payload) = post_rpc(&client, &server, &request).await?;
+    assert_eq!(status, 200);
+    assert_eq!(payload["result"]["questionId"], 7);
+    assert_eq!(payload["result"]["response"], "Approved");
+
+    let response_file: Value =
+        serde_json::from_slice(&fs::read(server.path(".ralph/api/robot-response.json"))?)?;
+    assert_eq!(response_file["id"], 7);
+    assert_eq!(response_file["loop_id"], "loop-1");
+    assert_eq!(response_file["response_token"], "token-7");
+    assert_eq!(response_file["response"], "Approved");
+
+    fs::remove_file(server.path(".ralph/api/robot-response.json"))?;
+    let (replay_status, replay_payload) = post_rpc(&client, &server, &request).await?;
+    assert_eq!(replay_status, status);
+    assert_eq!(replay_payload, payload);
+    assert!(
+        !server.path(".ralph/api/robot-response.json").exists(),
+        "idempotency replay should not rewrite response file"
+    );
+
+    server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn robot_guidance_appends_to_current_events_and_replays() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    fs::create_dir_all(server.path(".ralph"))?;
+    fs::write(
+        server.path(".ralph/current-events"),
+        ".ralph/events-active.jsonl",
+    )?;
+
+    let request = rpc_request(
+        "robot-guidance-1",
+        "robot.guidance",
+        json!({ "text": "Focus on cancellation" }),
+        Some("idem-robot-guidance-1"),
+    );
+
+    let (status, payload) = post_rpc(&client, &server, &request).await?;
+    assert_eq!(status, 200);
+    assert_eq!(payload["result"]["text"], "Focus on cancellation");
+
+    let events = fs::read_to_string(server.path(".ralph/events-active.jsonl"))?;
+    let lines = events.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 1);
+    let event: Value = serde_json::from_str(lines[0])?;
+    assert_eq!(event["topic"], "human.guidance");
+    assert_eq!(event["payload"], "Focus on cancellation");
+
+    let (replay_status, replay_payload) = post_rpc(&client, &server, &request).await?;
+    assert_eq!(replay_status, status);
+    assert_eq!(replay_payload, payload);
+    let replay_events = fs::read_to_string(server.path(".ralph/events-active.jsonl"))?;
+    assert_eq!(
+        replay_events.lines().count(),
+        1,
+        "idempotency replay should not append duplicate guidance"
+    );
+
+    server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn robot_guidance_rejects_parent_dir_current_events_marker() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    fs::create_dir_all(server.path(".ralph"))?;
+    fs::write(server.path(".ralph/current-events"), "../outside.jsonl")?;
+
+    let request = rpc_request(
+        "robot-guidance-traversal",
+        "robot.guidance",
+        json!({ "text": "Do not escape" }),
+        Some("idem-robot-guidance-traversal"),
+    );
+
+    let (status, payload) = post_rpc(&client, &server, &request).await?;
+    assert_eq!(status, 400);
+    assert_eq!(payload["error"]["code"], "INVALID_PARAMS");
+    assert!(
+        !server.path("../outside.jsonl").exists(),
+        "guidance should not append outside the workspace"
+    );
+
+    server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn robot_methods_require_idempotency_for_mutations() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    let respond = rpc_request(
+        "robot-respond-no-idem",
+        "robot.respond",
+        json!({
+            "questionId": 1,
+            "loopId": "loop-1",
+            "responseToken": "token-1",
+            "response": "ok"
+        }),
+        None,
+    );
+    let (status, payload) = post_rpc(&client, &server, &respond).await?;
+    assert_eq!(status, 400);
+    assert_eq!(payload["error"]["code"], "INVALID_PARAMS");
+
+    let guidance = rpc_request(
+        "robot-guidance-no-idem",
+        "robot.guidance",
+        json!({ "text": "Keep going" }),
+        None,
+    );
+    let (status, payload) = post_rpc(&client, &server, &guidance).await?;
+    assert_eq!(status, 400);
+    assert_eq!(payload["error"]["code"], "INVALID_PARAMS");
+
+    server.stop().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn robot_stream_topics_accept_rpc_side_effects_and_internal_publish() -> Result<()> {
+    let server = TestServer::start(ApiConfig::default()).await;
+    let client = Client::new();
+
+    let subscribe = rpc_request(
+        "robot-stream-sub",
+        "stream.subscribe",
+        json!({ "topics": ["robot.response.received", "robot.question.asked"] }),
+        None,
+    );
+    let (status, subscribe_payload) = post_rpc(&client, &server, &subscribe).await?;
+    assert_eq!(status, 200);
+    let subscription_id = subscribe_payload["result"]["subscriptionId"]
+        .as_str()
+        .unwrap();
+    let mut stream = open_stream(&server, subscription_id).await?;
+
+    let respond = rpc_request(
+        "robot-stream-respond",
+        "robot.respond",
+        json!({
+            "questionId": 9,
+            "loopId": "loop-1",
+            "responseToken": "token-9",
+            "response": "yes"
+        }),
+        Some("idem-robot-stream-respond"),
+    );
+    let (status, response) = post_rpc(&client, &server, &respond).await?;
+    assert_eq!(status, 200);
+    assert_eq!(response["result"]["questionId"], 9);
+
+    let response_event = recv_topic_event(&mut stream, "robot.response.received").await;
+    assert_eq!(response_event["payload"]["question_id"], 9);
+    assert_eq!(response_event["resource"]["type"], "robot");
+
+    let publish = rpc_request(
+        "robot-stream-internal",
+        "_internal.publish",
+        json!({
+            "topic": "robot.question.asked",
+            "resourceType": "robot",
+            "resourceId": "9",
+            "payload": {
+                "question_id": 9,
+                "payload": "Need approval?",
+                "hat": "executor",
+                "iteration": 4
+            }
+        }),
+        None,
+    );
+    let (status, _) = post_rpc(&client, &server, &publish).await?;
+    assert_eq!(status, 200);
+
+    let question_event = recv_topic_event(&mut stream, "robot.question.asked").await;
+    assert_eq!(question_event["payload"]["question_id"], 9);
+    assert_eq!(question_event["payload"]["hat"], "executor");
+
+    stream.close(None).await?;
+    server.stop().await;
+    Ok(())
+}

--- a/crates/ralph-api/tests/rpc_v1_uncovered.rs
+++ b/crates/ralph-api/tests/rpc_v1_uncovered.rs
@@ -109,6 +109,20 @@ async fn system_capabilities_returns_expected_shape() -> Result<()> {
     assert_eq!(status, 200);
     assert!(payload["result"]["methods"].is_array());
     assert!(payload["result"]["streamTopics"].is_array());
+    let methods = payload["result"]["methods"].as_array().unwrap();
+    assert!(methods.iter().any(|method| method == "robot.question"));
+    assert!(methods.iter().any(|method| method == "robot.respond"));
+    assert!(methods.iter().any(|method| method == "robot.guidance"));
+    assert!(methods.iter().any(|method| method == "robot.checkin"));
+    let topics = payload["result"]["streamTopics"].as_array().unwrap();
+    assert!(topics.iter().any(|topic| topic == "robot.question.asked"));
+    assert!(
+        topics
+            .iter()
+            .any(|topic| topic == "robot.response.received")
+    );
+    assert!(topics.iter().any(|topic| topic == "robot.guidance.sent"));
+    assert!(topics.iter().any(|topic| topic == "robot.checkin.updated"));
     assert!(payload["result"]["auth"]["mode"].is_string());
     assert!(payload["result"]["auth"]["supportedModes"].is_array());
 

--- a/crates/ralph-api/tests/rpc_v1_uncovered.rs
+++ b/crates/ralph-api/tests/rpc_v1_uncovered.rs
@@ -114,6 +114,7 @@ async fn system_capabilities_returns_expected_shape() -> Result<()> {
     assert!(methods.iter().any(|method| method == "robot.respond"));
     assert!(methods.iter().any(|method| method == "robot.guidance"));
     assert!(methods.iter().any(|method| method == "robot.checkin"));
+    assert!(!methods.iter().any(|method| method == "_internal.publish"));
     let topics = payload["result"]["streamTopics"].as_array().unwrap();
     assert!(topics.iter().any(|topic| topic == "robot.question.asked"));
     assert!(


### PR DESCRIPTION
Closes #243

## Summary
- add robot.question, robot.respond, robot.guidance, and robot.checkin RPC dispatch backed by .ralph/api files
- register robot stream topics and publish response/guidance side effects
- update RPC/event schemas, capabilities, MCP catalog expectations, and robot integration tests

## Verification
- cargo test -p ralph-api -- --nocapture
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --quiet
- cargo test -p ralph-core smoke_runner --quiet
- tmux smoke: cargo test -p ralph-api robot_stream_topics_accept_rpc_side_effects_and_internal_publish -- --nocapture (SMOKE_EXIT=0)