### PR TITLE
ci: fix fork-PR lint workflow (allow-unsafe-pr-checkout)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Required for pull_request_target: this workflow deliberately
+          # checks out the fork's head SHA (no secrets, permissions:{}),
+          # so opt into checking out fork PR code here.
+          allow-unsafe-pr-checkout: true
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## What

Fixes the `Lint (Fork PRs)` GitHub Actions workflow, which is silently failing the `Format` check on **every** external fork PR.

## Symptom

PRs from forks that are actually fmt-clean (e.g. **#358** OMP backend, **#353** JP localization) show `Format: FAILURE`. The failure is **not** a code defect:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow... Set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

The workflow triggers on `pull_request_target` but `actions/checkout@v4` refuses to fetch the fork head SHA, so the checkout step fails and rustfmt never runs. Verified locally: `cargo fmt --all -- --check` exits 0 on #358's head SHA, confirming the code is clean and the gate is the workflow itself.

## Fix

Added `allow-unsafe-pr-checkout: true` to the checkout step. This is the sanctioned opt-in for `pull_request_target` workflows that deliberately check out fork code. Safe here because the workflow is secrets-free (`permissions: {}`) and pins `ref` to the fork head SHA.

## Impact

Restores real format-gating for fork contributions and unblocks the accurate signal on #353 / #358 (both would otherwise appear to have bad CI when they don't).