### PR TITLE
fix(tui): capture keystrokes in search input mode

### DIFF
--- a/crates/ralph-tui/examples/guidance_test.rs
+++ b/crates/ralph-tui/examples/guidance_test.rs
@@ -19,8 +19,10 @@ async fn main() -> anyhow::Result<()> {
     let test_dir = PathBuf::from(home).join(".ralph-guidance-test");
     std::fs::create_dir_all(&test_dir)?;
     let events_path = test_dir.join("events.jsonl");
+    let urgent_steer_path = test_dir.join("urgent-steer.json");
     // Clean previous test data
     let _ = std::fs::remove_file(&events_path);
+    let _ = std::fs::remove_file(&urgent_steer_path);
 
     // Create termination channel
     let (_terminated_tx, terminated_rx) = tokio::sync::watch::channel(false);
@@ -28,7 +30,8 @@ async fn main() -> anyhow::Result<()> {
     // Build TUI
     let tui = Tui::new()
         .with_termination_signal(terminated_rx)
-        .with_events_path(events_path.clone());
+        .with_events_path(events_path.clone())
+        .with_urgent_steer_path(urgent_steer_path.clone());
 
     let state = tui.state();
 

--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -101,7 +101,13 @@ pub fn dispatch_action(action: Action, state: &mut TuiState, viewport_height: us
             }
         }
         Action::StartSearch => {
+            // Enter input mode with an empty query so the footer shows the
+            // "Search: " prompt immediately; characters are captured by
+            // `handle_search_input` while `search_mode` is active.
             state.search_state.search_mode = true;
+            state.search_state.query = Some(String::new());
+            state.search_state.matches.clear();
+            state.search_state.current_match = 0;
         }
         Action::SearchNext => {
             state.next_match();
@@ -130,6 +136,60 @@ pub fn dispatch_action(action: Action, state: &mut TuiState, viewport_height: us
         Action::None => {}
     }
     false
+}
+
+/// Handles a key press while search input mode is active.
+///
+/// While `search_state.search_mode` is true, every key is captured here
+/// (the caller must `continue` instead of mapping the key to an action) so
+/// that typing a query does not leak through to normal keybindings.
+///
+/// - `Char`/`Backspace`: edit the query and live-update matches.
+/// - `Enter`: commit a non-empty query (leaving `query`/`matches` intact so
+///   `n`/`N` can navigate); an empty query clears the search.
+/// - `Esc`: cancel and clear the search.
+///
+/// Returns `true` when the key was consumed (search mode was active).
+fn handle_search_input(state: &mut TuiState, code: crossterm::event::KeyCode) -> bool {
+    use crossterm::event::KeyCode;
+
+    if !state.search_state.search_mode {
+        return false;
+    }
+
+    match code {
+        KeyCode::Esc => {
+            state.clear_search();
+        }
+        KeyCode::Enter => {
+            let has_query = state
+                .search_state
+                .query
+                .as_deref()
+                .is_some_and(|q| !q.is_empty());
+            if has_query {
+                // Commit the search: leave the input mode but keep the query
+                // and matches so `n`/`N` navigate the highlighted results.
+                state.search_state.search_mode = false;
+            } else {
+                state.clear_search();
+            }
+        }
+        KeyCode::Backspace => {
+            // `search` preserves `search_mode`, so the user stays in input mode.
+            let mut query = state.search_state.query.clone().unwrap_or_default();
+            query.pop();
+            state.search(&query);
+        }
+        KeyCode::Char(c) => {
+            let mut query = state.search_state.query.clone().unwrap_or_default();
+            query.push(c);
+            state.search(&query);
+        }
+        _ => {}
+    }
+
+    true
 }
 
 fn set_mouse_capture(enabled: bool) -> Result<()> {
@@ -336,6 +396,14 @@ impl<W: AsyncWrite + Unpin + Send + 'static> App<W> {
                                                 }
                                                 _ => {}
                                             }
+                                            continue;
+                                        }
+                                    }
+
+                                    // Search input mode: capture all keys into the query
+                                    {
+                                        let mut state = self.state.lock().unwrap();
+                                        if handle_search_input(&mut state, key.code) {
                                             continue;
                                         }
                                     }
@@ -635,6 +703,140 @@ mod tests {
         dispatch_action(Action::SearchPrev, &mut state, 10);
 
         assert_eq!(state.search_state.current_match, 0);
+    }
+
+    // =========================================================================
+    // Search input mode: keys must be captured into the query, not dispatched
+    // as normal keybindings (regression: typing a query containing 'e' fired
+    // the export action because no interception block existed).
+    // =========================================================================
+
+    fn seed_search_state() -> TuiState {
+        let mut state = TuiState::new();
+        state.start_new_iteration();
+        let buffer = state.current_iteration_mut().unwrap();
+        buffer.append_line(Line::from("reviewing changes"));
+        buffer.append_line(Line::from("reviewing more"));
+        buffer.append_line(Line::from("done"));
+        state
+    }
+
+    #[test]
+    fn start_search_enters_input_mode_with_empty_query() {
+        let mut state = seed_search_state();
+
+        dispatch_action(Action::StartSearch, &mut state, 10);
+
+        assert!(state.search_state.search_mode, "'/' must enter input mode");
+        assert_eq!(
+            state.search_state.query.as_deref(),
+            Some(""),
+            "query prompt should start empty so the footer shows 'Search: '"
+        );
+    }
+
+    #[test]
+    fn typed_chars_build_query_and_do_not_dispatch_actions() {
+        let mut state = seed_search_state();
+        dispatch_action(Action::StartSearch, &mut state, 10);
+
+        // Type "review" — note this includes 'e', which previously fell through
+        // to Action::ExportCurrentIteration.
+        for c in "review".chars() {
+            assert!(
+                handle_search_input(&mut state, KeyCode::Char(c)),
+                "search mode must consume '{c}'"
+            );
+        }
+
+        assert_eq!(state.search_state.query.as_deref(), Some("review"));
+        assert!(
+            !state.search_state.matches.is_empty(),
+            "live search should find 'review' matches while typing"
+        );
+        assert!(
+            state.export_flash.is_none(),
+            "typing a query must NOT trigger the export action"
+        );
+    }
+
+    #[test]
+    fn backspace_edits_query_live() {
+        let mut state = seed_search_state();
+        dispatch_action(Action::StartSearch, &mut state, 10);
+        for c in "reviewx".chars() {
+            handle_search_input(&mut state, KeyCode::Char(c));
+        }
+        assert!(state.search_state.matches.is_empty(), "'reviewx' has no match");
+
+        handle_search_input(&mut state, KeyCode::Backspace);
+
+        assert_eq!(state.search_state.query.as_deref(), Some("review"));
+        assert!(
+            !state.search_state.matches.is_empty(),
+            "backspace should re-run search and restore matches"
+        );
+    }
+
+    #[test]
+    fn enter_commits_query_and_keeps_results_for_navigation() {
+        let mut state = seed_search_state();
+        dispatch_action(Action::StartSearch, &mut state, 10);
+        for c in "reviewing".chars() {
+            handle_search_input(&mut state, KeyCode::Char(c));
+        }
+
+        assert!(handle_search_input(&mut state, KeyCode::Enter));
+
+        assert!(
+            !state.search_state.search_mode,
+            "Enter exits input mode so n/N dispatch as navigation"
+        );
+        assert_eq!(
+            state.search_state.query.as_deref(),
+            Some("reviewing"),
+            "committed query is kept for the footer display"
+        );
+        let matches = state.search_state.matches.len();
+        assert!(matches >= 2, "two lines contain 'reviewing'");
+
+        // n/N now dispatch normally and navigate the committed results.
+        assert!(!handle_search_input(&mut state, KeyCode::Char('n')));
+        dispatch_action(Action::SearchNext, &mut state, 10);
+        assert_eq!(state.search_state.current_match, 1);
+    }
+
+    #[test]
+    fn enter_on_empty_query_clears_search() {
+        let mut state = seed_search_state();
+        dispatch_action(Action::StartSearch, &mut state, 10);
+
+        handle_search_input(&mut state, KeyCode::Enter);
+
+        assert!(!state.search_state.search_mode);
+        assert!(state.search_state.query.is_none(), "empty query is cleared");
+    }
+
+    #[test]
+    fn esc_cancels_search_input() {
+        let mut state = seed_search_state();
+        dispatch_action(Action::StartSearch, &mut state, 10);
+        for c in "review".chars() {
+            handle_search_input(&mut state, KeyCode::Char(c));
+        }
+
+        assert!(handle_search_input(&mut state, KeyCode::Esc));
+
+        assert!(!state.search_state.search_mode);
+        assert!(state.search_state.query.is_none());
+        assert!(state.search_state.matches.is_empty());
+    }
+
+    #[test]
+    fn handle_search_input_is_noop_when_not_searching() {
+        let mut state = seed_search_state();
+        // Not in search mode: the helper must not consume the key.
+        assert!(!handle_search_input(&mut state, KeyCode::Char('e')));
     }
 
     // =========================================================================

--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -767,7 +767,10 @@ mod tests {
         for c in "reviewx".chars() {
             handle_search_input(&mut state, KeyCode::Char(c));
         }
-        assert!(state.search_state.matches.is_empty(), "'reviewx' has no match");
+        assert!(
+            state.search_state.matches.is_empty(),
+            "'reviewx' has no match"
+        );
 
         handle_search_input(&mut state, KeyCode::Backspace);
 

--- a/crates/ralph-tui/src/widgets/footer.rs
+++ b/crates/ralph-tui/src/widgets/footer.rs
@@ -91,7 +91,10 @@ impl Widget for Footer<'_> {
 
         // If search state has an active query, render search display
         if let Some(query) = &self.state.search_state.query {
-            let match_info = if self.state.search_state.matches.is_empty() {
+            let match_info = if query.is_empty() {
+                // Still typing the query; no count to show yet.
+                String::new()
+            } else if self.state.search_state.matches.is_empty() {
                 "no matches".to_string()
             } else {
                 format!(


### PR DESCRIPTION
## Summary

Search mode in `ralph-tui` was non-functional: pressing `/` set `search_state.search_mode = true` but **no key-interception block existed**, so typed query characters fell through to `map_key` and dispatched as normal keybindings. Concretely:

- Typing a query containing `e` fired the new export action (added today in `3454c62`).
- The footer never showed the query or an `N/M` match counter.
- `n` / `N` / `Esc` were inert no-ops.

The state layer (`search`, `next_match`, `clear_search`) and footer rendering were already correct and unit-tested — the snapshot harness calls `state.search()` directly, so it **bypassed the broken interactive path**, which is why CI stayed green. Today's export keybindings (`e`/`E`) are what made the orphaned search-input path visibly collide.

## Fix

- Add `handle_search_input`, a testable helper invoked from the event loop right after the guidance interception block:
  - `Char`/`Backspace` edit the query and live-update matches
  - `Enter` commits a non-empty query (keeping `query`/`matches` so `n`/`N` navigate) or clears an empty one
  - `Esc` cancels and clears the search
- `StartSearch` seeds an empty query so the footer shows the `Search: ` prompt immediately; the footer omits the match count while the query is empty.
- Wire `with_urgent_steer_path` into the `guidance_test` example so the `!` urgent-steer path is exercisable in-process.

## Tests

- 7 new regression tests in `app.rs` drive the full interactive path the snapshot harness bypassed (typing, backspace, commit, navigate, cancel, no-op-when-inactive).
- `cargo test -p ralph-tui`: all pass (242 unit + snapshots/integration). Full workspace builds clean.

## Verification

Found by the `verify-tui-ux` tmux workflow and re-verified live:

```
/reviewing -> "Search: reviewing 1/20"
n          -> "Search: reviewing 2/20"
Esc        -> search cleared, normal footer restored
```

No export file is written while typing `reviewing` (proving `e` no longer leaks to the export action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)