### PR TITLE
release: prepare v2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to ralph-orchestrator are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.1] - 2026-06-22
+
+### Fixed
+
+- Restore e2e mock-mode verification by passing prompts to the cassette-backed custom backend over stdin.
+- Update the mock e2e single-iteration scenario to validate the completion signal instead of legacy scratchpad writes.
+- Isolate gitignore integration tests from user/global Git exclude files.
+
 ## [2.10.0] - 2026-06-21
 
 ### Added
@@ -258,7 +266,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Modularized codebase and fixed TUI mode
 
-[Unreleased]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.8.0...HEAD
+[Unreleased]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.10.1...HEAD
+[2.10.1]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.10.0...v2.10.1
+[2.10.0]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.9.3...v2.10.0
+[2.9.3]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.9.2...v2.9.3
+[2.9.2]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.9.1...v2.9.2
+[2.9.1]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.9.0...v2.9.1
+[2.9.0]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.8.1...v2.9.0
+[2.8.1]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.7.0...v2.8.0
 [2.7.0]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/mikeyobrien/ralph-orchestrator/compare/v2.5.1...v2.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ralph-adapters"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "agent-client-protocol",
  "ansi-to-tui",
@@ -2775,7 +2775,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-api"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-bench"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-cli"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-core"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-e2e"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-proto"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-telegram"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "ralph-tui"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [workspace.package]
 edition = "2024"
-version = "2.10.0"
+version = "2.10.1"
 license = "MIT"
 repository = "https://github.com/mikeyobrien/ralph-orchestrator"
 homepage = "https://github.com/mikeyobrien/ralph-orchestrator"
@@ -140,15 +140,15 @@ scopeguard = "1"
 strip-ansi-escapes = "0.2"
 
 # Internal crates (version required for crates.io publishing)
-ralph-proto = { version = "2.10.0", path = "crates/ralph-proto" }
-ralph-core = { version = "2.10.0", path = "crates/ralph-core", features = ["recording"] }
-ralph-adapters = { version = "2.10.0", path = "crates/ralph-adapters" }
-ralph-tui = { version = "2.10.0", path = "crates/ralph-tui" }
-ralph-cli = { version = "2.10.0", path = "crates/ralph-cli" }
-ralph-bench = { version = "2.10.0", path = "crates/ralph-bench" }
-ralph-e2e = { version = "2.10.0", path = "crates/ralph-e2e" }
-ralph-telegram = { version = "2.10.0", path = "crates/ralph-telegram" }
-ralph-api = { version = "2.10.0", path = "crates/ralph-api" }
+ralph-proto = { version = "2.10.1", path = "crates/ralph-proto" }
+ralph-core = { version = "2.10.1", path = "crates/ralph-core", features = ["recording"] }
+ralph-adapters = { version = "2.10.1", path = "crates/ralph-adapters" }
+ralph-tui = { version = "2.10.1", path = "crates/ralph-tui" }
+ralph-cli = { version = "2.10.1", path = "crates/ralph-cli" }
+ralph-bench = { version = "2.10.1", path = "crates/ralph-bench" }
+ralph-e2e = { version = "2.10.1", path = "crates/ralph-e2e" }
+ralph-telegram = { version = "2.10.1", path = "crates/ralph-telegram" }
+ralph-api = { version = "2.10.1", path = "crates/ralph-api" }
 
 # Telegram bot framework
 teloxide = { version = "0.13", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }

--- a/crates/ralph-e2e/src/scenarios/orchestration.rs
+++ b/crates/ralph-e2e/src/scenarios/orchestration.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 /// - Configures max_iterations to 1
 /// - Sends a simple task that completes in one turn
 /// - Verifies exactly 1 iteration completed
-/// - Verifies scratchpad was updated
+/// - Verifies the completion signal was emitted
 ///
 /// # Example
 ///
@@ -48,7 +48,7 @@ impl SingleIterScenario {
     pub fn new() -> Self {
         Self {
             id: "single-iter".to_string(),
-            description: "Verifies single iteration completion with scratchpad update".to_string(),
+            description: "Verifies single iteration completion signal".to_string(),
             tier: "Tier 2: Orchestration Loop".to_string(),
         }
     }
@@ -104,11 +104,10 @@ event_loop:
         // Create a prompt that completes in a single iteration
         let prompt = r"You are testing Ralph orchestration.
 Complete this task in a single iteration:
-1. Create a simple task list in the scratchpad
-2. Mark the task as complete
-3. Output LOOP_COMPLETE to signal completion
+1. Do the requested work
+2. Output LOOP_COMPLETE to signal completion
 
-Write to the scratchpad first, then output LOOP_COMPLETE.";
+Output LOOP_COMPLETE when the work is complete.";
 
         Ok(ScenarioConfig {
             config_file: "ralph.yml".into(),
@@ -142,7 +141,7 @@ Write to the scratchpad first, then output LOOP_COMPLETE.";
             Assertions::exit_code_success_or_limit(&execution),
             Assertions::no_timeout(&execution),
             Assertions::iterations_within(&execution, 1),
-            self.scratchpad_updated(&execution),
+            self.completion_signal_emitted(&execution),
         ];
 
         let all_passed = assertions.iter().all(|a| a.passed);
@@ -160,24 +159,25 @@ Write to the scratchpad first, then output LOOP_COMPLETE.";
 }
 
 impl SingleIterScenario {
-    /// Asserts that the scratchpad was updated during execution.
-    fn scratchpad_updated(
+    /// Asserts that the backend emitted the configured completion signal.
+    fn completion_signal_emitted(
         &self,
         result: &crate::executor::ExecutionResult,
     ) -> crate::models::Assertion {
-        let updated = result
-            .scratchpad
-            .as_ref()
-            .is_some_and(|s| !s.trim().is_empty());
-        super::AssertionBuilder::new("Scratchpad updated")
-            .expected("Scratchpad contains content")
-            .actual(if updated {
-                "Scratchpad has content".to_string()
+        let emitted = result.stdout.contains("LOOP_COMPLETE")
+            || result.termination_reason.as_deref() == Some("LOOP_COMPLETE");
+        super::AssertionBuilder::new("Completion signal emitted")
+            .expected("Output or termination reason contains LOOP_COMPLETE")
+            .actual(if emitted {
+                "LOOP_COMPLETE observed".to_string()
             } else {
-                "Scratchpad empty or missing".to_string()
+                format!(
+                    "No LOOP_COMPLETE observed; termination reason: {:?}",
+                    result.termination_reason
+                )
             })
             .build()
-            .with_passed(updated)
+            .with_passed(emitted)
     }
 }
 
@@ -630,29 +630,41 @@ mod tests {
     }
 
     #[test]
-    fn test_single_iter_scratchpad_assertion_passed() {
+    fn test_single_iter_completion_signal_assertion_passed() {
         let scenario = SingleIterScenario::new();
-        let result = mock_execution_result();
-        let assertion = scenario.scratchpad_updated(&result);
-        assert!(assertion.passed, "Should pass when scratchpad has content");
+        let mut result = mock_execution_result();
+        result.stdout = "Work complete\nLOOP_COMPLETE".to_string();
+        let assertion = scenario.completion_signal_emitted(&result);
+        assert!(
+            assertion.passed,
+            "Should pass when LOOP_COMPLETE is emitted"
+        );
     }
 
     #[test]
-    fn test_single_iter_scratchpad_assertion_failed_empty() {
+    fn test_single_iter_completion_signal_assertion_passed_from_reason() {
         let scenario = SingleIterScenario::new();
         let mut result = mock_execution_result();
-        result.scratchpad = Some(String::new());
-        let assertion = scenario.scratchpad_updated(&result);
-        assert!(!assertion.passed, "Should fail when scratchpad is empty");
+        result.stdout = "Work complete".to_string();
+        result.termination_reason = Some("LOOP_COMPLETE".to_string());
+        let assertion = scenario.completion_signal_emitted(&result);
+        assert!(
+            assertion.passed,
+            "Should pass when LOOP_COMPLETE is the termination reason"
+        );
     }
 
     #[test]
-    fn test_single_iter_scratchpad_assertion_failed_none() {
+    fn test_single_iter_completion_signal_assertion_failed() {
         let scenario = SingleIterScenario::new();
         let mut result = mock_execution_result();
-        result.scratchpad = None;
-        let assertion = scenario.scratchpad_updated(&result);
-        assert!(!assertion.passed, "Should fail when scratchpad is missing");
+        result.stdout = "Work complete".to_string();
+        result.termination_reason = Some("MAX_ITERATIONS".to_string());
+        let assertion = scenario.completion_signal_emitted(&result);
+        assert!(
+            !assertion.passed,
+            "Should fail when no completion signal is observed"
+        );
     }
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ralph-orchestrator",
-  "version": "2.9.2",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ralph-orchestrator",
-      "version": "2.9.2",
+      "version": "2.10.1",
       "license": "MIT",
       "workspaces": [
         "backend/*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ralph-orchestrator",
-  "version": "2.9.2",
+  "version": "2.10.1",
   "private": true,
   "description": "AI agent orchestrator with web dashboard",
   "workspaces": [


### PR DESCRIPTION
## Summary
- Bump Rust workspace crates and root npm metadata to v2.10.1.
- Add the v2.10.1 changelog entry and compare links.
- Update the mock e2e single-iteration scenario to assert the completion signal instead of legacy scratchpad writes.

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo test -p ralph-core --features recording --test smoke_runner`
- `cargo test -p ralph-e2e orchestration::`
- `cargo run -p ralph-e2e -- --mock` (15 passed, 60 skipped for missing cassettes)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo package -p ralph-cli --allow-dirty --list > /dev/null`
- `npm test`
- `npm run build` (passes; Vite reports existing chunk-size warning)

## Notes
- Local `npm test` initially hit a stale `better-sqlite3` native addon built for a different Node ABI; `npm rebuild better-sqlite3` repaired the local environment before the passing run.
- This PR prepares the release only. It does not create or push the `v2.10.1` tag.
