### PR TITLE
[v3] Re-wire Telegram bot daemon to the autoloop engine (#345)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ the merge queue, worktrees, loop registry, TUI, and—once implemented—HITL re
 ralph-cli      → CLI/TUI frontend, autoloop launch, completion and merge coordination
 ralph-core     → Shared config and coordination state (memories, tasks, registry, merge queue)
 ralph-adapters → Autoloop process integration and journal/event/summary contracts
-ralph-telegram → Telegram relay components (inactive with the autoloop engine; see RObot below)
+ralph-telegram → Telegram relay components (HITL via Autoloop `control respond`)
 ralph-tui      → Terminal UI (ratatui-based)
 ralph-e2e      → End-to-end test framework
 ralph-proto    → Protocol definitions
@@ -190,13 +190,15 @@ cargo run -p ralph-e2e -- --list
 
 ## RObot (Human-in-the-Loop)
 
-**Telegram HITL is inactive under the autoloop engine pending autoloop#345.**
-The `ralph-telegram` crate, `ralph bot` command, and configuration surface
-remain in the tree for when the engine relay lands, but an autoloop-backed
-`ralph run` does not currently relay agent questions or human guidance.
+When `RObot.enabled` is set on the primary loop, Ralph tails Autoloop
+`ask.pending` events and relays questions through Telegram or the file-backed
+web service. Answers and proactive `human.guidance` go back through
+`autoloop control respond` / `guide`. Human events stay in
+`.ralph/human-events.jsonl` so they cannot corrupt Autoloop's structured
+`--events` stream. TUI still displays pending asks only.
 
 ```yaml
-# Reserved configuration shape in ralph.yml
+# ralph.yml
 RObot:
   enabled: true
   timeout_seconds: 300
@@ -204,7 +206,7 @@ RObot:
     bot_token: "your-token"  # Or RALPH_TELEGRAM_BOT_TOKEN
 ```
 
-See `crates/ralph-telegram/README.md` for the retained bot setup.
+See `crates/ralph-telegram/README.md` for bot setup.
 
 ## Diagnostics
 

--- a/crates/ralph-adapters/src/autoloop_runner.rs
+++ b/crates/ralph-adapters/src/autoloop_runner.rs
@@ -226,6 +226,71 @@ impl AutoloopRunner {
         args
     }
 
+    /// Deliver an answer to a blocking Autoloop `human.ask`.
+    pub fn respond(
+        &self,
+        run_id: &str,
+        question_id: &str,
+        answer: &str,
+    ) -> Result<(), AutoloopRunError> {
+        self.run_control(["respond", run_id, question_id, answer], "respond")
+    }
+
+    /// Queue operator guidance for a running Autoloop.
+    pub fn guide(&self, run_id: &str, message: &str) -> Result<(), AutoloopRunError> {
+        self.run_control(["guide", run_id, message], "guide")
+    }
+
+    /// Interrupt a running Autoloop through its control channel.
+    pub fn interrupt(&self, run_id: &str, reason: &str) -> Result<(), AutoloopRunError> {
+        self.run_control(["interrupt", run_id, "--reason", reason], "interrupt")
+    }
+
+    fn control_args<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+        let (_program, mut command_args) = self.program_and_prefix();
+        command_args.push("control".to_string());
+        command_args.extend(args.into_iter().map(str::to_string));
+        command_args
+    }
+
+    fn control_command_display(&self, verb: &str) -> String {
+        match &self.bin {
+            AutoloopBin::PathLookup => format!("autoloop (PATH lookup): control {verb}"),
+            AutoloopBin::Node(_) => format!("Node-hosted autoloop: control {verb}"),
+            AutoloopBin::Explicit(_) => {
+                format!("configured autoloop executable: control {verb}")
+            }
+        }
+    }
+
+    fn run_control<'a>(
+        &self,
+        args: impl IntoIterator<Item = &'a str>,
+        verb: &str,
+    ) -> Result<(), AutoloopRunError> {
+        let (program, _) = self.program_and_prefix();
+        let args = self.control_args(args);
+        let command = self.control_command_display(verb);
+        let output = Command::new(&program)
+            .args(&args)
+            .current_dir(&self.working_dir)
+            .envs(self.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+            .output()
+            .map_err(|source| AutoloopRunError::Spawn {
+                command: command.clone(),
+                source,
+            })?;
+
+        if !output.status.success() {
+            return Err(AutoloopRunError::NonZeroExit {
+                command,
+                code: output.status.code(),
+            });
+        }
+
+        Ok(())
+    }
+
     /// Privacy-safe invocation context for error messages.
     ///
     /// Arguments are deliberately omitted because they can contain prompts,
@@ -739,6 +804,38 @@ journal: /j
         let first = args.iter().position(|a| a == "a.b=1").unwrap();
         let second = args.iter().position(|a| a == "c.d=2").unwrap();
         assert!(first < second);
+    }
+
+    #[test]
+    fn control_args_preserve_each_payload_as_one_argument() {
+        let runner = AutoloopRunner::new("/p", "x", "/w")
+            .bin(AutoloopBin::Node(PathBuf::from("/checkout/bin/autoloop")));
+
+        assert_eq!(
+            runner.control_args(["respond", "run-1", "ask-1", "use option A"]),
+            vec![
+                "/checkout/bin/autoloop",
+                "control",
+                "respond",
+                "run-1",
+                "ask-1",
+                "use option A",
+            ]
+        );
+        assert_eq!(
+            runner.control_args(["guide", "run-1", "focus on cancellation"]),
+            vec![
+                "/checkout/bin/autoloop",
+                "control",
+                "guide",
+                "run-1",
+                "focus on cancellation",
+            ]
+        );
+        assert_eq!(
+            runner.control_command_display("respond"),
+            "Node-hosted autoloop: control respond"
+        );
     }
 
     /// Opt-in smoke test that drives the real autoloop binary against the

--- a/crates/ralph-cli/src/autoloop_engine.rs
+++ b/crates/ralph-cli/src/autoloop_engine.rs
@@ -401,6 +401,28 @@ pub async fn run_autoloop_engine(
         }
     }
 
+    let mut current_events_guard = None;
+    let robot_service = if !tui {
+        if let Some(loop_context) = context.as_ref()
+            && config.robot.enabled
+            && loop_context.is_primary()
+        {
+            current_events_guard = Some(
+                crate::autoloop_robot::CurrentEventsGuard::install(&workspace)
+                    .context("installing Autoloop current-events marker")?,
+            );
+            let service = crate::autoloop_robot::create_robot_service(&config, loop_context);
+            if service.is_none() {
+                current_events_guard = None;
+            }
+            service
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     let start = Instant::now();
     let outcome = if tui {
         // In-process TUI: render the autoloop run live by tailing its --events
@@ -418,6 +440,20 @@ pub async fn run_autoloop_engine(
             Ok(outcome) => outcome,
             Err(error) => AutoloopOutcome::Failed(error.context("autoloop TUI run failed")),
         }
+    } else if let Some(service) = robot_service {
+        match run_autoloop_with_robot(
+            runner,
+            events_path.clone(),
+            workspace.clone(),
+            service,
+            role_display_names,
+            use_colors,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => AutoloopOutcome::Failed(error.context("autoloop RObot run failed")),
+        }
     } else {
         // Headless observes the same structured engine event stream as the TUI.
         // Keep the blocking child wait off the async runtime while a sibling
@@ -429,6 +465,7 @@ pub async fn run_autoloop_engine(
             Err(error) => AutoloopOutcome::Failed(error.context("autoloop headless run failed")),
         }
     };
+    drop(current_events_guard);
 
     // Validate the complete structured stream before trusting even a successful
     // process and summary. Live readers remain lenient so they can keep
@@ -460,7 +497,10 @@ pub async fn run_autoloop_engine(
     // returned after bookkeeping.
     let (reason, state, failure) = match outcome {
         AutoloopOutcome::Completed(summary) => {
-            let reason = map_stop_reason(&summary.stop_reason);
+            // A human /stop or /restart through the HITL bridge wins over the
+            // engine's own terminal reason and is consumed exactly once.
+            let reason = take_requested_termination(&workspace)
+                .unwrap_or_else(|| map_stop_reason(&summary.stop_reason));
             if reason == TerminationReason::CompletionPromise {
                 warn_on_open_ralph_tasks(&identity_context.tasks_path(), &loop_id);
             }
@@ -751,6 +791,175 @@ async fn run_autoloop_headless(
     Ok(interpret_autoloop_result(summary, false))
 }
 
+fn take_requested_termination(workspace: &Path) -> Option<TerminationReason> {
+    let ralph_dir = workspace.join(".ralph");
+    let restart = ralph_dir.join("restart-requested");
+    if restart.exists() {
+        let _ = std::fs::remove_file(restart);
+        return Some(TerminationReason::RestartRequested);
+    }
+    let stop = ralph_dir.join("stop-requested");
+    if stop.exists() {
+        let _ = std::fs::remove_file(stop);
+        return Some(TerminationReason::Stopped);
+    }
+    None
+}
+
+/// Run Autoloop headlessly while relaying RObot asks and guidance through its
+/// file-backed control protocol. Also prints the same structured progress
+/// lines as the plain headless path.
+async fn run_autoloop_with_robot(
+    runner: AutoloopRunner,
+    events_path: PathBuf,
+    workspace: PathBuf,
+    service: Box<dyn ralph_proto::RobotService>,
+    role_display_names: HashMap<String, String>,
+    use_colors: bool,
+) -> Result<AutoloopOutcome> {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::watch;
+
+    let runner = runner.own_process_group(true);
+    let child = runner.spawn().context("spawning the autoloop subprocess")?;
+    let done = Arc::new(AtomicBool::new(false));
+    let robot_shutdown = service.shutdown_flag();
+    let mut process_guard =
+        AutoloopProcessGuard::new(child.id(), Arc::clone(&done), Arc::clone(&robot_shutdown));
+
+    let (terminated_tx, mut terminated_rx) = watch::channel(false);
+    let printer_events = events_path.clone();
+    let printer_handle = tokio::spawn(async move {
+        let mut tailer = AutoloopEventTailer::new(printer_events);
+        let mut ctx = HeadlessPrintCtx::new(role_display_names, use_colors);
+        let mut ticker = tokio::time::interval(std::time::Duration::from_millis(100));
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = terminated_rx.changed() => {
+                    if *terminated_rx.borrow() {
+                        break;
+                    }
+                }
+                _ = ticker.tick() => {
+                    match tailer.poll() {
+                        Ok(events) => {
+                            for event in &events {
+                                print_headless_event(event, &mut ctx);
+                            }
+                        }
+                        Err(error) => {
+                            tracing::debug!(%error, "RObot autoloop event reader poll failed");
+                        }
+                    }
+                }
+            }
+        }
+
+        match tailer.poll() {
+            Ok(events) => {
+                for event in &events {
+                    print_headless_event(event, &mut ctx);
+                }
+            }
+            Err(error) => {
+                tracing::debug!(%error, "RObot autoloop event reader final drain failed");
+            }
+        }
+    });
+
+    let wait_runner = runner.clone();
+    let mut wait_handle = tokio::task::spawn_blocking(move || {
+        wait_runner.wait_with_summary_streaming_stderr(child, trace_engine_diagnostic)
+    });
+
+    let bridge_runner = runner.clone();
+    let bridge_done = Arc::clone(&done);
+    let mut bridge_handle = tokio::task::spawn_blocking(move || {
+        crate::autoloop_robot::run_bridge(
+            service,
+            bridge_runner,
+            events_path,
+            workspace,
+            bridge_done,
+        )
+    });
+
+    tokio::select! {
+        summary = &mut wait_handle => {
+            process_guard.disarm();
+            done.store(true, Ordering::Release);
+            robot_shutdown.store(true, Ordering::Release);
+            let _ = terminated_tx.send(true);
+            let bridge_result = bridge_handle
+                .await
+                .context("Autoloop RObot bridge panicked")?;
+            let _ = printer_handle.await;
+            let summary = summary
+                .context("autoloop wait task panicked")?
+                .context("autoloop run failed")?;
+            bridge_result?;
+            Ok(interpret_autoloop_result(Ok(summary), false))
+        }
+        bridge = &mut bridge_handle => {
+            process_guard.terminate();
+            done.store(true, Ordering::Release);
+            robot_shutdown.store(true, Ordering::Release);
+            let _ = terminated_tx.send(true);
+            let _ = printer_handle.await;
+            let bridge_result = bridge.context("Autoloop RObot bridge panicked")?;
+            let _ = wait_handle.await;
+            bridge_result?;
+            anyhow::bail!("Autoloop RObot bridge stopped before the subprocess")
+        }
+    }
+}
+
+struct AutoloopProcessGuard {
+    pid: u32,
+    armed: bool,
+    done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    robot_shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl AutoloopProcessGuard {
+    fn new(
+        pid: u32,
+        done: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        robot_shutdown: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> Self {
+        Self {
+            pid,
+            armed: true,
+            done,
+            robot_shutdown,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn terminate(&mut self) {
+        if self.armed {
+            use std::sync::atomic::Ordering;
+
+            self.done.store(true, Ordering::Release);
+            self.robot_shutdown.store(true, Ordering::Release);
+            kill_autoloop_group(self.pid);
+            self.armed = false;
+        }
+    }
+}
+
+impl Drop for AutoloopProcessGuard {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
 /// Run the autoloop subprocess with the in-process live TUI.
 ///
 /// The TUI renders inside this (parent) process, concurrent with the `autoloop
@@ -878,11 +1087,19 @@ fn kill_autoloop_group(pid: u32) {
         let pgid = Pid::from_raw(pid as i32);
         let _ = killpg(pgid, Signal::SIGTERM);
         // Detached escalation: hard-kill the group if it ignores SIGTERM. A
-        // SIGKILL to an already-dead group is ESRCH and harmless.
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            let _ = killpg(pgid, Signal::SIGKILL);
-        });
+        // SIGKILL to an already-dead group is ESRCH and harmless. Drop may
+        // run off the async runtime (spawn_blocking), so fall back to a thread.
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                let _ = killpg(pgid, Signal::SIGKILL);
+            });
+        } else {
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_secs(2));
+                let _ = killpg(pgid, Signal::SIGKILL);
+            });
+        }
     }
     #[cfg(not(unix))]
     {
@@ -903,10 +1120,8 @@ fn prepare_daemon_engine_state(
 ///
 /// This is the daemon's [`ralph_proto::StartLoopFn`] target: it loads config,
 /// applies the supplied prompt, forces autonomous/headless mode, acquires the
-/// primary loop lock, and drives the autoloop engine.
-///
-/// Note: human-in-the-loop robot wiring under the autoloop engine is descoped
-/// to #345. The loop still runs; in-loop Telegram interaction is not yet routed.
+/// primary loop lock, and drives the autoloop engine. When `RObot.enabled` is
+/// set, the HITL bridge relays Autoloop `ask.pending` through Telegram/Web.
 pub async fn start_loop(
     prompt: String,
     workspace_root: PathBuf,
@@ -972,17 +1187,23 @@ pub async fn start_loop(
     let loop_context = ralph_core::LoopContext::primary(workspace_root);
 
     // Drive the loop headlessly via the autoloop engine (daemon: never a TUI).
-    run_autoloop_engine(
-        config,
-        autoloop_bin,
-        Some(loop_context),
-        None,
-        None,
-        false,
-        false,
-        false,
-    )
-    .await
+    loop {
+        let reason = run_autoloop_engine(
+            config.clone(),
+            autoloop_bin.clone(),
+            Some(loop_context.clone()),
+            None,
+            None,
+            false,
+            false,
+            false,
+        )
+        .await?;
+        if reason == TerminationReason::RestartRequested {
+            continue;
+        }
+        return Ok(reason);
+    }
 }
 
 #[cfg(test)]
@@ -1487,5 +1708,26 @@ mod tests {
             }
         );
         assert_ne!(reason.exit_code(), 0);
+    }
+
+    #[test]
+    fn requested_termination_markers_override_reason_and_are_consumed() {
+        let temp = tempfile::tempdir().unwrap();
+        let ralph_dir = temp.path().join(".ralph");
+        std::fs::create_dir_all(&ralph_dir).unwrap();
+
+        std::fs::write(ralph_dir.join("stop-requested"), "").unwrap();
+        assert_eq!(
+            take_requested_termination(temp.path()),
+            Some(TerminationReason::Stopped)
+        );
+        assert_eq!(take_requested_termination(temp.path()), None);
+
+        std::fs::write(ralph_dir.join("restart-requested"), "").unwrap();
+        assert_eq!(
+            take_requested_termination(temp.path()),
+            Some(TerminationReason::RestartRequested)
+        );
+        assert_eq!(take_requested_termination(temp.path()), None);
     }
 }

--- a/crates/ralph-cli/src/autoloop_engine.rs
+++ b/crates/ralph-cli/src/autoloop_engine.rs
@@ -402,23 +402,21 @@ pub async fn run_autoloop_engine(
     }
 
     let mut current_events_guard = None;
-    let robot_service = if !tui {
-        if let Some(loop_context) = context.as_ref()
-            && config.robot.enabled
-            && loop_context.is_primary()
-        {
-            current_events_guard = Some(
-                crate::autoloop_robot::CurrentEventsGuard::install(&workspace)
-                    .context("installing Autoloop current-events marker")?,
-            );
-            let service = crate::autoloop_robot::create_robot_service(&config, loop_context);
-            if service.is_none() {
-                current_events_guard = None;
-            }
-            service
-        } else {
-            None
+    let robot_service = if tui {
+        None
+    } else if let Some(loop_context) = context.as_ref()
+        && config.robot.enabled
+        && loop_context.is_primary()
+    {
+        current_events_guard = Some(
+            crate::autoloop_robot::CurrentEventsGuard::install(&workspace)
+                .context("installing Autoloop current-events marker")?,
+        );
+        let service = crate::autoloop_robot::create_robot_service(&config, loop_context);
+        if service.is_none() {
+            current_events_guard = None;
         }
+        service
     } else {
         None
     };

--- a/crates/ralph-cli/src/autoloop_robot.rs
+++ b/crates/ralph-cli/src/autoloop_robot.rs
@@ -1,0 +1,607 @@
+//! Bridge Ralph's RObot services to Autoloop's subprocess control protocol.
+//!
+//! Autoloop emits `ask.pending` on its structured `--events` stream and blocks
+//! until `autoloop control respond` supplies an answer. Human replies and
+//! proactive guidance stay on a dedicated Ralph file so they cannot corrupt
+//! Autoloop's structured stream (which `parse_events_strict` requires to be
+//! well-typed Autoloop events).
+
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use ralph_adapters::{AutoloopEvent, AutoloopRunner};
+use ralph_core::{LoopContext, RalphConfig};
+use ralph_proto::RobotService;
+use tracing::{info, warn};
+
+use crate::web_robot_service::WebRobotService;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const HUMAN_EVENTS_REL: &str = ".ralph/human-events.jsonl";
+
+/// Restores the prior active-events marker when an Autoloop run ends.
+pub(crate) struct CurrentEventsGuard {
+    marker: PathBuf,
+    previous: Option<Vec<u8>>,
+}
+
+impl CurrentEventsGuard {
+    pub(crate) fn install(workspace: &Path) -> Result<Self> {
+        let ralph_dir = workspace.join(".ralph");
+        fs::create_dir_all(&ralph_dir)
+            .with_context(|| format!("creating {}", ralph_dir.display()))?;
+        let human_events = workspace.join(HUMAN_EVENTS_REL);
+        if !human_events.exists() {
+            File::create(&human_events).with_context(|| {
+                format!(
+                    "creating dedicated human-events file {}",
+                    human_events.display()
+                )
+            })?;
+        }
+        let marker = ralph_dir.join("current-events");
+        let previous = fs::read(&marker).ok();
+        fs::write(&marker, format!("{HUMAN_EVENTS_REL}\n"))
+            .with_context(|| format!("writing {}", marker.display()))?;
+        Ok(Self { marker, previous })
+    }
+
+    pub(crate) fn human_events_path(workspace: &Path) -> PathBuf {
+        workspace.join(HUMAN_EVENTS_REL)
+    }
+}
+
+impl Drop for CurrentEventsGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(contents) => {
+                if let Err(error) = fs::write(&self.marker, contents) {
+                    warn!(error = %error, marker = %self.marker.display(), "Failed to restore current-events marker");
+                }
+            }
+            None => {
+                if let Err(error) = fs::remove_file(&self.marker)
+                    && error.kind() != std::io::ErrorKind::NotFound
+                {
+                    warn!(error = %error, marker = %self.marker.display(), "Failed to remove current-events marker");
+                }
+            }
+        }
+    }
+}
+
+/// Create and start the configured primary-loop RObot service.
+pub(crate) fn create_robot_service(
+    config: &RalphConfig,
+    context: &LoopContext,
+) -> Option<Box<dyn RobotService>> {
+    if !config.robot.enabled || !context.is_primary() {
+        return None;
+    }
+
+    let workspace_root = context.workspace().to_path_buf();
+    let timeout_secs = config.robot.timeout_seconds.unwrap_or(300);
+    let loop_id = context
+        .loop_id()
+        .map(String::from)
+        .unwrap_or_else(|| "main".to_string());
+
+    if config.robot.mode.is_web() {
+        let service = WebRobotService::new(workspace_root, timeout_secs, loop_id);
+        if let Err(error) = service.start() {
+            warn!(error = %error, "Failed to start web RObot service");
+            return None;
+        }
+        info!(
+            timeout_secs = service.timeout_secs(),
+            "Web RObot service active for Autoloop"
+        );
+        return Some(Box::new(service));
+    }
+
+    match ralph_telegram::TelegramService::new(
+        workspace_root,
+        config.robot.resolve_bot_token(),
+        config.robot.resolve_api_url(),
+        timeout_secs,
+        loop_id,
+    ) {
+        Ok(service) => {
+            if let Err(error) = service.start() {
+                warn!(error = %error, "Failed to start Telegram RObot service");
+                return None;
+            }
+            info!(
+                bot_token = %service.bot_token_masked(),
+                timeout_secs,
+                "Telegram RObot service active for Autoloop"
+            );
+            Some(Box::new(service))
+        }
+        Err(error) => {
+            warn!(error = %error, "Failed to create Telegram RObot service");
+            None
+        }
+    }
+}
+
+/// Relay Autoloop asks and Ralph guidance until the subprocess has stopped.
+///
+/// This function is blocking by design and must run on `spawn_blocking`.
+pub(crate) fn run_bridge(
+    service: Box<dyn RobotService>,
+    runner: AutoloopRunner,
+    events_path: PathBuf,
+    workspace: PathBuf,
+    done: Arc<AtomicBool>,
+) -> Result<()> {
+    let result = run_bridge_inner(service.as_ref(), &runner, &events_path, &workspace, &done);
+    service.stop();
+    result
+}
+
+fn run_bridge_inner(
+    service: &dyn RobotService,
+    runner: &AutoloopRunner,
+    events_path: &Path,
+    workspace: &Path,
+    done: &AtomicBool,
+) -> Result<()> {
+    let human_events = CurrentEventsGuard::human_events_path(workspace);
+    let ralph_dir = workspace.join(".ralph");
+    let mut autoloop_pos = 0;
+    let mut human_pos = 0;
+    let mut run_id: Option<String> = None;
+    let mut pending_guidance = Vec::new();
+    let mut handled_questions = std::collections::HashSet::new();
+    let mut stop_forwarded = false;
+    let mut restart_forwarded = false;
+
+    loop {
+        let autoloop_lines = read_complete_lines(events_path, &mut autoloop_pos)?;
+        let human_lines = read_complete_lines(&human_events, &mut human_pos)?;
+        let had_lines = !autoloop_lines.is_empty() || !human_lines.is_empty();
+
+        for line in autoloop_lines {
+            let Ok(event) = serde_json::from_str::<AutoloopEvent>(&line) else {
+                continue;
+            };
+            if let Some(id) = event.run_id.as_ref() {
+                run_id = Some(id.clone());
+            }
+            let Some(ask) = event.ask_pending() else {
+                continue;
+            };
+            if !handled_questions.insert(ask.question_id.clone()) {
+                continue;
+            }
+            let response_start = fs::metadata(&human_events).map(|m| m.len()).unwrap_or(0);
+            service
+                .send_question(&ask.question)
+                .with_context(|| format!("sending Autoloop question {}", ask.question_id))?;
+            if let Some(answer) = wait_for_response_or_control(
+                service,
+                runner,
+                &human_events,
+                workspace,
+                &ask.run_id,
+                response_start,
+                done,
+                &mut stop_forwarded,
+                &mut restart_forwarded,
+            )
+            .with_context(|| format!("waiting for Autoloop question {}", ask.question_id))?
+            {
+                runner
+                    .respond(&ask.run_id, &ask.question_id, &answer)
+                    .with_context(|| {
+                        format!("responding to Autoloop question {}", ask.question_id)
+                    })?;
+            }
+        }
+
+        for line in human_lines {
+            let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) else {
+                continue;
+            };
+            if event.get("topic").and_then(|value| value.as_str()) == Some("human.guidance")
+                && let Some(message) = event.get("payload").and_then(|value| value.as_str())
+            {
+                pending_guidance.push(message.to_string());
+            }
+        }
+        if let Some(id) = run_id.as_deref() {
+            for message in pending_guidance.drain(..) {
+                runner
+                    .guide(id, &message)
+                    .context("forwarding human guidance to Autoloop")?;
+            }
+        }
+
+        if let Some(id) = run_id.as_deref() {
+            forward_control_markers(
+                runner,
+                &ralph_dir,
+                id,
+                &mut stop_forwarded,
+                &mut restart_forwarded,
+                None,
+            )?;
+        }
+
+        if done.load(Ordering::Acquire) {
+            // A quiet pass after process exit proves the final append was drained.
+            if !had_lines {
+                return Ok(());
+            }
+            continue;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn wait_for_response_or_control(
+    service: &dyn RobotService,
+    runner: &AutoloopRunner,
+    human_events: &Path,
+    workspace: &Path,
+    run_id: &str,
+    response_start: u64,
+    done: &AtomicBool,
+    stop_forwarded: &mut bool,
+    restart_forwarded: &mut bool,
+) -> Result<Option<String>> {
+    let shutdown = service.shutdown_flag();
+    let ralph_dir = workspace.join(".ralph");
+    std::thread::scope(|scope| {
+        let waiter = scope.spawn(|| service.wait_for_response(human_events, Some(response_start)));
+        while !waiter.is_finished() {
+            forward_control_markers(
+                runner,
+                &ralph_dir,
+                run_id,
+                stop_forwarded,
+                restart_forwarded,
+                Some(&shutdown),
+            )?;
+            if done.load(Ordering::Acquire) {
+                shutdown.store(true, Ordering::Release);
+            }
+            std::thread::sleep(POLL_INTERVAL);
+        }
+        waiter
+            .join()
+            .map_err(|_| anyhow::anyhow!("RObot response waiter panicked"))?
+    })
+}
+
+fn forward_control_markers(
+    runner: &AutoloopRunner,
+    ralph_dir: &Path,
+    run_id: &str,
+    stop_forwarded: &mut bool,
+    restart_forwarded: &mut bool,
+    shutdown: Option<&AtomicBool>,
+) -> Result<()> {
+    if !*stop_forwarded && ralph_dir.join("stop-requested").exists() {
+        runner
+            .interrupt(run_id, "Ralph stop requested")
+            .context("forwarding stop request to Autoloop")?;
+        *stop_forwarded = true;
+        if let Some(flag) = shutdown {
+            flag.store(true, Ordering::Release);
+        }
+    }
+    if !*restart_forwarded && ralph_dir.join("restart-requested").exists() {
+        runner
+            .interrupt(run_id, "Ralph restart requested")
+            .context("forwarding restart request to Autoloop")?;
+        *restart_forwarded = true;
+        if let Some(flag) = shutdown {
+            flag.store(true, Ordering::Release);
+        }
+    }
+    Ok(())
+}
+
+fn read_complete_lines(path: &Path, position: &mut u64) -> Result<Vec<String>> {
+    let Ok(mut file) = File::open(path) else {
+        return Ok(Vec::new());
+    };
+    file.seek(SeekFrom::Start(*position))?;
+    let mut reader = BufReader::new(file);
+    let mut lines = Vec::new();
+
+    loop {
+        let mut line = String::new();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            break;
+        }
+        if !line.ends_with('\n') {
+            break;
+        }
+        *position += bytes as u64;
+        let line = line.trim();
+        if !line.is_empty() {
+            lines.push(line.to_string());
+        }
+    }
+
+    Ok(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ralph_proto::CheckinContext;
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct FakeState {
+        questions: Mutex<Vec<String>>,
+        stopped: AtomicBool,
+    }
+
+    struct FakeRobot {
+        state: Arc<FakeState>,
+        shutdown: Arc<AtomicBool>,
+    }
+
+    impl RobotService for FakeRobot {
+        fn send_question(&self, payload: &str) -> anyhow::Result<i32> {
+            self.state
+                .questions
+                .lock()
+                .unwrap()
+                .push(payload.to_string());
+            Ok(7)
+        }
+
+        fn wait_for_response(
+            &self,
+            events_path: &Path,
+            start_position: Option<u64>,
+        ) -> anyhow::Result<Option<String>> {
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            let mut position = start_position.unwrap_or(0);
+            while std::time::Instant::now() < deadline {
+                if self.shutdown.load(Ordering::Acquire) {
+                    return Ok(None);
+                }
+                if let Ok(content) = fs::read_to_string(events_path) {
+                    let start = usize::try_from(position)
+                        .unwrap_or(content.len())
+                        .min(content.len());
+                    for line in content[start..].lines() {
+                        let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+                            continue;
+                        };
+                        if event.get("topic").and_then(|value| value.as_str())
+                            == Some("human.response")
+                        {
+                            return Ok(event
+                                .get("payload")
+                                .and_then(|value| value.as_str())
+                                .map(str::to_string));
+                        }
+                    }
+                    position = content.len() as u64;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None)
+        }
+
+        fn send_checkin(
+            &self,
+            _iteration: u32,
+            _elapsed: Duration,
+            _context: Option<&CheckinContext>,
+        ) -> anyhow::Result<i32> {
+            Ok(0)
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            2
+        }
+
+        fn shutdown_flag(&self) -> Arc<AtomicBool> {
+            self.shutdown.clone()
+        }
+
+        fn stop(self: Box<Self>) {
+            self.state.stopped.store(true, Ordering::Release);
+            self.shutdown.store(true, Ordering::Release);
+        }
+    }
+
+    #[cfg(unix)]
+    fn fake_control_bin(dir: &Path) -> (PathBuf, PathBuf) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let control_log = dir.join("control.log");
+        let fake_bin = dir.join("fake-autoloop.sh");
+        fs::write(
+            &fake_bin,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$CONTROL_LOG\"\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&fake_bin).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_bin, permissions).unwrap();
+        (fake_bin, control_log)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relays_pending_ask_response_and_guidance_through_control_cli_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        fs::create_dir_all(workspace.join(".ralph")).unwrap();
+        let events_path = workspace.join(".ralph/autoloop-events.ndjson");
+        let human_events = CurrentEventsGuard::human_events_path(workspace);
+        let (fake_bin, control_log) = fake_control_bin(workspace);
+
+        let runner = AutoloopRunner::new(workspace, "prompt", workspace)
+            .bin(ralph_adapters::AutoloopBin::Explicit(fake_bin))
+            .env("CONTROL_LOG", control_log.to_string_lossy().into_owned());
+        let state = Arc::new(FakeState::default());
+        let robot: Box<dyn RobotService> = Box::new(FakeRobot {
+            state: state.clone(),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        });
+        let done = Arc::new(AtomicBool::new(false));
+
+        let bridge_done = done.clone();
+        let bridge_events = events_path.clone();
+        let bridge_workspace = workspace.to_path_buf();
+        let bridge = std::thread::spawn(move || {
+            run_bridge(robot, runner, bridge_events, bridge_workspace, bridge_done).unwrap();
+        });
+
+        let mut events = File::create(&events_path).unwrap();
+        writeln!(
+            events,
+            r#"{{"type":"iteration.start","runId":"run-9","iteration":1}}"#
+        )
+        .unwrap();
+        writeln!(
+            events,
+            r#"{{"type":"ask.pending","runId":"run-9","iteration":1,"questionId":"ask-9","question":"A or B?"}}"#
+        )
+        .unwrap();
+        events.flush().unwrap();
+
+        let mut human = File::create(&human_events).unwrap();
+        writeln!(
+            human,
+            r#"{{"topic":"human.guidance","payload":"check cancellation"}}"#
+        )
+        .unwrap();
+        human.flush().unwrap();
+
+        let response_path = human_events.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            let mut file = fs::OpenOptions::new()
+                .append(true)
+                .open(response_path)
+                .unwrap();
+            writeln!(file, r#"{{"topic":"human.response","payload":"Use A"}}"#).unwrap();
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            let log = fs::read_to_string(&control_log).unwrap_or_default();
+            if log.contains("control respond run-9 ask-9 Use A") {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        done.store(true, Ordering::Release);
+        bridge.join().unwrap();
+
+        let log = fs::read_to_string(control_log).unwrap();
+        assert_eq!(
+            log.matches("control guide run-9 check cancellation")
+                .count(),
+            1
+        );
+        assert_eq!(log.matches("control respond run-9 ask-9 Use A").count(), 1);
+        assert_eq!(state.questions.lock().unwrap().as_slice(), ["A or B?"]);
+        assert!(state.stopped.load(Ordering::Acquire));
+        assert!(
+            !fs::read_to_string(&events_path)
+                .unwrap()
+                .contains("human.response"),
+            "human replies must not mix into Autoloop's structured event stream"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restart_interrupts_a_pending_ask_from_ralph_dir_without_waiting() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        fs::create_dir_all(workspace.join(".ralph")).unwrap();
+        let events_path = workspace.join(".ralph/autoloop-events.ndjson");
+        let (fake_bin, control_log) = fake_control_bin(workspace);
+
+        let runner = AutoloopRunner::new(workspace, "prompt", workspace)
+            .bin(ralph_adapters::AutoloopBin::Explicit(fake_bin))
+            .env("CONTROL_LOG", control_log.to_string_lossy().into_owned());
+        let state = Arc::new(FakeState::default());
+        let robot: Box<dyn RobotService> = Box::new(FakeRobot {
+            state,
+            shutdown: Arc::new(AtomicBool::new(false)),
+        });
+        let done = Arc::new(AtomicBool::new(false));
+        fs::write(
+            &events_path,
+            concat!(
+                r#"{"type":"iteration.start","runId":"run-9","iteration":1}"#,
+                "\n",
+                r#"{"type":"ask.pending","runId":"run-9","iteration":1,"questionId":"ask-9","question":"A or B?"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let bridge_done = done.clone();
+        let bridge_events = events_path;
+        let bridge_workspace = workspace.to_path_buf();
+        let bridge = std::thread::spawn(move || {
+            run_bridge(robot, runner, bridge_events, bridge_workspace, bridge_done).unwrap();
+        });
+        std::thread::sleep(Duration::from_millis(100));
+        fs::write(workspace.join(".ralph/restart-requested"), "").unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while std::time::Instant::now() < deadline {
+            if fs::read_to_string(&control_log)
+                .unwrap_or_default()
+                .contains("control interrupt run-9 --reason Ralph restart requested")
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        done.store(true, Ordering::Release);
+        bridge.join().unwrap();
+
+        let log = fs::read_to_string(control_log).unwrap();
+        assert_eq!(
+            log.matches("control interrupt run-9 --reason Ralph restart requested")
+                .count(),
+            1
+        );
+        assert!(!log.contains("control respond"));
+    }
+
+    #[test]
+    fn current_events_guard_points_at_dedicated_human_events_and_restores() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join(".ralph/current-events");
+        fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        fs::write(&marker, ".ralph/old.jsonl\n").unwrap();
+
+        {
+            let _guard = CurrentEventsGuard::install(temp.path()).unwrap();
+            assert_eq!(
+                fs::read_to_string(&marker).unwrap(),
+                ".ralph/human-events.jsonl\n"
+            );
+            assert!(CurrentEventsGuard::human_events_path(temp.path()).is_file());
+        }
+
+        assert_eq!(fs::read_to_string(marker).unwrap(), ".ralph/old.jsonl\n");
+    }
+}

--- a/crates/ralph-cli/src/bot.rs
+++ b/crates/ralph-cli/src/bot.rs
@@ -381,7 +381,7 @@ async fn bot_status(use_colors: bool) -> Result<()> {
     // Check RObot enabled
     let robot_enabled = is_robot_enabled();
     if robot_enabled {
-        print_warning(use_colors, &robot_enabled_status_message());
+        print_success(use_colors, "RObot: enabled in ralph.yml");
     } else {
         print_status(use_colors, "RObot: not enabled in ralph.yml");
     }
@@ -1087,13 +1087,6 @@ fn print_error(use_colors: bool, msg: &str) {
     }
 }
 
-fn robot_enabled_status_message() -> String {
-    format!(
-        "RObot: enabled in ralph.yml; {}",
-        ralph_core::ROBOT_HITL_INACTIVE_WARNING
-    )
-}
-
 fn format_warning(use_colors: bool, msg: &str) -> String {
     if use_colors {
         format!("  \x1b[33m!\x1b[0m {}", msg)
@@ -1155,18 +1148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_robot_status_enabled_renders_inactive_hitl_caveat() {
-        assert_eq!(
-            format_warning(false, &robot_enabled_status_message()),
-            format!(
-                "  WARN: RObot: enabled in ralph.yml; {}",
-                ralph_core::ROBOT_HITL_INACTIVE_WARNING
-            )
-        );
-    }
-
-    #[test]
-    fn test_daemon_config_warnings_include_inactive_hitl_caveat() {
+    fn test_daemon_config_warnings_omit_inactive_hitl_caveat() {
         let config: RalphConfig = serde_yaml::from_str(
             r#"
 RObot:
@@ -1180,12 +1162,10 @@ RObot:
 
         let warnings = daemon_config_warnings(&config).unwrap();
 
-        assert_eq!(
-            warnings,
-            vec![format!(
-                "Warning [RObot.enabled]: {}",
-                ralph_core::ROBOT_HITL_INACTIVE_WARNING
-            )]
+        assert!(
+            !warnings
+                .iter()
+                .any(|warning| warning.contains("HITL relay is INACTIVE"))
         );
     }
 

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -19,6 +19,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 mod autoloop_engine;
 mod autoloop_preset_gen;
+mod autoloop_robot;
 mod backend_support;
 mod bot;
 mod completion_coord;

--- a/crates/ralph-cli/src/web_robot_service.rs
+++ b/crates/ralph-cli/src/web_robot_service.rs
@@ -1,7 +1,4 @@
-// v3 cutover: the in-house engine's `create_robot_service` was the only caller
-// of this web RObot service. Re-wiring human-in-the-loop RObot onto the autoloop
-// engine is tracked in #345; until then this module is retained but unused.
-#![allow(dead_code)]
+//! File-backed RObot service used by the Autoloop HITL bridge.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -491,7 +488,11 @@ impl RobotService for WebRobotService {
         WebRobotService::send_question(self, payload)
     }
 
-    fn wait_for_response(&self, events_path: &Path) -> Result<Option<String>> {
+    fn wait_for_response(
+        &self,
+        events_path: &Path,
+        _start_position: Option<u64>,
+    ) -> Result<Option<String>> {
         let _ = events_path;
         WebRobotService::wait_for_response(self)
     }
@@ -604,8 +605,9 @@ mod tests {
         write_correlated_response(&dir, "response", "approved");
         let response_path = response_path(&dir);
 
-        let response = RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"))
-            .expect("wait for response");
+        let response =
+            RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"), None)
+                .expect("wait for response");
 
         assert_eq!(response, Some("approved".to_string()));
         assert!(
@@ -632,7 +634,7 @@ mod tests {
             .expect("reuse question");
         let reused_question = read_json(&dir.path().join(".ralph/api/robot-question.json"));
         let response =
-            RobotService::wait_for_response(&restarted, Path::new("unused-events.jsonl"))
+            RobotService::wait_for_response(&restarted, Path::new("unused-events.jsonl"), None)
                 .expect("wait for response");
 
         assert_eq!(reused_id, original_id);
@@ -724,8 +726,9 @@ mod tests {
             .send_question("Need approval?")
             .expect("send question");
 
-        let response = RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"))
-            .expect("wait for response");
+        let response =
+            RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"), None)
+                .expect("wait for response");
 
         assert_eq!(response, None);
         assert!(
@@ -751,7 +754,7 @@ mod tests {
         });
 
         let start = Instant::now();
-        let response = RobotService::wait_for_response(&service, &events_path(&dir))
+        let response = RobotService::wait_for_response(&service, &events_path(&dir), None)
             .expect("wait for response");
         writer.join().expect("join writer");
 
@@ -772,8 +775,9 @@ mod tests {
         service.shutdown_flag().store(true, Ordering::Relaxed);
 
         let start = Instant::now();
-        let response = RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"))
-            .expect("wait for response");
+        let response =
+            RobotService::wait_for_response(&service, Path::new("unused-events.jsonl"), None)
+                .expect("wait for response");
 
         assert_eq!(response, None);
         assert!(start.elapsed() < Duration::from_secs(1));
@@ -796,7 +800,7 @@ mod tests {
                 .expect("write complete response");
         });
 
-        let response = RobotService::wait_for_response(&service, &events_path(&dir))
+        let response = RobotService::wait_for_response(&service, &events_path(&dir), None)
             .expect("wait for response");
         writer.join().expect("join writer");
 
@@ -829,7 +833,7 @@ mod tests {
                 .expect("write complete response");
         });
 
-        let response = RobotService::wait_for_response(&service, &events_path(&dir))
+        let response = RobotService::wait_for_response(&service, &events_path(&dir), None)
             .expect("wait for response");
         writer.join().expect("join writer");
 

--- a/crates/ralph-core/src/config.rs
+++ b/crates/ralph-core/src/config.rs
@@ -597,12 +597,6 @@ impl RalphConfig {
 
         // Validate RObot config
         self.robot.validate()?;
-        if self.robot.enabled {
-            warnings.push(ConfigWarning::DeferredFeature {
-                field: "RObot.enabled".to_string(),
-                message: ROBOT_HITL_INACTIVE_WARNING.to_string(),
-            });
-        }
 
         // Validate hooks config semantics (v1 guardrails)
         self.validate_hooks()?;
@@ -878,9 +872,6 @@ impl std::fmt::Display for ConfigWarning {
         }
     }
 }
-
-/// Canonical warning shown when RObot is enabled with the autoloop engine.
-pub const ROBOT_HITL_INACTIVE_WARNING: &str = "Telegram HITL relay is INACTIVE under the autoloop engine (pending autoloop#345): bot commands/status work, but agent questions are not relayed.";
 
 /// Event loop configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3682,7 +3673,7 @@ RObot:
     }
 
     #[test]
-    fn test_robot_enabled_warns_that_autoloop_hitl_is_inactive() {
+    fn test_robot_enabled_does_not_warn_that_autoloop_hitl_is_inactive() {
         let yaml = r#"
 RObot:
   enabled: true
@@ -3693,12 +3684,10 @@ RObot:
         let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
         let warnings = config.validate().unwrap();
 
-        assert!(warnings.iter().any(|warning| {
-            let warning = warning.to_string();
-            warning.contains("Telegram HITL relay is INACTIVE under the autoloop engine")
-                && warning.contains("autoloop#345")
-                && warning.contains("bot commands/status work")
-                && warning.contains("agent questions are not relayed")
+        assert!(!warnings.iter().any(|warning| {
+            warning
+                .to_string()
+                .contains("Telegram HITL relay is INACTIVE")
         }));
     }
 

--- a/crates/ralph-core/src/lib.rs
+++ b/crates/ralph-core/src/lib.rs
@@ -61,8 +61,8 @@ pub mod worktree;
 pub use cli_capture::{CliCapture, CliCapturePair};
 pub use config::{
     CliConfig, ConfigError, CoreConfig, EventLoopConfig, EventMetadata, FeaturesConfig, HatBackend,
-    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, ROBOT_HITL_INACTIVE_WARNING,
-    RalphConfig, RobotMode, ScratchpadConfig, SkillOverride, SkillsConfig, resolve_context_window,
+    HatConfig, InjectMode, MemoriesConfig, MemoriesFilter, RalphConfig, RobotMode,
+    ScratchpadConfig, SkillOverride, SkillsConfig, resolve_context_window,
     resolve_context_window_for_backend,
 };
 // Re-export loop_name types (also available via FeaturesConfig.loop_naming)

--- a/crates/ralph-proto/src/robot.rs
+++ b/crates/ralph-proto/src/robot.rs
@@ -44,7 +44,14 @@ pub trait RobotService: Send + Sync {
     ///
     /// Blocks until a response arrives or the configured timeout expires.
     /// Returns `Ok(Some(response))` on response, `Ok(None)` on timeout.
-    fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>>;
+    ///
+    /// `start_position` is a byte offset into `events_path`. `None` starts at
+    /// the current end of the file so only later lines are consumed.
+    fn wait_for_response(
+        &self,
+        events_path: &Path,
+        start_position: Option<u64>,
+    ) -> anyhow::Result<Option<String>>;
 
     /// Whether `wait_for_response` consumes responses that are already durably
     /// written to the active events file.

--- a/crates/ralph-telegram/README.md
+++ b/crates/ralph-telegram/README.md
@@ -1,15 +1,9 @@
 # ralph-telegram
 
-> [!WARNING]
-> **Telegram HITL relay is INACTIVE under the v3 autoloop engine (pending
-> autoloop#345).** Bot setup, `status`, `test`, and the standalone daemon still
-> work, as do the daemon's informational bot commands. Agent questions are not
-> relayed to Telegram, and Telegram replies or proactive guidance are not
-> connected to running autoloop loops.
-
-This crate retains Ralph's Telegram bot surfaces and the reserved design for
-human-in-the-loop orchestration. The relay design described below is not
-current v3 runtime behavior.
+This crate is Ralph's Telegram bot surface for human-in-the-loop
+orchestration. When `RObot.enabled` is set, the Autoloop engine path relays
+`ask.pending` questions through this crate and returns answers via
+`autoloop control respond`.
 
 ## Setup
 

--- a/crates/ralph-telegram/src/service.rs
+++ b/crates/ralph-telegram/src/service.rs
@@ -626,7 +626,11 @@ impl TelegramService {
     /// `"human.response"`. On response, removes the pending question and
     /// returns the response message. On timeout, removes the pending question
     /// and returns `None`.
-    pub fn wait_for_response(&self, events_path: &Path) -> TelegramResult<Option<String>> {
+    pub fn wait_for_response(
+        &self,
+        events_path: &Path,
+        start_position: Option<u64>,
+    ) -> TelegramResult<Option<String>> {
         let poll_interval = Duration::from_millis(250);
         let deadline = if self.timeout_secs == 0 {
             None
@@ -635,11 +639,13 @@ impl TelegramService {
         };
 
         // Track file position to only read new lines
-        let initial_pos = if events_path.exists() {
-            std::fs::metadata(events_path).map(|m| m.len()).unwrap_or(0)
-        } else {
-            0
-        };
+        let initial_pos = start_position.unwrap_or_else(|| {
+            if events_path.exists() {
+                std::fs::metadata(events_path).map(|m| m.len()).unwrap_or(0)
+            } else {
+                0
+            }
+        });
         let mut file_pos = initial_pos;
 
         info!(
@@ -789,8 +795,16 @@ impl ralph_proto::RobotService for TelegramService {
         Ok(TelegramService::send_question(self, payload)?)
     }
 
-    fn wait_for_response(&self, events_path: &Path) -> anyhow::Result<Option<String>> {
-        Ok(TelegramService::wait_for_response(self, events_path)?)
+    fn wait_for_response(
+        &self,
+        events_path: &Path,
+        start_position: Option<u64>,
+    ) -> anyhow::Result<Option<String>> {
+        Ok(TelegramService::wait_for_response(
+            self,
+            events_path,
+            start_position,
+        )?)
     }
 
     fn response_events_are_durable(&self) -> bool {
@@ -1125,7 +1139,7 @@ mod tests {
             file.flush().unwrap();
         });
 
-        let result = service.wait_for_response(&events_path).unwrap();
+        let result = service.wait_for_response(&events_path, None).unwrap();
         writer.join().unwrap();
 
         assert_eq!(result, Some("Go with plan A".to_string()));
@@ -1136,6 +1150,29 @@ mod tests {
             !state.pending_questions.contains_key("main"),
             "pending question should be removed after response"
         );
+    }
+
+    #[test]
+    fn wait_for_response_honors_caller_position_for_preexisting_response() {
+        let dir = TempDir::new().unwrap();
+        let service = TelegramService::new(
+            dir.path().to_path_buf(),
+            Some("token".to_string()),
+            None,
+            2,
+            "main".to_string(),
+        )
+        .unwrap();
+        let events_path = dir.path().join("events.jsonl");
+        std::fs::write(
+            &events_path,
+            "{\"topic\":\"human.response\",\"payload\":\"Immediate answer\"}\n",
+        )
+        .unwrap();
+
+        let result = service.wait_for_response(&events_path, Some(0)).unwrap();
+
+        assert_eq!(result, Some("Immediate answer".to_string()));
     }
 
     #[test]
@@ -1170,7 +1207,7 @@ mod tests {
         });
 
         let start = Instant::now();
-        let result = service.wait_for_response(&events_path).unwrap();
+        let result = service.wait_for_response(&events_path, None).unwrap();
         writer.join().unwrap();
 
         assert_eq!(result, Some("Keep going".to_string()));
@@ -1199,7 +1236,7 @@ mod tests {
         // Store a pending question
         service.send_question("Will this timeout?").unwrap();
 
-        let result = service.wait_for_response(&events_path).unwrap();
+        let result = service.wait_for_response(&events_path, None).unwrap();
         assert_eq!(result, None, "should return None on timeout");
 
         // Pending question should be removed even on timeout
@@ -1400,7 +1437,7 @@ mod tests {
         service.shutdown_flag().store(true, Ordering::Relaxed);
 
         let start = Instant::now();
-        let result = service.wait_for_response(&events_path).unwrap();
+        let result = service.wait_for_response(&events_path, None).unwrap();
         let elapsed = start.elapsed();
 
         assert_eq!(result, None, "should return None when shutdown flag is set");

--- a/crates/ralph-tui/src/app.rs
+++ b/crates/ralph-tui/src/app.rs
@@ -118,7 +118,7 @@ pub fn dispatch_action(action: Action, state: &mut TuiState, viewport_height: us
         Action::GuidanceNext => {
             // Under the autoloop source there is no back-channel to the
             // subprocess, so guidance/steer would no-op. Suppress it entirely
-            // rather than opening a dead-end input (FIX gap#6; HITL is #345).
+            // rather than opening a dead-end input (FIX gap#6; TUI is display-only).
             if !state.autoloop_source {
                 state.start_guidance(crate::state::GuidanceMode::Next);
             }

--- a/crates/ralph-tui/src/state.rs
+++ b/crates/ralph-tui/src/state.rs
@@ -320,7 +320,7 @@ pub struct TuiState {
     // ========================================================================
     /// Pending human ask surfaced in the footer (autoloop `ask.pending`). Display
     /// only: there is no back-channel to answer through the autoloop subprocess
-    /// here (HITL answering is #345).
+    /// here (answers go through the RObot Autoloop control bridge).
     pub pending_ask: Option<String>,
     /// True when the TUI is driven by the autoloop `--events` source rather than
     /// the in-house event bus. Suppresses guidance/steer affordances that have no

--- a/crates/ralph-tui/src/widgets/footer.rs
+++ b/crates/ralph-tui/src/widgets/footer.rs
@@ -25,7 +25,7 @@ impl Widget for Footer<'_> {
         block.render(area, buf);
 
         // A pending human ask (autoloop HITL) is the most important thing to
-        // surface — the run is blocked on it. Display only; answering is #345.
+        // surface — the run is blocked on it. Display only; answers go through RObot.
         if let Some(question) = &self.state.pending_ask {
             let line = Line::from(vec![
                 Span::raw(" "),

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -18,7 +18,7 @@ The Cargo workspace has nine crates:
 | `ralph-adapters` | Autoloop process, journal, event-stream, and summary adapters |
 | `ralph-tui` | Ratatui observation UI |
 | `ralph-proto` | Shared protocol definitions |
-| `ralph-telegram` | Retained Telegram components; not connected to `ralph run` under v3 pending autoloop#345 |
+| `ralph-telegram` | Telegram HITL relay for Autoloop `ask.pending` / `control respond` |
 | `ralph-e2e` | Legacy E2E scenario inventory and test framework |
 | `ralph-bench` | Benchmarking support |
 | `ralph-api` | Rust RPC API used by the web dashboard |
@@ -97,8 +97,9 @@ running. When autoloop exits, Ralph reads the summary, maps the engine stop
 reason, updates coordination state, and either completes in place or queues a
 worktree for merge processing.
 
-Telegram HITL is not currently part of this flow. The retained bot and relay
-components are awaiting an autoloop engine relay contract (autoloop#345).
+On the primary loop with `RObot.enabled`, Ralph also tails Autoloop
+`ask.pending`, relays questions through Telegram or the file-backed web
+service, and answers through `autoloop control`.
 
 ## Process Model
 

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -37,7 +37,7 @@ ralph-orchestrator/
 │   ├── ralph-proto/     # Protocol types
 │   ├── ralph-core/      # Shared config and coordination state
 │   ├── ralph-adapters/  # Autoloop process/contract adapters
-│   ├── ralph-telegram/  # Retained bot components; v3 relay pending #345
+│   ├── ralph-telegram/  # Telegram HITL relay for Autoloop
 │   ├── ralph-tui/       # Terminal UI
 │   ├── ralph-cli/       # Binary entry point
 │   ├── ralph-e2e/       # End-to-end testing

--- a/docs/advanced/testing.md
+++ b/docs/advanced/testing.md
@@ -181,14 +181,15 @@ Hooks run CI-parity Rust checks before each commit:
 
 ## Testing Human-in-the-Loop (Telegram)
 
-Telegram relay is inactive for autoloop-backed `ralph run` pending
-autoloop#345. Test the retained crate with mocked bot behavior:
+Test the Telegram crate with mocked bot behavior, and the CLI HITL bridge
+with a fake Autoloop control executable:
 
 ```bash
 cargo test -p ralph-telegram
+cargo test -p ralph-cli autoloop_robot
 ```
 
-See the [Telegram guide](../guide/telegram.md) for the exact v3 limitation.
+See the [Telegram guide](../guide/telegram.md).
 
 ## Testing Best Practices
 

--- a/docs/guide/telegram.md
+++ b/docs/guide/telegram.md
@@ -1,15 +1,11 @@
 # Telegram Integration
 
-!!! warning "Not connected to the v3 engine"
-    Telegram human-in-the-loop relay is **inactive for `ralph run` under the
-    autoloop engine**. The engine relay contract is pending autoloop#345.
-    Enabling `RObot` does not currently make an autoloop-backed run pause for
-    questions, consume replies, or inject proactive guidance.
-
-The `ralph-telegram` crate, `ralph bot` command group, configuration shape, and
-persisted bot state remain in the repository for the future relay. You can set
-up credentials, inspect status, run the standalone daemon, and send a test
-message; do not treat those checks as evidence that in-loop HITL works.
+When `RObot.enabled` is set, an autoloop-backed `ralph run` (and the bot
+daemon) relays Autoloop `ask.pending` questions through Telegram and returns
+answers with `autoloop control respond`. Proactive messages become
+`human.guidance` and are forwarded with `control guide`. Human events are
+written to `.ralph/human-events.jsonl`, not Autoloop's structured `--events`
+stream. The in-process TUI still displays pending asks only.
 
 ## Setup
 
@@ -55,8 +51,8 @@ ralph bot test "Hello from Ralph"
 ```
 
 `ralph bot test` performs a Telegram network send and therefore needs a valid
-token and chat ID. It tests bot connectivity only; it does not activate the
-missing autoloop relay.
+token and chat ID. It tests bot connectivity. In-loop HITL also requires
+`RObot.enabled` and an Autoloop build that implements `control respond`.
 
 ## Retained Components
 
@@ -74,34 +70,17 @@ Bot state is stored in `.ralph/telegram-state.json`. The command group also
 includes `ralph bot token` and `ralph bot daemon`; use `ralph bot --help` for
 the current options.
 
-## What Is Deferred
-
-The retained code models the intended `human.interact`, `human.response`, and
-`human.guidance` relay. Under the old in-house loop, those events were routed
-between a running loop and Telegram. Under v3, autoloop owns the live event
-loop, so Ralph cannot correctly block engine execution or inject replies until
-autoloop exposes the relay contract tracked by autoloop#345.
-
-Until that lands:
-
-- Agents in `ralph run` cannot ask a human through the retained Telegram relay.
-- Telegram replies and proactive messages are not injected into an autoloop
-  iteration.
-- Worktree-loop routing and periodic in-run check-ins are not active v3
-  behavior.
-- A successful `ralph bot test` only proves Telegram credentials and network
-  access.
-
-## Testing the Retained Crate
+## Testing
 
 ```bash
 cargo test -p ralph-telegram
+cargo test -p ralph-cli autoloop_robot
 ```
 
 The crate tests use mocked bot behavior and do not require Telegram network
-access. A custom `RALPH_TELEGRAM_API_URL` remains useful when developing the
-retained bot components, but it cannot provide end-to-end v3 HITL while
-#345 is unresolved.
+access. A custom `RALPH_TELEGRAM_API_URL` remains useful when developing against
+a local mock server. End-to-end HITL additionally needs an Autoloop build that
+implements `control respond`.
 
 ## Troubleshooting Setup
 
@@ -115,5 +94,6 @@ Send a message to the bot during onboarding or provide `--chat-id` explicitly.
 
 ### The bot works, but `ralph run` does not pause or receive guidance
 
-That is the expected v3 limitation pending autoloop#345, not a credential
-problem.
+Confirm `RObot.enabled: true` in `ralph.yml`, that the Autoloop binary
+implements `control respond`, and that `.ralph/current-events` points at
+`.ralph/human-events.jsonl` while the run is active.

--- a/docs/migration/v3-autoloop-engine.md
+++ b/docs/migration/v3-autoloop-engine.md
@@ -31,7 +31,7 @@ runtime state: Ralph launches autoloop with a Ralph-owned state root at
 | `ralph run --rpc` (JSON-lines protocol) | Removed (tracked as #343). |
 | `ralph run --record-session` (smoke fixtures) | Removed. Replay tests use the fake-autoloop fixture substrate (`tests/fixtures/autoloop/`). |
 | `core.engine` config field | Autoloop is the only engine. `autoloop` remains valid; any other value is rejected because the in-house engine was removed in v3. Remove the field or set it to `autoloop`. |
-| Telegram RObot HITL during runs | Inactive pending autoloop relay wiring (#345). When enabled, config validation logs this warning: `Telegram HITL relay is INACTIVE under the autoloop engine (pending autoloop#345): bot commands/status work, but agent questions are not relayed.` |
+| Telegram RObot HITL during runs | Wired on the primary loop: Autoloop `ask.pending` is relayed through Telegram/Web; answers and `human.guidance` use `autoloop control`. TUI still displays asks only. |
 | In-house smoke corpus (`smoke_runner`) | Replaced by the fake-autoloop replay substrate and `ralph-e2e --mock`. |
 
 ## What keeps working (now via the engine)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #345 — re-wire the Telegram bot daemon (and primary-loop RObot) onto the autoloop engine.

## What

Draft #361 still applied on current `integration/v3-prerelease`, but it pointed `.ralph/current-events` at Autoloop’s `events.ndjson` and looked for stop/restart markers next to that file. That is wrong on the current spine:

- Autoloop events live under `.ralph/autoloop/events.ndjson`
- `parse_events_strict` requires every line to be a typed Autoloop event; a `human.response` line would fail the run closed
- stop/restart markers are written to `.ralph/stop-requested` and `.ralph/restart-requested`

This PR keeps #361’s product IA (Autoloop subprocess + `control respond` / `guide` / `interrupt`) and rewrites the seam:

- `AutoloopRunner` gains privacy-safe `respond` / `guide` / `interrupt` (payloads stay out of error text)
- `autoloop_robot.rs` tails Autoloop `ask.pending`, sends questions through Telegram/Web, waits on **`.ralph/human-events.jsonl`**, and answers through Autoloop control
- `CurrentEventsGuard` points `.ralph/current-events` at that dedicated human-events file, then restores the previous marker
- `/stop` and `/restart` markers are read from `.ralph/`; `/restart` re-enters `start_loop`
- The inactive `RObot.enabled` warning is removed because the relay is now wired
- TUI remains display-only for pending asks (no new TUI input IA)

## Relation to #361

https://github.com/mikeyobrien/ralph-orchestrator/pull/361 is the earlier draft. This PR supersedes it. #361 can be closed after this lands.

## Proof

Verified on this branch (Rust 1.98.0; workspace is edition 2024):

```
cargo test -p ralph-cli -p ralph-adapters -p ralph-telegram -p ralph-core -p ralph-proto
```

New / updated tests all green:

- `autoloop_robot::relays_pending_ask_response_and_guidance_through_control_cli_once`
- `autoloop_robot::restart_interrupts_a_pending_ask_from_ralph_dir_without_waiting`
- `autoloop_robot::current_events_guard_points_at_dedicated_human_events_and_restores`
- `autoloop_engine::requested_termination_markers_override_reason_and_are_consumed`
- `autoloop_runner::control_args_preserve_each_payload_as_one_argument`
- `telegram::wait_for_response_honors_caller_position_for_preexisting_response`
- `config::test_robot_enabled_does_not_warn_that_autoloop_hitl_is_inactive`

Full package counts from the same gate: ralph-adapters 347 passed; ralph-telegram suite green; ralph-core suite green; ralph-cli bin **379 passed, 1 failed**.

The one ralph-cli failure is **pre-existing on `integration/v3-prerelease`**, reproduced there without this branch:

`tests::test_auto_preflight_skip_list_can_omit_hooks_check_failures` (`skipped.passed` is false in this environment; not caused by the HITL bridge).

```
cargo fmt --all -- --check          # clean
cargo clippy -p ralph-cli -p ralph-adapters -p ralph-telegram -p ralph-core -p ralph-proto --all-targets --no-deps -- -D warnings  # clean
```

## Human gate

Draft until review/merge onto `integration/v3-prerelease`. Do not merge from this agent.

## Still human-gated / out of scope

- TUI answering (display-only; answers go through Telegram/Web RObot)
- #344 direct `autoloop resume` (still the documented escape hatch)
- #347 backend mapping — already on the spine via `autoloop_backend_spec`; do not land #363
- Merge of this PR onto `integration/v3-prerelease`
- Closing superseded drafts #361 / #362 / #363
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e72e6a96-086c-4fe2-bdc6-dda45eac74c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e72e6a96-086c-4fe2-bdc6-dda45eac74c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

