### PR TITLE
feat(doctor): recognize OrcaRouter as a named provider for models.dev backends

### DIFF
--- a/crates/ralph-cli/presets/minimal/opencode.yml
+++ b/crates/ralph-cli/presets/minimal/opencode.yml
@@ -3,7 +3,9 @@
 #
 # Requires:
 # - `opencode` CLI installed (https://github.com/opencode-ai/opencode)
-# - Configured provider credentials (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
+# - Configured provider credentials (ANTHROPIC_API_KEY, OPENAI_API_KEY, ORCAROUTER_API_KEY, etc.)
+#   OrcaRouter is a named provider in the models.dev registry; set ORCAROUTER_API_KEY
+#   and use a model like `orcarouter/auto` (https://www.orcarouter.ai).
 #
 # Note: opencode 1.1.30+ requires explicit model flag (-m) for reliable operation.
 # Change the model below to your preferred provider/model combination.

--- a/crates/ralph-cli/src/doctor.rs
+++ b/crates/ralph-cli/src/doctor.rs
@@ -371,15 +371,18 @@ fn auth_env_vars(backend: &str) -> Option<Vec<&'static str>> {
         "kiro-acp" => Some(vec!["KIRO_API_KEY"]),
         "opencode" => Some(vec![
             "OPENCODE_API_KEY",
+            "ORCAROUTER_API_KEY",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
         ]),
         "pi" => Some(vec![
+            "ORCAROUTER_API_KEY",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GEMINI_API_KEY",
         ]),
         "roo" => Some(vec![
+            "ORCAROUTER_API_KEY",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GEMINI_API_KEY",
@@ -697,6 +700,33 @@ mod tests {
         });
 
         assert_eq!(check.status, CheckStatus::Pass);
+    }
+
+    #[test]
+    fn orcarouter_api_key_satisfies_opencode_pi_roo_auth_hints() {
+        for backend in ["opencode", "pi", "roo"] {
+            let backends = vec![backend.to_string()];
+            let check = auth_hint_check(&backends, |key| match key {
+                "ORCAROUTER_API_KEY" => Some("present".to_string()),
+                _ => None,
+            });
+            assert_eq!(
+                check.status,
+                CheckStatus::Pass,
+                "ORCAROUTER_API_KEY should satisfy {backend} auth hint"
+            );
+        }
+    }
+
+    #[test]
+    fn orcarouter_api_key_listed_in_auth_env_vars_for_models_dev_backends() {
+        for backend in ["opencode", "pi", "roo"] {
+            let envs = auth_env_vars(backend).expect("known backend");
+            assert!(
+                envs.contains(&"ORCAROUTER_API_KEY"),
+                "{backend} auth env vars should include ORCAROUTER_API_KEY: {envs:?}"
+            );
+        }
     }
 
     #[test]

--- a/docs/guide/backends.md
+++ b/docs/guide/backends.md
@@ -300,8 +300,20 @@ opencode --version
 ```
 
 **Auth & env vars:**
-- Set one of: `OPENCODE_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
+- Set one of: `OPENCODE_API_KEY`, `ORCAROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`
 - OpenCode can proxy multiple providers; use the env var matching your provider
+
+**OrcaRouter (optional):**
+
+OpenCode reads provider definitions from the [models.dev](https://models.dev) registry, which includes OrcaRouter as a first-class provider (`ORCAROUTER_API_KEY`). Route any `orcarouter/*` model through the [OrcaRouter](https://www.orcarouter.ai) gateway:
+
+```yaml
+hats:
+  strategist:
+    backend:
+      type: "opencode"
+      args: ["-m", "orcarouter/auto"]
+```
 
 **Hat YAML:**
 ```yaml
@@ -312,7 +324,7 @@ hats:
 
 **Doctor checks:**
 - `opencode --version` must succeed
-- Warns if none of `OPENCODE_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` are set
+- Warns if none of `OPENCODE_API_KEY`, `ORCAROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY` are set
 
 ### Pi (`pi`)
 
@@ -327,9 +339,21 @@ pi --version
 ```
 
 **Auth & env vars:**
-- Set one of: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or any supported provider key
+- Set one of: `ORCAROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or any supported provider key
 - Pi routes to the provider specified via `--provider` (default: google)
 - Pass API key explicitly with `--api-key` or rely on provider-specific env vars
+
+**OrcaRouter (optional):**
+
+Pi supports [models.dev](https://models.dev) providers, including OrcaRouter as a named provider. Route through the [OrcaRouter](https://www.orcarouter.ai) gateway with `--provider orcarouter`:
+
+```yaml
+hats:
+  coder:
+    backend:
+      type: "pi"
+      args: ["--provider", "orcarouter", "--model", "orcarouter/auto"]
+```
 
 **Hat YAML:**
 ```yaml


### PR DESCRIPTION
## What changed

Adds **OrcaRouter** as a recognized named provider for the models.dev-backed backends (`opencode`, `pi`, `roo`).

All three CLIs resolve their provider and model catalog through the [models.dev](https://models.dev) registry, which already lists OrcaRouter as a first-class provider (base `https://api.orcarouter.ai/v1`, env key `ORCAROUTER_API_KEY`, 80+ models). This PR makes `ralph doctor` recognize an OrcaRouter key as satisfying authentication for those backends, and documents the named wiring in the backends guide.

- `crates/ralph-cli/src/doctor.rs` — add `ORCAROUTER_API_KEY` to `auth_env_vars` for `opencode`, `pi`, `roo`; two new unit tests pin that an OrcaRouter key passes the auth hint check and is listed in the env hints for each backend.
- `docs/guide/backends.md` — add an "OrcaRouter (optional)" subsection under OpenCode and Pi with usage examples (`-m orcarouter/auto`, `--provider orcarouter`), and include `ORCAROUTER_API_KEY` in the auth env lists.
- `crates/ralph-cli/presets/minimal/opencode.yml` — mention `ORCAROUTER_API_KEY` in the preset's credential comment.

## Why

Users of Ralph who already route models through a gateway can now use the [OrcaRouter](https://www.orcarouter.ai) gateway as a first-class backend with zero config beyond setting `ORCAROUTER_API_KEY`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Validation

- `cargo build -p ralph-cli` — clean
- `cargo test -p ralph-cli --bin ralph` — 474 passed (2 new OrcaRouter tests)
- `cargo test -p ralph-adapters --lib` — 305 passed
- `cargo test -p ralph-core --lib` — 879 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p ralph-cli --bin ralph` — no new warnings
- Live check against `https://api.orcarouter.ai/v1/chat/completions` (`orcarouter/auto`) returned HTTP 200 with `ORCA-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
