### PR TITLE
fix(adapters): wait for Claude stream result events

### DIFF
--- a/crates/ralph-adapters/src/cli_executor.rs
+++ b/crates/ralph-adapters/src/cli_executor.rs
@@ -19,7 +19,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 use tracing::{debug, warn};
 
-const POST_EVENT_GRACE_TIMEOUT: Duration = Duration::from_secs(5);
+const TEXT_POST_EVENT_GRACE_TIMEOUT: Duration = Duration::from_secs(5);
 const TERMINATION_GRACE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Result of a CLI execution.
@@ -183,9 +183,11 @@ impl CliExecutor {
 
             match next_event {
                 Some(StreamEvent::StdoutLine(line)) => {
-                    if line_signals_event_emitted(&line) {
+                    if self.backend.output_format == OutputFormat::Text
+                        && line_signals_event_emitted(&line)
+                    {
                         post_event_deadline.get_or_insert_with(|| {
-                            tokio::time::Instant::now() + POST_EVENT_GRACE_TIMEOUT
+                            tokio::time::Instant::now() + TEXT_POST_EVENT_GRACE_TIMEOUT
                         });
                     }
                     if self.backend.output_format == OutputFormat::CopilotStreamJson {
@@ -203,9 +205,11 @@ impl CliExecutor {
                     accumulated_output.push('\n');
                 }
                 Some(StreamEvent::StderrLine(line)) => {
-                    if line_signals_event_emitted(&line) {
+                    if self.backend.output_format == OutputFormat::Text
+                        && line_signals_event_emitted(&line)
+                    {
                         post_event_deadline.get_or_insert_with(|| {
-                            tokio::time::Instant::now() + POST_EVENT_GRACE_TIMEOUT
+                            tokio::time::Instant::now() + TEXT_POST_EVENT_GRACE_TIMEOUT
                         });
                     }
                     if verbose {
@@ -614,6 +618,61 @@ mod tests {
         );
         assert!(result.output.contains("Event emitted: task.done"));
         assert!(result.output.contains("heartbeat"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_claude_stream_waits_for_result_after_final_assistant_message() {
+        let backend = CliBackend {
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"Event emitted: task.done"}]}}'; sleep 6; printf '%s\n' '{"type":"result","duration_ms":6000,"total_cost_usd":0.01,"num_turns":1,"is_error":false}'"#.to_string(),
+            ],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::StreamJson,
+            env_vars: vec![],
+        };
+
+        let executor = CliExecutor::new(backend);
+        let result = executor
+            .execute_capture_with_timeout("", Some(Duration::from_secs(10)))
+            .await
+            .unwrap();
+
+        assert!(
+            !result.timed_out,
+            "Claude stream should receive its terminal result event during the post-assistant quiet window"
+        );
+        assert!(result.success, "Claude stream should exit successfully");
+        assert!(result.output.contains(r#"{"type":"result""#));
+    }
+
+    #[tokio::test]
+    async fn test_execute_claude_stream_still_times_out_without_result() {
+        let backend = CliBackend {
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                r#"printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"Event emitted: task.done"}]}}'; sleep 10"#.to_string(),
+            ],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::StreamJson,
+            env_vars: vec![],
+        };
+
+        let executor = CliExecutor::new(backend);
+        let result = executor
+            .execute_capture_with_timeout("", Some(Duration::from_millis(200)))
+            .await
+            .unwrap();
+
+        assert!(
+            result.timed_out,
+            "Claude stream without a result event should retain inactivity timeout protection"
+        );
+        assert!(!result.success, "Timed-out Claude stream must fail");
     }
 
     #[tokio::test]

--- a/crates/ralph-core/src/diagnostics/mod.rs
+++ b/crates/ralph-core/src/diagnostics/mod.rs
@@ -228,12 +228,12 @@ mod tests {
         let dir_name = session_dir.file_name().unwrap().to_str().unwrap();
 
         // Verify format: YYYY-MM-DDTHH-MM-SS
-        assert!(dir_name.len() == 19); // 2024-01-21T08-49-56
-        assert!(dir_name.chars().nth(4) == Some('-'));
-        assert!(dir_name.chars().nth(7) == Some('-'));
-        assert!(dir_name.chars().nth(10) == Some('T'));
-        assert!(dir_name.chars().nth(13) == Some('-'));
-        assert!(dir_name.chars().nth(16) == Some('-'));
+        assert_eq!(dir_name.len(), 19); // 2024-01-21T08-49-56
+        assert_eq!(dir_name.chars().nth(4), Some('-'));
+        assert_eq!(dir_name.chars().nth(7), Some('-'));
+        assert_eq!(dir_name.chars().nth(10), Some('T'));
+        assert_eq!(dir_name.chars().nth(13), Some('-'));
+        assert_eq!(dir_name.chars().nth(16), Some('-'));
     }
 
     #[test]

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -2430,7 +2430,7 @@ impl EventLoop {
         for malformed in &result.malformed {
             let payload = format!(
                 "Line {}: {}\nContent: {}",
-                malformed.line_number, malformed.error, &malformed.content
+                malformed.line_number, malformed.error, malformed.content
             );
             let event = Event::new("event.malformed", &payload);
             self.bus.publish(event);

--- a/crates/ralph-core/src/memory_store.rs
+++ b/crates/ralph-core/src/memory_store.rs
@@ -401,7 +401,7 @@ mod tests {
         store.init(false).unwrap();
         let result = store.init(false);
         assert!(result.is_err());
-        assert!(result.unwrap_err().kind() == io::ErrorKind::AlreadyExists);
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::AlreadyExists);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Scope the five-second post-event shutdown grace to plain-text adapters so Claude `stream-json` can emit its terminal `result` after a quiet window.
- Preserve the configured inactivity timeout for genuinely hung structured streams and add deterministic regression coverage for both paths.
- Include mechanical Rust 1.97 clippy fixes required by the repository's mandatory commit/push hooks.

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test -p ralph-core --features recording --test smoke_runner` (52 passed)
- Hooks BDD gate (18 passed)
- Mock E2E smoke (15 available cassettes passed; 60 missing-cassette scenarios skipped)
- Independent read-only diff review: PASS, no security or logic findings

Closes #354