### PR TITLE
[v3] Drive ralph-bench task execution on the autoloop engine (#346)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "ralph-proto",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/ralph-bench/Cargo.toml
+++ b/crates/ralph-bench/Cargo.toml
@@ -26,3 +26,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/ralph-bench/src/autoloop_task.rs
+++ b/crates/ralph-bench/src/autoloop_task.rs
@@ -1,0 +1,343 @@
+use anyhow::{Context, Result};
+use ralph_adapters::{AutoloopBin, AutoloopRunner};
+use ralph_core::{Record, SessionRecorder, TaskDefinition, TaskWorkspace};
+use ralph_proto::TerminalWrite;
+use serde_json::Value;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const PRESET_DIR: &str = ".ralph/bench-autoloop-preset";
+const EVENTS_FILE: &str = ".ralph/bench-autoloop-events.ndjson";
+
+pub async fn run_task_loop(
+    task: &TaskDefinition,
+    workspace: &TaskWorkspace,
+    record_path: Option<&PathBuf>,
+    record_ux: bool,
+) -> Result<(u32, String)> {
+    run_task_loop_with_bin(
+        task,
+        workspace,
+        record_path,
+        record_ux,
+        AutoloopBin::PathLookup,
+    )
+    .await
+}
+
+async fn run_task_loop_with_bin(
+    task: &TaskDefinition,
+    workspace: &TaskWorkspace,
+    record_path: Option<&PathBuf>,
+    record_ux: bool,
+    bin: AutoloopBin,
+) -> Result<(u32, String)> {
+    let prompt_path = workspace.path().join("PROMPT.md");
+    let prompt = fs::read_to_string(&prompt_path)
+        .with_context(|| format!("Failed to read prompt file: {prompt_path:?}"))?;
+
+    let preset = workspace.path().join(PRESET_DIR);
+    write_preset(task, &preset).context("Failed to generate benchmark Autoloop preset")?;
+
+    let events_path = workspace.path().join(EVENTS_FILE);
+    let _ = fs::remove_file(&events_path);
+    let max_runtime = format!("{}s", task.timeout_seconds);
+    let runner = AutoloopRunner::new(preset, prompt, workspace.path())
+        .bin(bin)
+        .max_iterations(task.max_iterations)
+        .set_override("event_loop.max_runtime", &max_runtime)
+        .set_override("event_loop.completion_promise", &task.completion_promise)
+        .events_path(events_path.clone());
+
+    let started = Instant::now();
+    let summary = tokio::task::spawn_blocking(move || runner.run())
+        .await
+        .context("Autoloop benchmark task panicked")?
+        .context("Autoloop benchmark task failed")?;
+
+    if let Some(path) = record_path {
+        let events = fs::read_to_string(&events_path)
+            .with_context(|| format!("Failed to read Autoloop events from {events_path:?}"))?;
+        let file = File::create(path)
+            .with_context(|| format!("Failed to create recording file: {path:?}"))?;
+        write_recording_with_elapsed(
+            task,
+            &events,
+            record_ux,
+            started.elapsed().as_secs_f64(),
+            BufWriter::new(file),
+        )?;
+    }
+
+    Ok((summary.iterations, summary.stop_reason))
+}
+
+fn write_preset(task: &TaskDefinition, preset: &Path) -> Result<()> {
+    fs::create_dir_all(preset.join("roles"))?;
+    fs::write(
+        preset.join("autoloops.toml"),
+        format!(
+            "event_loop.max_iterations = {}\n\
+             event_loop.max_runtime = {}\n\
+             event_loop.completion_event = \"task.complete\"\n\
+             event_loop.completion_promise = {}\n\n\
+             harness.instructions_file = \"harness.md\"\n",
+            task.max_iterations,
+            toml_string(&format!("{}s", task.timeout_seconds)),
+            toml_string(&task.completion_promise),
+        ),
+    )?;
+    fs::write(
+        preset.join("topology.toml"),
+        "name = \"ralph-bench\"\ncompletion = \"task.complete\"\n\n\
+         [[role]]\nid = \"ralph\"\nemits = [\"task.complete\"]\n\
+         prompt_file = \"roles/ralph.md\"\n\n\
+         [handoff]\n\"loop.start\" = [\"ralph\"]\n",
+    )?;
+    fs::write(
+        preset.join("roles/ralph.md"),
+        format!(
+            "Complete the benchmark objective in the current workspace. Verify the work before finishing. \
+             Emit `task.complete` or end your output with `{}` only when complete.\n",
+            task.completion_promise
+        ),
+    )?;
+    fs::write(
+        preset.join("harness.md"),
+        "Work only inside the benchmark workspace. Preserve deterministic task inputs.\n",
+    )?;
+    Ok(())
+}
+
+fn toml_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg(test)]
+fn write_recording(
+    task: &TaskDefinition,
+    events: &str,
+    record_ux: bool,
+    writer: impl Write,
+) -> Result<()> {
+    write_recording_with_elapsed(task, events, record_ux, 0.0, writer)
+}
+
+fn write_recording_with_elapsed(
+    task: &TaskDefinition,
+    events: &str,
+    record_ux: bool,
+    elapsed_secs: f64,
+    writer: impl Write,
+) -> Result<()> {
+    let recorder = SessionRecorder::new(writer);
+    recorder.record_meta(Record::meta_loop_start(
+        "PROMPT.md",
+        task.max_iterations,
+        Some("cli"),
+    ));
+
+    let mut iterations = 0;
+    let mut termination_reason = "Stopped".to_string();
+    let mut ux_writes = 0;
+    for line in events.lines().filter(|line| !line.trim().is_empty()) {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            tracing::warn!("Skipping malformed Autoloop event while recording");
+            continue;
+        };
+        let kind = value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+
+        if kind == "iteration.start"
+            && let Some(iteration) = value.get("iteration").and_then(Value::as_u64)
+        {
+            iterations = iterations.max(iteration as u32);
+            recorder.record_meta(Record::meta_iteration(iteration as u32, 0, "autoloop"));
+        }
+        if matches!(kind, "loop.finish" | "summary") {
+            if let Some(count) = value.get("iterations").and_then(Value::as_u64) {
+                iterations = count as u32;
+            }
+            if let Some(reason) = value.get("stopReason").and_then(Value::as_str) {
+                termination_reason = reason.to_string();
+            }
+        }
+        if record_ux
+            && kind == "backend.output"
+            && let Some(output) = value.get("output").and_then(Value::as_str)
+        {
+            let offset_ms = recorder.elapsed().as_millis() as u64;
+            recorder.record_meta(Record::new(
+                "ux.terminal.write",
+                TerminalWrite::new(output.as_bytes(), true, offset_ms),
+            ));
+            ux_writes += 1;
+        }
+
+        recorder.record_meta(Record::new(format!("autoloop.{kind}"), value));
+    }
+
+    recorder.record_meta(Record::meta_termination(
+        &termination_reason,
+        iterations,
+        elapsed_secs,
+        ux_writes,
+    ));
+    recorder
+        .flush()
+        .context("Failed to flush session recording")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ralph_core::{SessionPlayer, Verification};
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::io::BufReader;
+    use std::io::Cursor;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    fn task() -> TaskDefinition {
+        TaskDefinition::builder("fixture", "PROMPT.md", "BENCH_COMPLETE")
+            .max_iterations(7)
+            .timeout_seconds(13)
+            .expected_iterations(2)
+            .verification(Verification::new("test -f result.txt"))
+            .build()
+    }
+
+    #[cfg(unix)]
+    fn workspace(task: &TaskDefinition) -> (tempfile::TempDir, TaskWorkspace) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = TaskWorkspace::create(task, temp.path()).expect("workspace");
+        fs::write(workspace.path().join("PROMPT.md"), "write result.txt").expect("prompt");
+        (temp, workspace)
+    }
+
+    #[cfg(unix)]
+    fn fake_autoloop(dir: &std::path::Path, exit_code: i32) -> PathBuf {
+        let path = dir.join("fake-autoloop.sh");
+        let script = format!(
+            r#"#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$@" > "$PWD/autoloop-argv.txt"
+events=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '--events' ]; then events="$2"; shift 2; else shift; fi
+done
+if [ {exit_code} -ne 0 ]; then
+  echo 'fixture failure' >&2
+  exit {exit_code}
+fi
+mkdir -p "$(dirname "$events")" "$PWD/.autoloop"
+printf '%s\n' \
+  '{{"type":"iteration.start","iteration":1,"maxIterations":7,"runId":"bench-fixture"}}' \
+  '{{"type":"backend.output","iteration":1,"runId":"bench-fixture","output":"fixture output\n"}}' \
+  '{{"type":"iteration.start","iteration":2,"maxIterations":7,"runId":"bench-fixture"}}' \
+  '{{"type":"loop.finish","iterations":2,"stopReason":"completed","runId":"bench-fixture"}}' > "$events"
+touch "$PWD/.autoloop/journal.jsonl" "$PWD/.autoloop/memory.jsonl" "$PWD/result.txt"
+printf '%s\n' \
+  'autoloops summary' \
+  '===================' \
+  'run_id: bench-fixture' \
+  'iterations: 2' \
+  'stop_reason: completed' \
+  "journal: $PWD/.autoloop/journal.jsonl" \
+  "memory: $PWD/.autoloop/memory.jsonl"
+"#
+        );
+        fs::write(&path, script).expect("fake autoloop");
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn runs_autoloop_with_task_limits_and_replayable_recording() {
+        let task = task();
+        let (_temp, workspace) = workspace(&task);
+        let bin = fake_autoloop(workspace.path(), 0);
+        let recording = workspace.path().join("session.jsonl");
+
+        let result = run_task_loop_with_bin(
+            &task,
+            &workspace,
+            Some(&recording),
+            true,
+            AutoloopBin::Explicit(bin),
+        )
+        .await
+        .expect("benchmark run");
+
+        assert_eq!(result, (2, "completed".to_string()));
+        let preset = fs::read_to_string(
+            workspace
+                .path()
+                .join(".ralph/bench-autoloop-preset/autoloops.toml"),
+        )
+        .expect("generated config");
+        assert!(preset.contains("event_loop.max_iterations = 7"));
+        assert!(preset.contains("event_loop.max_runtime = \"13s\""));
+        assert!(preset.contains("event_loop.completion_promise = \"BENCH_COMPLETE\""));
+
+        let argv = fs::read_to_string(workspace.path().join("autoloop-argv.txt")).unwrap();
+        assert!(argv.lines().any(|arg| arg == "run"));
+        assert!(argv.lines().any(|arg| arg == "write result.txt"));
+        assert!(argv.lines().any(|arg| arg == "event_loop.max_iterations=7"));
+        assert!(argv.lines().any(|arg| arg == "event_loop.max_runtime=13s"));
+
+        let file = fs::File::open(&recording).expect("recording");
+        let mut player = SessionPlayer::from_reader(BufReader::new(file)).expect("replay format");
+        assert_eq!(player.metadata_events().len(), 4);
+        assert_eq!(player.filter_by_event("autoloop.").len(), 4);
+        let mut replayed = Vec::new();
+        player.replay_terminal(&mut replayed).expect("replay");
+        assert_eq!(replayed, b"fixture output\n");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn preserves_nonzero_autoloop_exit_as_an_error() {
+        let task = task();
+        let (_temp, workspace) = workspace(&task);
+        let bin = fake_autoloop(workspace.path(), 17);
+
+        let error =
+            run_task_loop_with_bin(&task, &workspace, None, false, AutoloopBin::Explicit(bin))
+                .await
+                .expect_err("non-zero autoloop must fail");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("code Some(17)"), "{message}");
+        // Note: as of integration/v3-prerelease, AutoloopRunner's error surface
+        // is "{command} failed (exit code {code:?}); verify the engine
+        // configuration and retry" — it does not include the child's stderr.
+        // The bench harness must not require stderr content in the error chain.
+        assert!(message.contains("failed (exit code Some(17))"), "{message}");
+    }
+
+    #[test]
+    fn recording_without_ux_remains_valid_and_has_no_terminal_writes() {
+        let events = concat!(
+            "{\"type\":\"iteration.start\",\"iteration\":1,\"runId\":\"r1\"}\n",
+            "not json\n",
+            "{\"type\":\"backend.output\",\"iteration\":1,\"runId\":\"r1\",\"output\":\"hidden\"}\n",
+            "{\"type\":\"loop.finish\",\"iterations\":1,\"stopReason\":\"completed\",\"runId\":\"r1\"}\n",
+        );
+        let task = task();
+        let mut output = Vec::new();
+        write_recording(&task, events, false, &mut output).expect("recording");
+        let player = SessionPlayer::from_reader(Cursor::new(output)).expect("replay format");
+        assert!(player.terminal_writes().is_empty());
+        assert_eq!(player.filter_by_event("autoloop.").len(), 3);
+    }
+}

--- a/crates/ralph-bench/src/main.rs
+++ b/crates/ralph-bench/src/main.rs
@@ -18,6 +18,8 @@ use std::io::{self, BufReader, BufWriter};
 use std::path::PathBuf;
 use tracing::info;
 
+mod autoloop_task;
+
 /// Ralph Benchmark Harness - Record, replay, and benchmark orchestration loops
 #[derive(Parser, Debug)]
 #[command(name = "ralph-bench", version, about)]
@@ -247,7 +249,7 @@ async fn cmd_run(
 
         // Run the orchestration loop for this task
         let (iterations, termination_reason) =
-            run_task_loop(task, &workspace, record_path.as_ref(), record_ux)
+            autoloop_task::run_task_loop(task, &workspace, record_path.as_ref(), record_ux)
                 .await
                 .with_context(|| format!("Failed to run task '{}'", task.name))?;
 
@@ -315,30 +317,6 @@ async fn cmd_run(
     }
 
     Ok(())
-}
-
-/// Run the orchestration loop for a single benchmark task.
-///
-/// Returns (iterations, termination_reason) tuple.
-#[allow(clippy::unused_async)] // Keeps the benchmark runner's async call shape for future event-loop work.
-async fn run_task_loop(
-    task: &ralph_core::TaskDefinition,
-    _workspace: &ralph_core::TaskWorkspace,
-    _record_path: Option<&PathBuf>,
-    _record_ux: bool,
-) -> Result<(u32, String)> {
-    // v3 cutover: the in-house EventLoop engine has been removed. The bench
-    // harness previously drove `ralph_core::EventLoop` directly; porting it to
-    // the autoloop engine is descoped to #346. Fail loudly rather than returning
-    // a misleading success — a no-op "pass" would run verification against an
-    // untouched workspace and report bogus verdicts.
-    //
-    // see #346 — re-implement bench task execution on the autoloop engine.
-    anyhow::bail!(
-        "ralph-bench task execution requires the autoloop engine port (#346); \
-         task '{}' cannot run",
-        task.name
-    )
 }
 
 /// Replay a recorded session


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #346 — re-point `ralph-bench` at the autoloop engine.

## What

Reuses the still-valid draft from #362 (rebased onto current `integration/v3-prerelease` @ `2e1fc52`) on a new review branch.

The in-house `EventLoop` stub that bailed with “requires the autoloop engine port (#346)” is replaced by a real Autoloop-backed runner:

- `crates/ralph-bench/src/autoloop_task.rs` generates a benchmark Autoloop preset, drives `AutoloopRunner` with task limits (`max_iterations` / `max_runtime` / `completion_promise`), and converts Autoloop `--events` into replayable `SessionRecorder` recordings (including `ux.terminal.write` passthrough).
- Non-zero Autoloop exits fail the bench task instead of reporting a bogus verification pass.

This does **not** invent new product IA. It restores the existing `ralph-bench run` task path onto the v3 engine.

## Relation to #362

https://github.com/mikeyobrien/ralph-orchestrator/pull/362 is the earlier draft of the same change. This PR is that work transplanted onto `cursor/v3-ralph-bench-autoloop-74c5` for this migration pass. #362 can be closed as superseded after this lands.

## Proof

Verified on this branch after installing Rust 1.98.0 (workspace is edition 2024; the environment’s default 1.83.0 cannot parse the manifests):

```
cargo test -p ralph-bench
# 5 passed; 0 failed
# - recording_without_ux_remains_valid_and_has_no_terminal_writes
# - test_ux_mode_conversion
# - test_chrono_timestamp_format
# - preserves_nonzero_autoloop_exit_as_an_error
# - runs_autoloop_with_task_limits_and_replayable_recording

cargo fmt --all -- --check          # clean
cargo clippy -p ralph-bench --all-targets -- -D warnings  # clean
```

## Human gate

Draft until review/merge onto `integration/v3-prerelease`. Do not merge from this agent.

## Not in this PR

- **#347 backend forwarding** is already on the spine via `autoloop_backend_spec` in `autoloop_preset_gen.rs` (generated presets carry `backend.kind` / command / args / prompt_mode; unrepresentable backends fail before spawn). Draft #363 is a duplicate/regressive `-b` mapping and should not land.
- **#345 Telegram HITL** is a separate PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e72e6a96-086c-4fe2-bdc6-dda45eac74c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e72e6a96-086c-4fe2-bdc6-dda45eac74c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

