### PR TITLE
fix(telegram): wire /stop and /restart; skip stale HITL guidance

### DIFF
--- a/crates/ralph-cli/src/autoloop_robot.rs
+++ b/crates/ralph-cli/src/autoloop_robot.rs
@@ -155,7 +155,9 @@ fn run_bridge_inner(
     let human_events = CurrentEventsGuard::human_events_path(workspace);
     let ralph_dir = workspace.join(".ralph");
     let mut autoloop_pos = 0;
-    let mut human_pos = 0;
+    let mut human_pos = fs::metadata(&human_events)
+        .map(|meta| meta.len())
+        .unwrap_or(0);
     let mut run_id: Option<String> = None;
     let mut pending_guidance = Vec::new();
     let mut handled_questions = std::collections::HashSet::new();
@@ -584,6 +586,77 @@ mod tests {
             1
         );
         assert!(!log.contains("control respond"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ignores_guidance_written_before_the_bridge_starts() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        fs::create_dir_all(workspace.join(".ralph")).unwrap();
+        let events_path = workspace.join(".ralph/autoloop-events.ndjson");
+        let human_events = CurrentEventsGuard::human_events_path(workspace);
+        let (fake_bin, control_log) = fake_control_bin(workspace);
+        fs::write(
+            &human_events,
+            concat!(
+                r#"{"topic":"human.guidance","payload":"stale leftover"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        fs::write(
+            &events_path,
+            concat!(
+                r#"{"type":"iteration.start","runId":"run-9","iteration":1}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let runner = AutoloopRunner::new(workspace, "prompt", workspace)
+            .bin(ralph_adapters::AutoloopBin::Explicit(fake_bin))
+            .env("CONTROL_LOG", control_log.to_string_lossy().into_owned());
+        let robot: Box<dyn RobotService> = Box::new(FakeRobot {
+            state: Arc::new(FakeState::default()),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        });
+        let done = Arc::new(AtomicBool::new(false));
+
+        let bridge_done = done.clone();
+        let bridge_events = events_path;
+        let bridge_workspace = workspace.to_path_buf();
+        let bridge = std::thread::spawn(move || {
+            run_bridge(robot, runner, bridge_events, bridge_workspace, bridge_done).unwrap();
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        let mut human = fs::OpenOptions::new()
+            .append(true)
+            .open(&human_events)
+            .unwrap();
+        writeln!(
+            human,
+            r#"{{"topic":"human.guidance","payload":"fresh this run"}}"#
+        )
+        .unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if fs::read_to_string(&control_log)
+                .unwrap_or_default()
+                .contains("control guide run-9 fresh this run")
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        done.store(true, Ordering::Release);
+        bridge.join().unwrap();
+
+        let log = fs::read_to_string(&control_log).unwrap_or_default();
+        assert!(!log.contains("stale leftover"));
+        assert_eq!(log.matches("control guide run-9 fresh this run").count(), 1);
     }
 
     #[test]

--- a/crates/ralph-telegram/README.md
+++ b/crates/ralph-telegram/README.md
@@ -65,8 +65,8 @@ Available commands while the standalone daemon is running:
 - `/tail` — last 20 retained events
 - `/model` — current backend/model (runtime or config fallback)
 - `/models` — configured model options found in `ralph*.yml`
-- `/restart` — reports that restart is unsupported under the autoloop engine
-- `/stop` — reports that stop is unsupported under the autoloop engine
+- `/restart` — write `.ralph/restart-requested` when a loop is running
+- `/stop` — write `.ralph/stop-requested` when a loop is running
 - `/help` — list available commands
 
 ## Reserved Relay Design (Not Current v3 Behavior)

--- a/crates/ralph-telegram/src/commands.rs
+++ b/crates/ralph-telegram/src/commands.rs
@@ -70,8 +70,8 @@ fn cmd_help() -> String {
         "/tail — Last 20 events",
         "/model — Show current backend/model",
         "/models — Show configured model options",
-        "/restart — Unsupported under the autoloop engine",
-        "/stop — Unsupported under the autoloop engine",
+        "/restart — Request a loop restart",
+        "/stop — Request a loop stop",
         "/help — This message",
     ]
     .join("\n")
@@ -604,16 +604,39 @@ fn cmd_memories(workspace_root: &Path) -> String {
     lines.join("\n")
 }
 
-/// `/restart` — Report that loop restart is unavailable under autoloop.
-fn cmd_restart(_workspace_root: &Path) -> String {
-    "Restart is NOT supported under the autoloop engine (pending engine restart support). No restart was requested."
-        .to_string()
+fn request_loop_control(workspace_root: &Path, marker_name: &str, action: &str) -> String {
+    match lock_state(workspace_root) {
+        Ok(LockState::Active) => {
+            let ralph_dir = workspace_root.join(".ralph");
+            if let Err(error) = std::fs::create_dir_all(&ralph_dir) {
+                return format!(
+                    "Failed to request {action}: {}",
+                    escape_html(&error.to_string())
+                );
+            }
+            let marker = ralph_dir.join(marker_name);
+            if let Err(error) = std::fs::write(&marker, "") {
+                return format!(
+                    "Failed to request {action}: {}",
+                    escape_html(&error.to_string())
+                );
+            }
+            format!("{action} requested.")
+        }
+        Ok(_) => format!("No running loop. No {action} was requested."),
+        Err(error) => format!(
+            "Failed to inspect loop lock: {}",
+            escape_html(&error.to_string())
+        ),
+    }
 }
 
-/// `/stop` — Report that loop stop is unavailable under autoloop.
-fn cmd_stop(_workspace_root: &Path) -> String {
-    "Stop is NOT supported under the autoloop engine (pending engine stop support). No stop was requested."
-        .to_string()
+fn cmd_restart(workspace_root: &Path) -> String {
+    request_loop_control(workspace_root, "restart-requested", "Restart")
+}
+
+fn cmd_stop(workspace_root: &Path) -> String {
+    request_loop_control(workspace_root, "stop-requested", "Stop")
 }
 
 /// `/tail` — Last 20 lines of the current events file.
@@ -969,42 +992,31 @@ mod tests {
     }
 
     #[test]
-    fn cmd_restart_is_unsupported_without_active_loop() {
+    fn cmd_restart_is_a_noop_without_a_running_loop() {
         let dir = TempDir::new().unwrap();
         setup_workspace(&dir);
 
         let result = cmd_restart(dir.path());
 
-        assert_eq!(
-            result,
-            "Restart is NOT supported under the autoloop engine (pending engine restart support). No restart was requested."
-        );
+        assert_eq!(result, "No running loop. No Restart was requested.");
         assert!(!dir.path().join(".ralph/restart-requested").exists());
     }
 
     #[test]
-    fn cmd_stop_is_unsupported_without_active_loop() {
+    fn cmd_stop_is_a_noop_without_a_running_loop() {
         let dir = TempDir::new().unwrap();
         setup_workspace(&dir);
 
         let result = cmd_stop(dir.path());
 
-        assert_eq!(
-            result,
-            "Stop is NOT supported under the autoloop engine (pending engine stop support). No stop was requested."
-        );
+        assert_eq!(result, "No running loop. No Stop was requested.");
         assert!(!dir.path().join(".ralph/stop-requested").exists());
     }
 
     #[cfg(unix)]
-    #[test]
-    fn cmd_restart_reports_unsupported_without_writing_signal_file() {
+    fn hold_active_loop_lock(dir: &TempDir) -> nix::fcntl::Flock<std::fs::File> {
         use nix::fcntl::{Flock, FlockArg};
 
-        let dir = TempDir::new().unwrap();
-        setup_workspace(&dir);
-
-        // Create lock file to simulate active loop
         let lock = serde_json::json!({
             "pid": 12345,
             "started": "2026-01-30T10:00:00Z",
@@ -1012,52 +1024,36 @@ mod tests {
         });
         let lock_path = dir.path().join(".ralph/loop.lock");
         std::fs::write(&lock_path, serde_json::to_string(&lock).unwrap()).unwrap();
-
         let file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
             .open(&lock_path)
             .unwrap();
-        let _flock = Flock::lock(file, FlockArg::LockExclusiveNonblock).unwrap();
-
-        let result = cmd_restart(dir.path());
-        assert_eq!(
-            result,
-            "Restart is NOT supported under the autoloop engine (pending engine restart support). No restart was requested."
-        );
-        assert!(!dir.path().join(".ralph/restart-requested").exists());
+        Flock::lock(file, FlockArg::LockExclusiveNonblock).unwrap()
     }
 
     #[cfg(unix)]
     #[test]
-    fn cmd_stop_reports_unsupported_without_writing_signal_file() {
-        use nix::fcntl::{Flock, FlockArg};
-
+    fn cmd_restart_writes_restart_marker_for_an_active_loop() {
         let dir = TempDir::new().unwrap();
         setup_workspace(&dir);
+        let _flock = hold_active_loop_lock(&dir);
 
-        // Create lock file to simulate active loop
-        let lock = serde_json::json!({
-            "pid": 12345,
-            "started": "2026-01-30T10:00:00Z",
-            "prompt": "Test prompt"
-        });
-        let lock_path = dir.path().join(".ralph/loop.lock");
-        std::fs::write(&lock_path, serde_json::to_string(&lock).unwrap()).unwrap();
+        let result = cmd_restart(dir.path());
+        assert_eq!(result, "Restart requested.");
+        assert!(dir.path().join(".ralph/restart-requested").exists());
+    }
 
-        let file = std::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(&lock_path)
-            .unwrap();
-        let _flock = Flock::lock(file, FlockArg::LockExclusiveNonblock).unwrap();
+    #[cfg(unix)]
+    #[test]
+    fn cmd_stop_writes_stop_marker_for_an_active_loop() {
+        let dir = TempDir::new().unwrap();
+        setup_workspace(&dir);
+        let _flock = hold_active_loop_lock(&dir);
 
         let result = cmd_stop(dir.path());
-        assert_eq!(
-            result,
-            "Stop is NOT supported under the autoloop engine (pending engine stop support). No stop was requested."
-        );
-        assert!(!dir.path().join(".ralph/stop-requested").exists());
+        assert_eq!(result, "Stop requested.");
+        assert!(dir.path().join(".ralph/stop-requested").exists());
     }
 
     #[test]
@@ -1075,15 +1071,15 @@ mod tests {
     }
 
     #[test]
-    fn cmd_help_marks_restart_unsupported() {
+    fn cmd_help_lists_restart() {
         let result = cmd_help();
-        assert!(result.contains("/restart — Unsupported under the autoloop engine"));
+        assert!(result.contains("/restart — Request a loop restart"));
     }
 
     #[test]
-    fn cmd_help_marks_stop_unsupported() {
+    fn cmd_help_lists_stop() {
         let result = cmd_help();
-        assert!(result.contains("/stop — Unsupported under the autoloop engine"));
+        assert!(result.contains("/stop — Request a loop stop"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the independent FAIL on https://github.com/mikeyobrien/ralph-orchestrator/pull/366.

## What

`/stop` and `/restart` write `.ralph/stop-requested` and `.ralph/restart-requested` when a loop lock is active. The Autoloop HITL bridge already interrupts on those markers. With no running loop, the commands stay a no-op and write nothing.

The bridge starts reading `.ralph/human-events.jsonl` at EOF so `human.guidance` from a prior run is not sent again.

## Proof

```
cargo test -p ralph-telegram --lib commands
# 34 passed

cargo test -p ralph-cli autoloop_robot
# 4 passed, including ignores_guidance_written_before_the_bridge_starts

cargo fmt --all -- --check
cargo clippy -p ralph-telegram -p ralph-cli --all-targets --no-deps -- -D warnings
```

## Not in this PR

I wrote this diff, so I am not an independent verifier for merge. #343 and #344 stay open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c92dbb8-6efc-4c9f-958e-ae5c02ac5a16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c92dbb8-6efc-4c9f-958e-ae5c02ac5a16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

