### PR TITLE
Fix #369: completion promise on final iteration takes priority over MaxIterations

### DIFF
--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -2064,8 +2064,6 @@ impl EventLoop {
             self.state.consecutive_failures += 1;
         }
 
-        let _ = output;
-
         // File-modification audit: detect when a hat with disallowed Edit/Write tools
         // modified files. This is hard enforcement — emits a scope_violation event.
         self.audit_file_modifications(hat_id);
@@ -2073,6 +2071,20 @@ impl EventLoop {
         // Events are ONLY read from the JSONL file written by `ralph emit`.
         // This enforces tool use and prevents confabulation (agent claiming to emit without actually doing so).
         // See process_events_from_jsonl() for event processing.
+
+        // Completion takes priority over MaxIterations at the boundary iteration:
+        // if the iteration that just finished emitted the configured completion promise,
+        // surface that as the termination reason before checking iteration limits. This
+        // mirrors the text-fallback path in loop_runner so completion is detected even
+        // when the final allowed iteration produces the promise. See issue #369.
+        if EventParser::contains_promise(output, &self.config.event_loop.completion_promise) {
+            self.request_completion_from_text_fallback();
+            if let Some(reason) = self.check_completion_event() {
+                return Some(reason);
+            }
+            // Completion was rejected (persistent mode, missing required events, etc.).
+            // Fall through to check_termination() below to enforce budget limits.
+        }
 
         // Check termination conditions
         self.check_termination()

--- a/crates/ralph-core/src/event_loop/tests.rs
+++ b/crates/ralph-core/src/event_loop/tests.rs
@@ -298,6 +298,67 @@ event_loop:
 }
 
 #[test]
+fn test_completion_promise_on_final_iteration_takes_priority_over_max_iterations() {
+    // Per issue #369: when the final allowed iteration outputs the completion promise,
+    // the loop should terminate with CompletionPromise, not MaxIterations.
+    let yaml = r"
+event_loop:
+  max_iterations: 1
+  completion_promise: LOOP_COMPLETE
+";
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+
+    let hat_id = HatId::new("builder");
+    let reason = event_loop.process_output(&hat_id, "LOOP_COMPLETE\n", true);
+
+    assert_eq!(
+        reason,
+        Some(TerminationReason::CompletionPromise),
+        "Completion promise on the final iteration must take priority over MaxIterations"
+    );
+}
+
+#[test]
+fn test_completion_promise_under_max_iterations_still_terminates() {
+    // Sanity check: completion promise on an iteration below the limit still terminates.
+    let yaml = r"
+event_loop:
+  max_iterations: 5
+  completion_promise: LOOP_COMPLETE
+";
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+
+    let hat_id = HatId::new("builder");
+    let reason = event_loop.process_output(&hat_id, "All done.\nLOOP_COMPLETE", true);
+
+    assert_eq!(reason, Some(TerminationReason::CompletionPromise));
+}
+
+#[test]
+fn test_max_iterations_still_fires_when_completion_absent_on_final_iteration() {
+    // Regression guard: when the final iteration produces NO completion promise,
+    // MaxIterations should still fire.
+    let yaml = r"
+event_loop:
+  max_iterations: 2
+  completion_promise: LOOP_COMPLETE
+";
+    let config: RalphConfig = serde_yaml::from_str(yaml).unwrap();
+    let mut event_loop = EventLoop::new(config);
+    event_loop.initialize("Test");
+
+    let hat_id = HatId::new("builder");
+    event_loop.process_output(&hat_id, "iteration 1 output", true);
+    let reason = event_loop.process_output(&hat_id, "iteration 2 output, no promise", true);
+
+    assert_eq!(reason, Some(TerminationReason::MaxIterations));
+}
+
+#[test]
 fn test_persisted_loop_state_round_trips_iteration_cost_and_last_hat() {
     use tempfile::TempDir;
 
@@ -661,27 +722,19 @@ fn test_completion_promise_requires_last_event() {
 }
 
 #[test]
-fn test_builder_cannot_terminate_loop() {
-    // Per spec: completion requires an emitted event; output-only tokens are ignored
+fn test_text_completion_promise_triggers_termination_from_any_hat() {
+    // Completion promise in output text should terminate the loop, regardless of hat.
+    // Mirrors the text-fallback path used by `loop_runner` so completion works on the
+    // final allowed iteration (see issue #369). Note: `RalphConfig::default()` has
+    // max_iterations > 1, so the iteration limit does not mask the completion signal.
     let config = RalphConfig::default();
     let mut event_loop = EventLoop::new(config);
     event_loop.initialize("Test");
 
-    // Builder output containing completion promise - should be IGNORED
     let hat_id = HatId::new("builder");
     let reason = event_loop.process_output(&hat_id, "Done!\nLOOP_COMPLETE", true);
 
-    // Builder cannot terminate, so no termination reason
-    assert_eq!(reason, None);
-
-    // Completion event should still terminate
-    let temp_dir = tempfile::tempdir().unwrap();
-    let events_path = temp_dir.path().join("events.jsonl");
-    event_loop.event_reader = crate::event_reader::EventReader::new(&events_path);
-    write_event_to_jsonl(&events_path, "LOOP_COMPLETE", "Done");
-    let _ = event_loop.process_events_from_jsonl();
-    let completion = event_loop.check_completion_event();
-    assert_eq!(completion, Some(TerminationReason::CompletionPromise));
+    assert_eq!(reason, Some(TerminationReason::CompletionPromise));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

When the configured `completion_promise` (e.g. `LOOP_COMPLETE`) appears in the output of the final allowed iteration, `EventLoop::process_output()` previously returned `MaxIterations` instead of `CompletionPromise`. The text-fallback path in `loop_runner` that detects text-based completion was unreachable in this case because `process_output()` short-circuited on the iteration-limit check before the fallback could run.

Fixes #369.

## Root cause

In `crates/ralph-core/src/event_loop/mod.rs`, `process_output()`:

1. Increments `self.state.iteration`
2. Calls `self.check_termination()` at the end
3. `check_termination()` returns `MaxIterations` when `iteration >= max_iterations`
4. The caller in `crates/ralph-cli/src/loop_runner.rs` (the `loop_runner::run_loop_impl` body around line 2020) sees `termination = Some(MaxIterations)` and exits with that reason before reaching the text-fallback block at line ~2619

The result: a `LOOP_COMPLETE` produced on the final allowed iteration is masked by `MaxIterations`, the loop exits with status 2 instead of status 0.

## Fix

Detect the completion promise in output text inside `process_output()` and run `check_completion_event()` before `check_termination()`. If completion is accepted, surface it as the termination reason. If completion is rejected (persistent mode, missing required events, open tasks, etc.), fall through to `check_termination()` so budget limits still apply. This mirrors the existing text-fallback logic in `loop_runner` so the boundary iteration behaves consistently with iterations below the limit.

The fix is small (10 lines) and is contained to one function. It reuses the existing `request_completion_from_text_fallback` and `check_completion_event` helpers, which apply all the same safety checks as the JSONL event path.

## Tests

Three new tests in `crates/ralph-core/src/event_loop/tests.rs`:

- `test_completion_promise_on_final_iteration_takes_priority_over_max_iterations` — reproduces the bug at `max_iterations: 1` and asserts `CompletionPromise` is returned.
- `test_completion_promise_under_max_iterations_still_terminates` — sanity check that completion still works below the limit.
- `test_max_iterations_still_fires_when_completion_absent_on_final_iteration` — regression guard that `MaxIterations` still fires when the final iteration produces no completion promise.

Also updates `test_builder_cannot_terminate_loop` (renamed to `test_text_completion_promise_triggers_termination_from_any_hat`). The previous assertion — that `process_output()` ignores text-only completion promises — is exactly the behavior the bug report identifies as wrong. The text-fallback path intentionally accepts completion from any hat; the previous test was a unit-level artifact, not a real production constraint (the live `loop_runner` does not filter by hat either).

All `event_loop` tests pass:

```
test result: ok. 165 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy -p ralph-core --lib --no-deps` both pass clean.

## Reproduction (from the issue)

```bash
ralph run --autonomous --max-iterations 1   -p "Do not use any tools. Your entire response MUST be exactly: LOOP_COMPLETE"
```

Before the fix: exits with status 2 (`Maximum iterations reached`).
After the fix: exits with status 0 (`Completion promise detected`).
