### PR TITLE
chore: release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,61 @@ All notable changes to ralph-orchestrator are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.10.0] - 2026-06-21
+
+### Added
+
+- Forge CLI backend integration.
+- RObot (human-in-the-loop) RPC domain in the control plane, plus a file-backed web mode that drives human interaction through files instead of a live socket.
+- Worktree loops can publish remote review branches, with rebase support.
+- Local file-based hat imports in preflight, including import resolution and schema validation with imported-file context.
+- On-demand export of TUI iteration buffers to disk: `e` exports the current iteration, `E` exports all iterations.
+- Context-window utilization telemetry, surfaced in the TUI.
+
+### Changed
+
+- Updated the Pi backend package reference to `@earendil-works/pi-coding-agent`.
+- Refreshed agent waves observability documentation and added the hat imports design spec.
+
+### Fixed
+
+- TUI search mode now captures typed query characters instead of leaking them to keybindings (e.g. an `e` in the query no longer triggers export); the `Search:` prompt, `N/M` match counter, and `n`/`N` navigation work again.
+- Runtime now requires an explicit completion signal after guidance, preventing premature loop termination.
+- Persist loop continue state across iterations.
+- Honor per-hat scratchpad configuration in generated instructions.
+- Drain ACP terminal output before exit so the final output is no longer truncated.
+- Canonicalize Ralph artifact paths to avoid path-mismatch errors.
+- Deduplicate MCP tool schemas exposed over the API.
+
+## [2.9.3] - 2026-05-08
+
+### Added
+
+- `ralph-docs` skill for `llms.txt`-driven introspection.
+- Unified preset mechanism under `-H <name>`, supporting both YAML and TOML presets.
+- `ralph plan` support for the kiro-acp backend, including a completion fallback.
+- Visual workflow editor (builder) with live agent observation.
+- Per-hat scratchpad configuration.
+- Hats can set a cancellation promise.
+- Improved `--no-tui` UX with a loop banner, per-iteration footer, and resume hint.
+
+### Changed
+
+- Switched Linux distribution targets to musl for Amazon Linux 2 / 2023 compatibility.
+- Documented global user config for hooks, added an FAQ section, and linked the autoloop authoring guide for the TOML preset format.
 
 ### Fixed
 
 - Claude child sessions now default to `--setting-sources project,local`, preventing host user-level `~/.claude/settings.json` hooks, plugins, and MCP servers from leaking into Ralph orchestration runs. Users who want the old behavior can opt back in with `cli.args: ["--setting-sources", "user,project,local"]`.
+- Route the text completion fallback through `check_completion_event()`.
+- Propagate the `RALPH_EVENTS_FILE` env var and preserve late termination reasons.
+- Prevent lingering text backends from stalling loop progression.
+- Resolve Rust 1.95 `duration_suboptimal_units` clippy warnings.
+
+### Security
+
+- Replaced `source` with a safe variable parser in `sync-embedded-files.sh`.
+- Use `npm ci` instead of `npm install` in `test-fresh-install.sh`.
 
 ## [2.9.2] - 2026-04-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ralph-adapters"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-api"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-bench"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-cli"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-core"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-e2e"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-proto"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-telegram"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-tui"
-version = "2.9.3"
+version = "2.10.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [workspace.package]
 edition = "2024"
-version = "2.9.3"
+version = "2.10.0"
 license = "MIT"
 repository = "https://github.com/mikeyobrien/ralph-orchestrator"
 homepage = "https://github.com/mikeyobrien/ralph-orchestrator"
@@ -140,15 +140,15 @@ scopeguard = "1"
 strip-ansi-escapes = "0.2"
 
 # Internal crates (version required for crates.io publishing)
-ralph-proto = { version = "2.9.3", path = "crates/ralph-proto" }
-ralph-core = { version = "2.9.3", path = "crates/ralph-core", features = ["recording"] }
-ralph-adapters = { version = "2.9.3", path = "crates/ralph-adapters" }
-ralph-tui = { version = "2.9.3", path = "crates/ralph-tui" }
-ralph-cli = { version = "2.9.3", path = "crates/ralph-cli" }
-ralph-bench = { version = "2.9.3", path = "crates/ralph-bench" }
-ralph-e2e = { version = "2.9.3", path = "crates/ralph-e2e" }
-ralph-telegram = { version = "2.9.3", path = "crates/ralph-telegram" }
-ralph-api = { version = "2.9.3", path = "crates/ralph-api" }
+ralph-proto = { version = "2.10.0", path = "crates/ralph-proto" }
+ralph-core = { version = "2.10.0", path = "crates/ralph-core", features = ["recording"] }
+ralph-adapters = { version = "2.10.0", path = "crates/ralph-adapters" }
+ralph-tui = { version = "2.10.0", path = "crates/ralph-tui" }
+ralph-cli = { version = "2.10.0", path = "crates/ralph-cli" }
+ralph-bench = { version = "2.10.0", path = "crates/ralph-bench" }
+ralph-e2e = { version = "2.10.0", path = "crates/ralph-e2e" }
+ralph-telegram = { version = "2.10.0", path = "crates/ralph-telegram" }
+ralph-api = { version = "2.10.0", path = "crates/ralph-api" }
 
 # Telegram bot framework
 teloxide = { version = "0.13", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }


### PR DESCRIPTION
Release prep for **v2.10.0** (19 commits since v2.9.3).

## Changes
- Bump workspace version `2.9.3` → `2.10.0` (all 10 crates + Cargo.lock).
- Stamp the `[2.10.0] - 2026-06-21` changelog section.
- Backfill the previously-missing `[2.9.3]` changelog section and relocate the orphaned settings-sources entry (#294) into it, so the changelog is continuous 2.9.2 → 2.9.3 → 2.10.0.

## Highlights for 2.10.0

**Added** — Forge CLI backend; RObot RPC domain + file-backed web mode; remote review-branch publishing for worktree loops; local hat imports in preflight; on-demand TUI iteration-buffer export (`e`/`E`); context-window utilization telemetry.

**Fixed** — TUI search-input regression (#337); require-explicit-completion-after-guidance (#326); persist continue state; per-hat scratchpad in prompts; ACP output drain; artifact path canonicalization; MCP schema dedup.

## Verification
- `cargo build` clean (Cargo.lock updated to 2.10.0).
- `cargo test` — full workspace suite passes, 0 failures.

After merge, tag `v2.10.0` on main to trigger the release workflow (GitHub release + macOS/Linux binaries + crates.io + npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)