### PR TITLE
feat(cli): restore ralph run --rpc and native ralph resume (#343 #344)

### DIFF
--- a/crates/ralph-adapters/src/autoloop_runner.rs
+++ b/crates/ralph-adapters/src/autoloop_runner.rs
@@ -111,6 +111,8 @@ pub struct AutoloopRunner {
     /// left off for headless so the child stays in ralph's foreground group and
     /// receives terminal SIGINT normally.
     own_process_group: bool,
+    /// When set, invoke `autoloop resume <run_id>` instead of `autoloop run`.
+    resume_run_id: Option<String>,
 }
 
 impl AutoloopRunner {
@@ -133,7 +135,14 @@ impl AutoloopRunner {
             events_path: None,
             env: Vec::new(),
             own_process_group: false,
+            resume_run_id: None,
         }
+    }
+
+    /// Continue a persisted Autoloop run instead of starting a new one.
+    pub fn resume(mut self, run_id: impl Into<String>) -> Self {
+        self.resume_run_id = Some(run_id.into());
+        self
     }
 
     /// Spawn the child as the leader of a new process group (Unix only), so its
@@ -197,12 +206,24 @@ impl AutoloopRunner {
 
     /// Assembles the full argv (excluding the program itself).
     ///
-    /// Layout: `[<node bin>?] run <preset> [-b <backend>] [--set kv]... [--events path] <prompt>`.
+    /// Fresh runs: `[<node bin>?] run <preset> [-b <backend>] [--set kv]... [--events path] <prompt>`.
+    /// Resume: `[<node bin>?] resume <run_id> [--events path]`.
     ///
-    /// The positional prompt must remain last because autoloop parses it as a
-    /// variadic argument; options placed after it can be consumed as prompt text.
+    /// The positional prompt must remain last on `run` because autoloop parses
+    /// it as a variadic argument; options placed after it can be consumed as
+    /// prompt text.
     fn build_args(&self) -> Vec<String> {
         let (_program, mut args) = self.program_and_prefix();
+        if let Some(run_id) = &self.resume_run_id {
+            args.push("resume".to_string());
+            args.push(run_id.clone());
+            if let Some(events) = &self.events_path {
+                args.push("--events".to_string());
+                args.push(events.to_string_lossy().into_owned());
+            }
+            return args;
+        }
+
         args.push("run".to_string());
         args.push(self.preset_dir.to_string_lossy().into_owned());
 
@@ -296,10 +317,15 @@ impl AutoloopRunner {
     /// Arguments are deliberately omitted because they can contain prompts,
     /// credentials, arbitrary overrides, and physical filesystem paths.
     fn command_display(&self) -> String {
+        let action = if self.resume_run_id.is_some() {
+            "resume"
+        } else {
+            "run"
+        };
         match &self.bin {
-            AutoloopBin::PathLookup => "autoloop (PATH lookup): run".to_string(),
-            AutoloopBin::Node(_) => "Node-hosted autoloop: run".to_string(),
-            AutoloopBin::Explicit(_) => "configured autoloop executable: run".to_string(),
+            AutoloopBin::PathLookup => format!("autoloop (PATH lookup): {action}"),
+            AutoloopBin::Node(_) => format!("Node-hosted autoloop: {action}"),
+            AutoloopBin::Explicit(_) => format!("configured autoloop executable: {action}"),
         }
     }
 
@@ -692,6 +718,19 @@ journal: /j
         assert_eq!(program, "node");
         let args = runner.build_args();
         assert_eq!(args, vec!["/checkout/bin/autoloop", "run", "/p", "x"]);
+    }
+
+    #[test]
+    fn resume_args_are_run_id_and_events_without_a_prompt() {
+        let runner = AutoloopRunner::new("/presets/autocode", "unused prompt", "/work")
+            .events_path("/tmp/events.jsonl")
+            .resume("run-abc123");
+
+        assert_eq!(
+            runner.build_args(),
+            vec!["resume", "run-abc123", "--events", "/tmp/events.jsonl",]
+        );
+        assert!(runner.command_display().contains("resume"));
     }
 
     fn assert_no_sensitive_markers(rendered: &str) {

--- a/crates/ralph-cli/src/autoloop_engine.rs
+++ b/crates/ralph-cli/src/autoloop_engine.rs
@@ -20,10 +20,12 @@ use ralph_core::{
     EventLoopConfig, LoopContext, RalphConfig, RunStats, TaskStore, TerminationReason,
     engine_state::{
         engine_config_overrides, engine_env, engine_journal_path, engine_memory_path,
-        prepare_engine_state_root,
+        persist_current_run_id, prepare_engine_state_root, read_current_run_id,
     },
     sanitize_tui_inline_text,
 };
+
+use crate::rpc_events::RpcEventMapper;
 
 use crate::completion_coord::{coordinate_completion, mark_merge_run_started};
 use crate::display::Palette;
@@ -290,6 +292,15 @@ fn resolve_autoloop_prompt(workspace: &Path, event_loop: &EventLoopConfig) -> Re
     std::fs::read_to_string(&path).context("reading prompt file from the configured workspace")
 }
 
+/// How Ralph observes and continues an Autoloop engine process.
+pub struct AutoloopLaunch {
+    pub continue_mode: bool,
+    pub native_resume: bool,
+    pub use_colors: bool,
+    pub tui: bool,
+    pub rpc: bool,
+}
+
 /// Drive the configured autoloop preset as ralph's engine, returning the mapped
 /// [`TerminationReason`].
 ///
@@ -304,9 +315,7 @@ pub async fn run_autoloop_engine(
     context: Option<LoopContext>,
     auto_merge_override: Option<bool>,
     loop_id: Option<String>,
-    continue_mode: bool,
-    use_colors: bool,
-    tui: bool,
+    launch: AutoloopLaunch,
 ) -> Result<TerminationReason> {
     let workspace = config.core.workspace_root.clone();
     let engine_state_root =
@@ -314,7 +323,8 @@ pub async fn run_autoloop_engine(
     let identity_context = context
         .clone()
         .unwrap_or_else(|| LoopContext::primary(workspace.clone()));
-    let loop_id = prepare_loop_identity(&identity_context, continue_mode, loop_id.as_deref())?;
+    let loop_id =
+        prepare_loop_identity(&identity_context, launch.continue_mode, loop_id.as_deref())?;
 
     if let Ok(merge_loop_id) = std::env::var("RALPH_MERGE_LOOP_ID") {
         let repo_root = context
@@ -372,7 +382,11 @@ pub async fn run_autoloop_engine(
             .collect()
     };
 
-    let prompt = resolve_autoloop_prompt(&workspace, &config.event_loop)?;
+    let prompt = if launch.native_resume {
+        String::new()
+    } else {
+        resolve_autoloop_prompt(&workspace, &config.event_loop)?
+    };
 
     // Structured event sink beneath the owned engine root — the preferred
     // observability channel. The root was prepared before any run state.
@@ -389,6 +403,16 @@ pub async fn run_autoloop_engine(
     let mut runner = AutoloopRunner::new(preset, prompt.clone(), workspace.clone())
         .bin(autoloop_bin)
         .events_path(events_path.clone());
+    if launch.native_resume {
+        let run_id = read_current_run_id(&engine_state_root)
+            .context("reading the persisted Autoloop run_id")?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Ralph has no persisted Autoloop run_id. Start a loop with `ralph run` before `ralph resume`."
+                )
+            })?;
+        runner = runner.resume(run_id);
+    }
     for (key, value) in engine_env(&engine_state_root) {
         runner = runner.env(key, value);
     }
@@ -402,7 +426,7 @@ pub async fn run_autoloop_engine(
     }
 
     let mut current_events_guard = None;
-    let robot_service = if tui {
+    let robot_service = if launch.tui {
         None
     } else if let Some(loop_context) = context.as_ref()
         && config.robot.enabled
@@ -422,7 +446,21 @@ pub async fn run_autoloop_engine(
     };
 
     let start = Instant::now();
-    let outcome = if tui {
+    let outcome = if launch.rpc {
+        match run_autoloop_rpc(
+            runner,
+            events_path.clone(),
+            prompt.clone(),
+            config.cli.backend.clone(),
+            config.event_loop.max_iterations,
+            role_display_names,
+        )
+        .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => AutoloopOutcome::Failed(error.context("autoloop RPC run failed")),
+        }
+    } else if launch.tui {
         // In-process TUI: render the autoloop run live by tailing its --events
         // file, concurrent with the subprocess. Resolves Ctrl+C by killing the
         // child (see run_autoloop_with_tui).
@@ -445,7 +483,7 @@ pub async fn run_autoloop_engine(
             workspace.clone(),
             service,
             role_display_names,
-            use_colors,
+            launch.use_colors,
         )
         .await
         {
@@ -456,8 +494,13 @@ pub async fn run_autoloop_engine(
         // Headless observes the same structured engine event stream as the TUI.
         // Keep the blocking child wait off the async runtime while a sibling
         // task tails and flushes live progress to stdout.
-        match run_autoloop_headless(runner, events_path.clone(), role_display_names, use_colors)
-            .await
+        match run_autoloop_headless(
+            runner,
+            events_path.clone(),
+            role_display_names,
+            launch.use_colors,
+        )
+        .await
         {
             Ok(outcome) => outcome,
             Err(error) => AutoloopOutcome::Failed(error.context("autoloop headless run failed")),
@@ -534,6 +577,8 @@ pub async fn run_autoloop_engine(
         }
     };
 
+    persist_run_id_from_outcome(&engine_state_root, &events_path);
+
     let auto_merge = auto_merge_override.unwrap_or(config.features.auto_merge);
 
     coordinate_completion(
@@ -544,7 +589,8 @@ pub async fn run_autoloop_engine(
         &prompt,
         auto_merge,
         &loop_id,
-        use_colors,
+        launch.use_colors,
+        !launch.rpc,
     );
 
     match failure {
@@ -785,6 +831,100 @@ async fn run_autoloop_headless(
     reader_handle
         .await
         .context("headless autoloop event reader task failed")?;
+
+    Ok(interpret_autoloop_result(summary, false))
+}
+
+fn persist_run_id_from_outcome(engine_state_root: &Path, events_path: &Path) {
+    if let Some(run_id) = read_events(events_path)
+        .iter()
+        .rev()
+        .find_map(|event| event.run_id.clone())
+    {
+        let _ = persist_current_run_id(engine_state_root, &run_id);
+    }
+}
+
+/// Headless Autoloop run that serializes the same `--events` file as `RpcEvent` JSON lines.
+async fn run_autoloop_rpc(
+    runner: AutoloopRunner,
+    events_path: PathBuf,
+    prompt: String,
+    backend: String,
+    max_iterations: Option<u32>,
+    role_display_names: HashMap<String, String>,
+) -> Result<AutoloopOutcome> {
+    use ralph_proto::json_rpc::emit_event_line;
+    use tokio::sync::watch;
+
+    let child = runner.spawn().context("spawning the autoloop subprocess")?;
+    let (terminated_tx, mut terminated_rx) = watch::channel(false);
+
+    let reader_handle = tokio::spawn(async move {
+        let mut tailer = AutoloopEventTailer::new(events_path);
+        let mut mapper = RpcEventMapper::new(prompt, backend, max_iterations, role_display_names);
+        let mut ticker = tokio::time::interval(std::time::Duration::from_millis(100));
+
+        let emit = |event: ralph_proto::json_rpc::RpcEvent| {
+            print!("{}", emit_event_line(&event));
+            let _ = std::io::stdout().flush();
+        };
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = terminated_rx.changed() => {
+                    if *terminated_rx.borrow() {
+                        break;
+                    }
+                }
+                _ = ticker.tick() => {
+                    match tailer.poll() {
+                        Ok(events) => {
+                            for event in &events {
+                                for rpc_event in mapper.map(event) {
+                                    emit(rpc_event);
+                                }
+                            }
+                        }
+                        Err(error) => {
+                            tracing::debug!(%error, "RPC autoloop event reader poll failed");
+                        }
+                    }
+                }
+            }
+        }
+
+        match tailer.poll() {
+            Ok(events) => {
+                for event in &events {
+                    for rpc_event in mapper.map(event) {
+                        emit(rpc_event);
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::debug!(%error, "RPC autoloop event reader final drain failed");
+            }
+        }
+    });
+
+    let wait_handle = tokio::spawn(async move {
+        let summary = tokio::task::spawn_blocking(move || {
+            runner.wait_with_summary_streaming_stderr(child, trace_engine_diagnostic)
+        })
+        .await
+        .context("autoloop wait task panicked")
+        .and_then(|summary| summary.context("autoloop run failed"));
+        let _ = terminated_tx.send(true);
+        summary
+    });
+
+    let summary = wait_handle.await.context("autoloop wait join failed")?;
+    reader_handle
+        .await
+        .context("RPC autoloop event reader task failed")?;
 
     Ok(interpret_autoloop_result(summary, false))
 }
@@ -1192,9 +1332,13 @@ pub async fn start_loop(
             Some(loop_context.clone()),
             None,
             None,
-            false,
-            false,
-            false,
+            AutoloopLaunch {
+                continue_mode: false,
+                native_resume: false,
+                use_colors: false,
+                tui: false,
+                rpc: false,
+            },
         )
         .await?;
         if reason == TerminationReason::RestartRequested {

--- a/crates/ralph-cli/src/completion_coord.rs
+++ b/crates/ralph-cli/src/completion_coord.rs
@@ -65,6 +65,7 @@ pub fn coordinate_completion(
     auto_merge: bool,
     loop_id: &str,
     use_colors: bool,
+    print_banner: bool,
 ) {
     let repo_root = context
         .map(|c| c.repo_root().to_path_buf())
@@ -158,8 +159,10 @@ pub fn coordinate_completion(
         }
     }
 
-    // 7. Console termination banner.
-    print_termination(reason, state, use_colors, Some(loop_id));
+    // 7. Console termination banner. RPC mode keeps stdout as `RpcEvent` lines.
+    if print_banner {
+        print_termination(reason, state, use_colors, Some(loop_id));
+    }
 }
 
 #[cfg(test)]
@@ -192,6 +195,7 @@ mod tests {
             false,
             "test-loop",
             false,
+            true,
         );
     }
 

--- a/crates/ralph-cli/src/main.rs
+++ b/crates/ralph-cli/src/main.rs
@@ -38,6 +38,7 @@ mod memory;
 mod merge_processing;
 mod preflight;
 mod presets;
+mod rpc_events;
 mod skill_cli;
 mod sop_runner;
 mod task_cli;
@@ -545,9 +546,8 @@ enum Commands {
     /// Interactive walkthrough of hats, hat collections, and workflow
     Tutorial(TutorialArgs),
 
-    /// Direct loop resume is not yet supported; use `ralph run --continue`.
-    #[command(hide = true)]
-    Resume,
+    /// Resume the last Autoloop run without redoing completed work.
+    Resume(ResumeArgs),
 
     /// View event history for debugging
     Events(EventsArgs),
@@ -621,6 +621,18 @@ struct InitArgs {
     force: bool,
 }
 
+/// Arguments for `ralph resume`.
+#[derive(Parser, Debug)]
+struct ResumeArgs {
+    /// Skip preflight checks before resume.
+    #[arg(long)]
+    skip_preflight: bool,
+
+    /// Disable TUI observation mode (TUI is enabled by default on a tty).
+    #[arg(long)]
+    no_tui: bool,
+}
+
 /// Arguments for the run subcommand.
 #[derive(Parser, Debug)]
 struct RunArgs {
@@ -691,6 +703,14 @@ struct RunArgs {
     /// Overrides features.preflight.enabled from config.
     #[arg(long)]
     skip_preflight: bool,
+
+    /// Emit Ralph `RpcEvent` JSON lines on stdout from the Autoloop `--events` stream.
+    #[arg(long)]
+    rpc: bool,
+
+    /// Invoke `autoloop resume` for the persisted run_id instead of `autoloop run`.
+    #[arg(skip)]
+    native_resume: bool,
 
     // ─────────────────────────────────────────────────────────────────────────
     // Verbosity Options
@@ -909,6 +929,7 @@ async fn main() -> Result<()> {
         eprintln!("No interactive terminal detected; using headless mode.");
     }
     let mcp_enabled = matches!(&cli.command, Some(Commands::Mcp(_)));
+    let rpc_enabled = matches!(&cli.command, Some(Commands::Run(args)) if args.rpc);
 
     // Initialize logging - suppress in TUI mode to avoid corrupting the display
     let filter = if cli.verbose { "debug" } else { "info" };
@@ -959,8 +980,8 @@ async fn main() -> Result<()> {
             }
         }
         // If log file creation fails, silently continue without logging
-    } else if mcp_enabled {
-        // MCP mode: logs must go to stderr to keep stdout clean for protocol messages
+    } else if mcp_enabled || rpc_enabled {
+        // MCP and --rpc keep stdout as the machine protocol.
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_writer(std::io::stderr)
@@ -1057,7 +1078,16 @@ async fn main() -> Result<()> {
             .await
         }
         Some(Commands::Tutorial(args)) => tutorial_command(cli.color, args),
-        Some(Commands::Resume) => resume_command(),
+        Some(Commands::Resume(args)) => {
+            resume_command(
+                &config_sources,
+                hats_source.as_ref(),
+                cli.verbose,
+                cli.color,
+                args,
+            )
+            .await
+        }
         Some(Commands::Events(args)) => events_command(cli.color, args),
         Some(Commands::Init(args)) => init_command(cli.color, args),
         Some(Commands::Clean(args)) => clean_command(&config_sources, cli.color, args),
@@ -1111,6 +1141,8 @@ async fn main() -> Result<()> {
                 exclusive: false,
                 no_auto_merge: false,
                 skip_preflight: false,
+                rpc: false,
+                native_resume: false,
                 verbose: false,
             };
             run_command(
@@ -1323,7 +1355,7 @@ async fn run_command(
     color_mode: ColorMode,
     args: RunArgs,
 ) -> Result<()> {
-    let wants_tui = !args.no_tui && !args.autonomous && has_interactive_terminal();
+    let wants_tui = !args.rpc && !args.no_tui && !args.autonomous && has_interactive_terminal();
     let mut config = preflight::load_config_for_preflight(config_sources, hats_source).await?;
 
     // Apply CLI overrides (after normalization so they take final precedence)
@@ -1673,9 +1705,13 @@ async fn run_command(
         Some(loop_context),
         auto_merge_override,
         args.loop_id.clone(),
-        args.continue_mode,
-        color_mode.should_use_colors(),
-        wants_tui,
+        autoloop_engine::AutoloopLaunch {
+            continue_mode: args.continue_mode,
+            native_resume: args.native_resume,
+            use_colors: color_mode.should_use_colors(),
+            tui: wants_tui,
+            rpc: args.rpc,
+        },
     )
     .await?;
 
@@ -1728,10 +1764,19 @@ fn clear_restart_request_signal(workspace_root: &std::path::Path) {
     let _ = std::fs::remove_file(&restart_path);
 }
 
-fn resume_command() -> Result<()> {
-    anyhow::bail!(
-        "direct loop resume is not yet supported (tracked #344); use `ralph run --continue` to continue Ralph coordination state. Advanced escape hatch: `autoloop resume <run-id>` resumes the engine directly"
-    )
+async fn resume_command(
+    config_sources: &[ConfigSource],
+    hats_source: Option<&HatsSource>,
+    verbose: bool,
+    color_mode: ColorMode,
+    args: ResumeArgs,
+) -> Result<()> {
+    let mut run_args = RunArgs::try_parse_from(["run", "--continue"]).expect("resume run args");
+    run_args.continue_mode = true;
+    run_args.native_resume = true;
+    run_args.skip_preflight = args.skip_preflight;
+    run_args.no_tui = args.no_tui;
+    run_command(config_sources, hats_source, verbose, color_mode, run_args).await
 }
 
 fn init_command(color_mode: ColorMode, args: InitArgs) -> Result<()> {
@@ -2562,7 +2607,6 @@ mod tests {
     #[test]
     fn test_r8_removed_run_flags_are_rejected() {
         let removed_arguments = [
-            vec!["--rpc"],
             vec!["--record-session", "session.jsonl"],
             vec!["-q"],
             vec!["--quiet"],
@@ -2588,7 +2632,6 @@ mod tests {
             vec!["--quiet"],
             vec!["--idle-timeout", "30"],
             vec!["--max-iterations", "2"],
-            vec!["--no-tui"],
             vec!["--autonomous"],
             vec!["-a"],
         ];
@@ -2617,6 +2660,18 @@ mod tests {
             panic!("expected run command");
         };
         assert!(args.autonomous);
+
+        let cli = Cli::try_parse_from(["ralph", "run", "--rpc", "--no-tui"])
+            .expect("rpc flag must parse");
+        let Some(Commands::Run(args)) = cli.command else {
+            panic!("expected run command");
+        };
+        assert!(args.rpc);
+        assert!(args.no_tui);
+
+        let cli = Cli::try_parse_from(["ralph", "resume", "--skip-preflight", "--no-tui"])
+            .expect("resume flags must parse");
+        assert!(matches!(cli.command, Some(Commands::Resume(_))));
     }
 
     #[test]
@@ -3408,6 +3463,8 @@ core:
             exclusive: false,
             no_auto_merge: false,
             skip_preflight: true,
+            rpc: false,
+            native_resume: false,
             verbose: false,
         }
     }

--- a/crates/ralph-cli/src/rpc_events.rs
+++ b/crates/ralph-cli/src/rpc_events.rs
@@ -1,0 +1,332 @@
+//! Map Autoloop `--events` records onto Ralph's existing [`RpcEvent`] contract.
+//!
+//! This is the #343 restore path. The structured plane stays Autoloop's
+//! `events.ndjson`. RPC mode only changes the stdout serialization.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ralph_adapters::AutoloopEvent;
+use ralph_proto::json_rpc::{RpcEvent, TerminationReason};
+
+/// Stateful translator from one Autoloop `--events` stream onto `RpcEvent`s.
+pub struct RpcEventMapper {
+    prompt: String,
+    backend: String,
+    max_iterations: Option<u32>,
+    started_at: u64,
+    role_display_names: HashMap<String, String>,
+    announced_role: Option<(u32, String)>,
+    current_iteration: Option<u32>,
+    iteration_started_at: Option<u64>,
+    loop_started: bool,
+    last_cost_usd: f64,
+}
+
+impl RpcEventMapper {
+    /// Creates a mapper for one Ralph `--rpc` run.
+    pub fn new(
+        prompt: impl Into<String>,
+        backend: impl Into<String>,
+        max_iterations: Option<u32>,
+        role_display_names: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            prompt: prompt.into(),
+            backend: backend.into(),
+            max_iterations,
+            started_at: unix_ms(),
+            role_display_names,
+            announced_role: None,
+            current_iteration: None,
+            iteration_started_at: None,
+            loop_started: false,
+            last_cost_usd: 0.0,
+        }
+    }
+
+    /// Maps one Autoloop event into zero or more `RpcEvent`s.
+    pub fn map(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        match event.kind.as_str() {
+            "loop.start" => vec![self.ensure_loop_started()],
+            "iteration.banner" => {
+                self.observe_banner(event);
+                Vec::new()
+            }
+            "iteration.start" => self.map_iteration_start(event),
+            "progress" => self.map_progress(event),
+            "backend.output" => self.map_backend_output(event),
+            "ask.pending" => self.map_ask(event),
+            "loop.finish" | "summary" => self.map_terminal(event),
+            "log" => self.map_log(event),
+            _ => Vec::new(),
+        }
+    }
+
+    fn ensure_loop_started(&mut self) -> RpcEvent {
+        self.loop_started = true;
+        RpcEvent::LoopStarted {
+            prompt: self.prompt.clone(),
+            max_iterations: self.max_iterations,
+            backend: self.backend.clone(),
+            workspace_root: None,
+            started_at: self.started_at,
+        }
+    }
+
+    fn observe_banner(&mut self, event: &AutoloopEvent) {
+        if let (Some(iteration), Some(role_id)) = (
+            event.iteration,
+            event.allowed_roles.as_ref().and_then(|roles| roles.first()),
+        ) {
+            self.announced_role = Some((iteration, self.role_display(role_id)));
+        }
+        if let Some(max) = event.max_iterations {
+            self.max_iterations = Some(max);
+        }
+    }
+
+    fn map_iteration_start(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        let mut out = Vec::new();
+        if !self.loop_started {
+            out.push(self.ensure_loop_started());
+        }
+        let iteration = event.iteration.unwrap_or(0);
+        if let Some(max) = event.max_iterations {
+            self.max_iterations = Some(max);
+        }
+        self.current_iteration = Some(iteration);
+        self.iteration_started_at = Some(unix_ms());
+        let hat = self.role_id_for(iteration);
+        let hat_display = self.role_display(&hat);
+        out.push(RpcEvent::IterationStart {
+            iteration,
+            max_iterations: self.max_iterations,
+            hat,
+            hat_display,
+            backend: self.backend.clone(),
+            started_at: self.iteration_started_at.unwrap_or(self.started_at),
+        });
+        out
+    }
+
+    fn map_progress(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        let iteration = event.iteration.or(self.current_iteration).unwrap_or(0);
+        if let Some(cost) = event.cost_usd {
+            self.last_cost_usd = cost;
+        }
+        let duration_ms = self
+            .iteration_started_at
+            .map(|started| unix_ms().saturating_sub(started))
+            .unwrap_or(0);
+        let loop_complete_triggered = event
+            .outcome
+            .as_deref()
+            .is_some_and(|outcome| outcome.starts_with("complete"));
+        let mut out = vec![RpcEvent::IterationEnd {
+            iteration,
+            duration_ms,
+            cost_usd: event.cost_usd.unwrap_or(0.0),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_write_tokens: 0,
+            context_window: 0,
+            context_tokens: 0,
+            loop_complete_triggered,
+        }];
+        if let Some(topic) = event.emitted_topic.as_deref() {
+            out.push(RpcEvent::OrchestrationEvent {
+                topic: topic.to_string(),
+                payload: event.outcome.clone().unwrap_or_default(),
+                source: self.announced_role.as_ref().map(|(_, name)| name.clone()),
+                target: None,
+            });
+        }
+        out
+    }
+
+    fn map_backend_output(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        let Some(output) = event.output.as_deref() else {
+            return Vec::new();
+        };
+        if output.is_empty() {
+            return Vec::new();
+        }
+        vec![RpcEvent::TextDelta {
+            iteration: event.iteration.or(self.current_iteration).unwrap_or(0),
+            delta: output.to_string(),
+        }]
+    }
+
+    fn map_ask(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        vec![RpcEvent::OrchestrationEvent {
+            topic: "human.ask".to_string(),
+            payload: event.question.clone().unwrap_or_default(),
+            source: None,
+            target: None,
+        }]
+    }
+
+    fn map_terminal(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        let mut out = Vec::new();
+        if !self.loop_started {
+            out.push(self.ensure_loop_started());
+        }
+        if let Some(cost) = event.cost_usd {
+            self.last_cost_usd = cost;
+        }
+        out.push(RpcEvent::LoopTerminated {
+            reason: map_rpc_stop_reason(event.stop_reason.as_deref()),
+            total_iterations: event.iterations.or(self.current_iteration).unwrap_or(0),
+            duration_ms: unix_ms().saturating_sub(self.started_at),
+            total_cost_usd: self.last_cost_usd,
+            terminated_at: unix_ms(),
+        });
+        out
+    }
+
+    fn map_log(&mut self, event: &AutoloopEvent) -> Vec<RpcEvent> {
+        if !matches!(event.level.as_deref(), Some("error" | "ERROR")) {
+            return Vec::new();
+        }
+        vec![RpcEvent::Error {
+            iteration: event.iteration.or(self.current_iteration).unwrap_or(0),
+            code: "ENGINE_LOG".to_string(),
+            message: event.message.clone().unwrap_or_default(),
+            recoverable: true,
+        }]
+    }
+
+    fn role_id_for(&self, iteration: u32) -> String {
+        self.announced_role
+            .as_ref()
+            .filter(|(announced, _)| *announced == iteration)
+            .map(|(_, label)| label.clone())
+            .unwrap_or_else(|| "working".to_string())
+    }
+
+    fn role_display(&self, role_id: &str) -> String {
+        self.role_display_names
+            .get(role_id)
+            .cloned()
+            .unwrap_or_else(|| role_id.to_string())
+    }
+}
+
+fn map_rpc_stop_reason(reason: Option<&str>) -> TerminationReason {
+    match reason {
+        Some("completed" | "completion_event" | "completion_promise" | "verdict_exit") => {
+            TerminationReason::Completed
+        }
+        Some("max_iterations") => TerminationReason::MaxIterations,
+        Some("interrupted") => TerminationReason::Interrupted,
+        Some(_) => TerminationReason::Error,
+        None => TerminationReason::Error,
+    }
+}
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ralph_adapters::parse_events;
+
+    fn mapper() -> RpcEventMapper {
+        let mut names = HashMap::new();
+        names.insert("planner".to_string(), "Planning Lead".to_string());
+        names.insert("builder".to_string(), "Build Crew".to_string());
+        RpcEventMapper::new("do the work", "claude", Some(2), names)
+    }
+
+    #[test]
+    fn maps_banner_start_progress_and_finish_onto_rpc_events() {
+        let events = parse_events(concat!(
+            r#"{"type":"iteration.banner","runId":"r1","iteration":1,"maxIterations":2,"allowedRoles":["planner"]}"#,
+            "\n",
+            r#"{"type":"iteration.start","runId":"r1","iteration":1,"maxIterations":2}"#,
+            "\n",
+            r#"{"type":"progress","runId":"r1","iteration":1,"emittedTopic":"build.task","outcome":"continue:routed_event","costUsd":0.01}"#,
+            "\n",
+            r#"{"type":"loop.finish","runId":"r1","iterations":1,"stopReason":"completed","costUsd":0.01}"#,
+            "\n",
+        ));
+        let mut mapper = mapper();
+        let mapped: Vec<RpcEvent> = events.iter().flat_map(|event| mapper.map(event)).collect();
+
+        assert!(matches!(
+            &mapped[0],
+            RpcEvent::LoopStarted {
+                prompt,
+                backend,
+                max_iterations: Some(2),
+                ..
+            } if prompt == "do the work" && backend == "claude"
+        ));
+        assert!(matches!(
+            &mapped[1],
+            RpcEvent::IterationStart {
+                iteration: 1,
+                hat_display,
+                ..
+            } if hat_display == "Planning Lead"
+        ));
+        assert!(matches!(
+            &mapped[2],
+            RpcEvent::IterationEnd {
+                iteration: 1,
+                loop_complete_triggered: false,
+                ..
+            }
+        ));
+        assert!(matches!(
+            &mapped[3],
+            RpcEvent::OrchestrationEvent { topic, .. } if topic == "build.task"
+        ));
+        assert!(matches!(
+            &mapped[4],
+            RpcEvent::LoopTerminated {
+                reason: TerminationReason::Completed,
+                total_iterations: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn maps_backend_output_and_ask_without_a_second_events_plane() {
+        let events = parse_events(concat!(
+            r#"{"type":"iteration.start","runId":"r1","iteration":1}"#,
+            "\n",
+            r#"{"type":"backend.output","iteration":1,"output":"hello from the agent"}"#,
+            "\n",
+            r#"{"type":"ask.pending","runId":"r1","questionId":"q1","question":"ship it?"}"#,
+            "\n",
+        ));
+        let mut mapper = mapper();
+        let mapped: Vec<RpcEvent> = events.iter().flat_map(|event| mapper.map(event)).collect();
+        assert!(
+            mapped
+                .iter()
+                .any(|event| matches!(event, RpcEvent::TextDelta { delta, .. } if delta == "hello from the agent"))
+        );
+        assert!(mapped.iter().any(|event| matches!(
+            event,
+            RpcEvent::OrchestrationEvent { topic, payload, .. }
+                if topic == "human.ask" && payload == "ship it?"
+        )));
+    }
+
+    #[test]
+    fn unknown_autoloop_kinds_do_not_emit_rpc_events() {
+        let events = parse_events(r#"{"type":"progress.internal","runId":"r1"}"#);
+        let mut mapper = mapper();
+        assert!(mapper.map(&events[0]).is_empty());
+    }
+}

--- a/crates/ralph-cli/tests/integration_autoloop_rpc.rs
+++ b/crates/ralph-cli/tests/integration_autoloop_rpc.rs
@@ -1,0 +1,207 @@
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use ralph_core::testing::fake_autoloop::{FakeAutoloop, build_fake_autoloop};
+use ralph_proto::json_rpc::RpcEvent;
+use tempfile::TempDir;
+
+const RALPH_YML: &str = r#"
+core:
+  engine: autoloop
+cli:
+  backend: claude
+event_loop:
+  max_iterations: 2
+  completion_promise: LOOP_COMPLETE
+hats:
+  planner:
+    name: "Planning Lead"
+    description: "Plans the work"
+    triggers: ["loop.start"]
+    publishes: ["build.task"]
+    instructions: "Plan the work."
+  builder:
+    name: "Build Crew"
+    description: "Builds the work"
+    triggers: ["build.task"]
+    publishes: ["task.complete"]
+    instructions: "Build the work."
+features:
+  auto_merge: false
+  preflight:
+    enabled: true
+    skip: [config, hooks, backend, telegram, git, paths, tools]
+"#;
+
+struct Harness {
+    workspace: TempDir,
+    home: TempDir,
+    fake_autoloop: FakeAutoloop,
+    path: OsString,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let workspace = tempfile::tempdir().expect("workspace temp dir");
+        let home = tempfile::tempdir().expect("home temp dir");
+        fs::write(workspace.path().join("ralph.yml"), RALPH_YML).expect("write ralph.yml");
+        fs::write(workspace.path().join("README.md"), "rpc test\n").expect("write README");
+        run_git(workspace.path(), &["init", "--quiet"]);
+        run_git(workspace.path(), &["add", "README.md", "ralph.yml"]);
+        run_git(
+            workspace.path(),
+            &[
+                "-c",
+                "user.name=Ralph Test",
+                "-c",
+                "user.email=ralph@example.invalid",
+                "commit",
+                "--quiet",
+                "-m",
+                "initial",
+            ],
+        );
+
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/autoloop/headless_voice.jsonl");
+        let fake_autoloop = build_fake_autoloop(&workspace.path().join("fake-autoloop"), &fixture)
+            .expect("build fixture-driven fake autoloop");
+        let inherited_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut paths = vec![fake_autoloop.bin_dir().to_path_buf()];
+        paths.extend(std::env::split_paths(&inherited_path));
+        let path = std::env::join_paths(paths).expect("construct PATH");
+
+        Self {
+            workspace,
+            home,
+            fake_autoloop,
+            path,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_ralph"));
+        command
+            .current_dir(self.workspace.path())
+            .env("PATH", &self.path)
+            .env("HOME", self.home.path())
+            .env("USERPROFILE", self.home.path())
+            .env("ARGV_OUT", self.fake_autoloop.argv_out())
+            .env_remove("RALPH_CONFIG")
+            .env_remove("RALPH_WORKSPACE_ROOT")
+            .env_remove("RALPH_MERGE_LOOP_ID");
+        command
+    }
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("execute git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn rendered(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn run_rpc_emits_rpc_events_from_autoloop_events_and_persists_run_id() {
+    let harness = Harness::new();
+    let output = harness
+        .command()
+        .args([
+            "--color",
+            "never",
+            "--config",
+            "ralph.yml",
+            "run",
+            "--rpc",
+            "--skip-preflight",
+            "--max-iterations",
+            "2",
+            "-p",
+            "exercise rpc",
+        ])
+        .output()
+        .expect("run ralph --rpc");
+    let text = rendered(&output);
+    assert!(output.status.success(), "rpc run failed: {text}");
+
+    let events: Vec<RpcEvent> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line)
+                .unwrap_or_else(|error| panic!("stdout line is not an RpcEvent ({error}): {line}"))
+        })
+        .collect();
+
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RpcEvent::LoopStarted { .. })),
+        "LoopStarted missing: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RpcEvent::IterationStart {
+                hat_display,
+                ..
+            } if hat_display == "Planning Lead"
+        )),
+        "planner IterationStart missing: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            RpcEvent::OrchestrationEvent { topic, .. } if topic == "build.task"
+        )),
+        "build.task OrchestrationEvent missing: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, RpcEvent::LoopTerminated { .. })),
+        "LoopTerminated missing: {events:?}"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("Iteration 1/2 started"),
+        "headless banner leaked onto the RPC stream: {text}"
+    );
+
+    let argv = harness
+        .fake_autoloop
+        .recorded_argv()
+        .expect("recorded autoloop argv");
+    assert!(
+        argv.iter().any(|arg| arg == "--events"),
+        "RPC mode must still pass Autoloop --events: {argv:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(
+            harness
+                .workspace
+                .path()
+                .join(".ralph/autoloop/current-run-id")
+        )
+        .expect("read persisted run_id")
+        .trim(),
+        "run-headless-voice"
+    );
+}

--- a/crates/ralph-cli/tests/integration_continue_resume.rs
+++ b/crates/ralph-cli/tests/integration_continue_resume.rs
@@ -174,14 +174,21 @@ fn run_continue_without_scratchpad_completes_and_reuses_coordination_loop() {
 }
 
 #[test]
-fn resume_reports_native_engine_limitation_without_inspecting_scratchpad() {
+fn resume_without_a_persisted_run_id_fails_without_inspecting_scratchpad() {
     let harness = Harness::new();
     assert!(!harness.scratchpad.exists());
-    assert!(!harness.fake_autoloop.argv_out().exists());
 
     let output = harness
         .command()
-        .args(["--color", "never", "resume"])
+        .args([
+            "--color",
+            "never",
+            "--config",
+            "ralph.yml",
+            "resume",
+            "--no-tui",
+            "--skip-preflight",
+        ])
         .output()
         .expect("run ralph resume");
     let text = rendered(&output);
@@ -191,21 +198,86 @@ fn resume_reports_native_engine_limitation_without_inspecting_scratchpad() {
         "resume unexpectedly succeeded: {text}"
     );
     assert!(
-        text.contains(
-            "direct loop resume is not yet supported (tracked #344); use `ralph run --continue` to continue Ralph coordination state. Advanced escape hatch: `autoloop resume <run-id>` resumes the engine directly"
-        ),
-        "Ralph-first unsupported message missing: {text}"
-    );
-    assert!(
-        text.find("ralph run --continue") < text.find("autoloop resume <run-id>"),
-        "Ralph recovery command must precede the advanced engine escape hatch: {text}"
+        text.contains("Ralph has no persisted Autoloop run_id"),
+        "missing persisted run_id error: {text}"
     );
     assert!(
         !text.contains("scratchpad not found"),
         "resume reported obsolete scratchpad error: {text}"
     );
+}
+
+#[test]
+fn resume_invokes_autoloop_resume_for_the_persisted_run_id() {
+    let harness = Harness::new();
+
+    let first = harness
+        .command()
+        .args([
+            "--color",
+            "never",
+            "--config",
+            "ralph.yml",
+            "run",
+            "--continue",
+            "--no-tui",
+            "--skip-preflight",
+            "--max-iterations",
+            "2",
+            "-p",
+            "seed run_id",
+        ])
+        .output()
+        .expect("seed ralph run");
+    let first_text = rendered(&first);
+    assert!(first.status.success(), "seed run failed: {first_text}");
+    assert_eq!(
+        fs::read_to_string(
+            harness
+                .workspace
+                .path()
+                .join(".ralph/autoloop/current-run-id")
+        )
+        .expect("read persisted run_id")
+        .trim(),
+        "run-headless-voice"
+    );
+
+    let output = harness
+        .command()
+        .args([
+            "--color",
+            "never",
+            "--config",
+            "ralph.yml",
+            "resume",
+            "--no-tui",
+            "--skip-preflight",
+        ])
+        .output()
+        .expect("run ralph resume");
+    let text = rendered(&output);
+    assert!(output.status.success(), "resume failed: {text}");
+
+    let argv = harness
+        .fake_autoloop
+        .recorded_argv()
+        .expect("recorded autoloop argv");
+    assert_eq!(
+        argv.first().map(String::as_str),
+        Some("resume"),
+        "native resume must invoke autoloop resume: {argv:?}"
+    );
     assert!(
-        !harness.fake_autoloop.argv_out().exists(),
-        "resume must not launch or provision autoloop"
+        argv.iter().any(|arg| arg == "run-headless-voice"),
+        "resume argv missing persisted run_id: {argv:?}"
+    );
+    assert!(
+        argv.iter().any(|arg| arg == "--events"),
+        "resume must keep the Autoloop --events plane: {argv:?}"
+    );
+    assert!(
+        !argv.iter().any(|arg| arg == "run"),
+        "resume must not start a fresh autoloop run: {argv:?}"
     );
 }

--- a/crates/ralph-core/src/engine_state.rs
+++ b/crates/ralph-core/src/engine_state.rs
@@ -161,6 +161,38 @@ pub fn engine_memory_path(engine_root: &Path) -> PathBuf {
     engine_root.join("memory.jsonl")
 }
 
+/// Path of the last Autoloop `run_id` Ralph persisted for `ralph resume`.
+pub fn current_run_id_path(engine_root: &Path) -> PathBuf {
+    engine_root.join("current-run-id")
+}
+
+/// Persist a safe Autoloop `run_id` for a later native resume.
+pub fn persist_current_run_id(engine_root: &Path, run_id: &str) -> io::Result<()> {
+    if engine_run_dir(engine_root, run_id).is_none() {
+        return Err(safe_state_error(
+            io::ErrorKind::InvalidInput,
+            "Autoloop run_id is not safe to persist",
+        ));
+    }
+    fs::write(current_run_id_path(engine_root), format!("{run_id}\n"))
+}
+
+/// Read the persisted Autoloop `run_id`, if Ralph has completed a run here.
+pub fn read_current_run_id(engine_root: &Path) -> io::Result<Option<String>> {
+    match fs::read_to_string(current_run_id_path(engine_root)) {
+        Ok(contents) => {
+            let run_id = contents.trim();
+            if run_id.is_empty() || engine_run_dir(engine_root, run_id).is_none() {
+                Ok(None)
+            } else {
+                Ok(Some(run_id.to_string()))
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
 fn engine_tasks_path(engine_root: &Path) -> PathBuf {
     engine_root.join("tasks.jsonl")
 }
@@ -249,6 +281,16 @@ mod tests {
                 "run ID should be rejected: {run_id:?}"
             );
         }
+    }
+
+    #[test]
+    fn persist_current_run_id_rejects_unsafe_ids_and_round_trips_safe_ones() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        assert!(persist_current_run_id(root, "../escape").is_err());
+        persist_current_run_id(root, "run-9").unwrap();
+        assert_eq!(read_current_run_id(root).unwrap().as_deref(), Some("run-9"));
+        assert_eq!(current_run_id_path(root), root.join("current-run-id"));
     }
 
     #[test]

--- a/docs/migration/v3-autoloop-engine.md
+++ b/docs/migration/v3-autoloop-engine.md
@@ -28,7 +28,7 @@ runtime state: Ralph launches autoloop with a Ralph-owned state root at
 | v2 | v3 |
 |----|----|
 | `ralph wave …` (wave system) | Removed. Use hat `concurrency:`/`aggregate:` — they map to autoloop's declarative per-role concurrency. `presets/wave-review.yml` is ported. |
-| `ralph run --rpc` (JSON-lines protocol) | Removed (tracked as #343). |
+| `ralph run --rpc` (JSON-lines protocol) | Restored. Autoloop `--events` is mapped onto the existing `RpcEvent` contract on stdout. |
 | `ralph run --record-session` (smoke fixtures) | Removed. Replay tests use the fake-autoloop fixture substrate (`tests/fixtures/autoloop/`). |
 | `core.engine` config field | Autoloop is the only engine. `autoloop` remains valid; any other value is rejected because the in-house engine was removed in v3. Remove the field or set it to `autoloop`. |
 | Telegram RObot HITL during runs | Wired on the primary loop: Autoloop `ask.pending` is relayed through Telegram/Web; answers and `human.guidance` use `autoloop control`. TUI still displays asks only. |
@@ -58,6 +58,8 @@ runtime state: Ralph launches autoloop with a Ralph-owned state root at
 ## Observability
 
 - TUI and headless runs both render the engine's `--events` stream live.
+- `ralph run --rpc` emits the same `--events` stream as Ralph `RpcEvent` JSON lines.
+- `ralph resume` persists Autoloop `run_id` under `.ralph/autoloop/current-run-id` and invokes `autoloop resume <run_id>`.
 - Engine state: the run journal is at `.ralph/autoloop/journal.jsonl`, with
   run-scoped state under `.ralph/autoloop/runs/`.
 - Ralph's coordination stores remain separate under `.ralph/agent/`, and its


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The v3 leftover-caller cutover deleted `rpc_stdin` and left `ralph resume` as an escape hatch. Those two product gaps were parked as #343 and #344. The owner asked to finish them on `integration/v3-prerelease`.

The cutover spec keeps Autoloop `--events` as the structured plane. This PR maps that stream onto the existing `RpcEvent` contract and persists Autoloop `run_id` so native resume can call `autoloop resume <run_id>`.

## Scope

- `crates/ralph-cli/src/rpc_events.rs` maps Autoloop `--events` kinds onto `RpcEvent` (`LoopStarted`, `IterationStart`/`End`, `TextDelta`, `OrchestrationEvent`, `LoopTerminated`).
- `ralph run --rpc` tails the same `.ralph/autoloop/events.ndjson` file. Tracing goes to stderr so stdout stays JSON lines. The termination banner is suppressed in RPC mode.
- `ralph resume` is a real command again. It reads `.ralph/autoloop/current-run-id` and invokes `autoloop resume <run_id> --events …`.
- `AutoloopRunner::resume` builds resume argv without a prompt. Unsafe run IDs are rejected by `persist_current_run_id`.

Out of scope: replacing `RpcEvent`, stdin command restoration beyond what the event map needs, #343/#344 product extras such as waves, `v3-ga-readiness.spec.md` (still missing).

## Tradeoffs

- `RpcEvent` stays. The spec did not ask to replace the contract.
- Resume reuses `ralph run --continue` coordination (loop identity) and swaps only the engine invocation to `autoloop resume`.
- One PR for both units because they share `autoloop_engine.rs` and `main.rs`.

## Blast Radius

- CLI users of `ralph run --rpc` and `ralph resume`.
- Subprocess TUI (`Tui::spawn`) can talk to `--rpc` again for events.
- Headless and TUI paths are unchanged except run_id persist after every engine run.

## Verification

```
cargo test -p ralph-cli --bin ralph rpc_events
# 3 passed

cargo test -p ralph-cli --test integration_autoloop_rpc
# 1 passed

cargo test -p ralph-cli --test integration_continue_resume
# 3 passed

cargo test -p ralph-core --lib engine_state
cargo test -p ralph-adapters --lib resume_args
cargo fmt --all -- --check
cargo clippy -p ralph-core -p ralph-adapters -p ralph-cli --all-targets --no-deps -- -D warnings
```

Writer is this session (Grok). Independent verify must come from a different model family before merge. No GitHub auto-merge. No force-push of the spine.

`.ralph/specs/v3-ga-readiness.spec.md` is still missing. The cutover spec says these two close the remaining descoped product units from slice 8. GA signoff stays gated on that missing spec.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c92dbb8-6efc-4c9f-958e-ae5c02ac5a16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c92dbb8-6efc-4c9f-958e-ae5c02ac5a16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

