### PR TITLE
fix(cli): preserve post-event handoff success

### DIFF
--- a/crates/ralph-adapters/src/cli_executor.rs
+++ b/crates/ralph-adapters/src/cli_executor.rs
@@ -35,6 +35,9 @@ pub struct ExecutionResult {
     pub exit_code: Option<i32>,
     /// Whether the execution was terminated due to timeout.
     pub timed_out: bool,
+    /// Whether the post-event grace deadline caused the executor to terminate
+    /// the process instead of the normal inactivity timeout.
+    pub post_event_grace_expired: bool,
     /// Parsed assistant text for Pi-family NDJSON backends (the processor owns
     /// extraction; the mandatory final-text fallback is already applied). `None`
     /// for backends that keep using raw/normalized output (Claude stream-json,
@@ -137,6 +140,7 @@ impl CliExecutor {
         }
 
         let mut timed_out = false;
+        let mut post_event_grace_expired = false;
         let mut post_event_deadline: Option<tokio::time::Instant> = None;
         let mut terminated_status = None;
 
@@ -189,14 +193,19 @@ impl CliExecutor {
 
         while !stdout_done || !stderr_done {
             let now = tokio::time::Instant::now();
-            let effective_timeout = match (timeout, post_event_deadline) {
-                (_, Some(deadline)) if deadline <= now => Some(Duration::ZERO),
+            let (effective_timeout, timeout_is_post_event) = match (timeout, post_event_deadline) {
+                (_, Some(deadline)) if deadline <= now => (Some(Duration::ZERO), true),
                 (Some(duration), Some(deadline)) => {
-                    Some(duration.min(deadline.saturating_duration_since(now)))
+                    let post_event_remaining = deadline.saturating_duration_since(now);
+                    if post_event_remaining <= duration {
+                        (Some(post_event_remaining), true)
+                    } else {
+                        (Some(duration), false)
+                    }
                 }
-                (None, Some(deadline)) => Some(deadline.saturating_duration_since(now)),
-                (Some(duration), None) => Some(duration),
-                (None, None) => None,
+                (None, Some(deadline)) => (Some(deadline.saturating_duration_since(now)), true),
+                (Some(duration), None) => (Some(duration), false),
+                (None, None) => (None, false),
             };
 
             let next_event = match effective_timeout {
@@ -208,6 +217,7 @@ impl CliExecutor {
                             "Execution inactivity timeout reached, sending SIGTERM"
                         );
                         timed_out = true;
+                        post_event_grace_expired = timeout_is_post_event;
                         terminated_status = Some(Self::terminate_child_and_wait(&mut child).await?);
                         break;
                     }
@@ -320,6 +330,7 @@ impl CliExecutor {
             success,
             exit_code: status.code(),
             timed_out,
+            post_event_grace_expired,
             extracted_text,
             session_result,
             protocol_error,
@@ -588,6 +599,10 @@ mod tests {
 
         assert!(result.timed_out, "Expected execution to time out");
         assert!(
+            !result.post_event_grace_expired,
+            "Normal inactivity timeout must not be classified as post-event grace expiry"
+        );
+        assert!(
             !result.success,
             "Timed out execution should not be successful"
         );
@@ -707,10 +722,41 @@ mod tests {
             "Expected lingering post-event process to be terminated"
         );
         assert!(
+            result.post_event_grace_expired,
+            "Expected termination to be attributed to the post-event grace deadline"
+        );
+        assert!(
             started.elapsed() < Duration::from_secs(10),
             "Event-emitting backends should use the short post-event grace timeout instead of the full inactivity timeout"
         );
         assert!(result.output.contains("Event emitted: task.done"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_short_inactivity_timeout_wins_over_post_event_grace() {
+        let backend = CliBackend {
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "printf 'Event emitted: task.done\\n'; sleep 10".to_string(),
+            ],
+            prompt_mode: PromptMode::Stdin,
+            prompt_flag: None,
+            output_format: OutputFormat::Text,
+            env_vars: vec![],
+        };
+
+        let executor = CliExecutor::new(backend);
+        let result = executor
+            .execute_capture_with_timeout("", Some(Duration::from_millis(100)))
+            .await
+            .unwrap();
+
+        assert!(result.timed_out);
+        assert!(
+            !result.post_event_grace_expired,
+            "The shorter inactivity timeout must win over the post-event grace deadline"
+        );
     }
 
     #[tokio::test]
@@ -738,6 +784,10 @@ mod tests {
         assert!(
             result.timed_out,
             "Expected noisy post-event process to be terminated"
+        );
+        assert!(
+            result.post_event_grace_expired,
+            "Expected the fixed post-event grace deadline to terminate the noisy process"
         );
         assert!(
             started.elapsed() < Duration::from_secs(10),

--- a/crates/ralph-cli/src/loop_runner.rs
+++ b/crates/ralph-cli/src/loop_runner.rs
@@ -48,6 +48,8 @@ use crate::{ColorMode, Verbosity};
 pub(crate) struct ExecutionOutcome {
     pub output: String,
     pub success: bool,
+    /// Whether a text CLI backend was terminated by the post-event grace deadline.
+    pub post_event_grace_expired: bool,
     pub termination: Option<TerminationReason>,
     pub total_cost_usd: f64,
     pub input_tokens: u64,
@@ -1817,6 +1819,7 @@ pub async fn run_loop_impl(
                 Ok(ExecutionOutcome {
                     output,
                     success: result.success,
+                    post_event_grace_expired: result.post_event_grace_expired,
                     termination: None,
                     total_cost_usd: metrics.as_ref().map_or(0.0, |m| m.total_cost_usd),
                     input_tokens: metrics.as_ref().map_or(0, |m| m.input_tokens),
@@ -1952,6 +1955,7 @@ pub async fn run_loop_impl(
 
         let output = outcome.output;
         let success = outcome.success;
+        let post_event_grace_expired = outcome.post_event_grace_expired;
 
         // Note: TUI lines are now written directly to IterationBuffer during streaming,
         // so no post-execution transfer is needed.
@@ -2018,6 +2022,19 @@ pub async fn run_loop_impl(
         // max_cost applies across iterations and across --continue resumes.
         event_loop.add_cost(outcome.total_cost_usd);
         let termination = event_loop.process_output(&hat_id, &output, success);
+
+        // A text backend terminated by the post-event grace deadline may have
+        // completed its semantic handoff successfully even though the process
+        // itself was force-terminated. If that apparent failure trips the
+        // consecutive-failure limit, defer only that termination until the
+        // durable JSONL event has been validated below.
+        let defer_consecutive_failures =
+            post_event_grace_expired && termination == Some(TerminationReason::ConsecutiveFailures);
+        let termination = if defer_consecutive_failures {
+            None
+        } else {
+            termination
+        };
         if let Err(e) = event_loop.save_loop_state(&loop_state_path) {
             warn!("Failed to persist loop state: {}", e);
         }
@@ -2284,6 +2301,20 @@ pub async fn run_loop_impl(
                     (None, Vec::new())
                 }
             };
+
+        // Only durable events that survived JSONL processing can turn a
+        // post-event grace termination into a successful iteration. The
+        // textual `Event emitted:` marker alone is intentionally insufficient.
+        let accepted_wave_event =
+            ralph_core::detect_wave_events(&wave_events, event_loop.registry()).is_some();
+        let accepted_jsonl_event = processed_events
+            .as_ref()
+            .is_some_and(|events| events.had_events)
+            || accepted_wave_event;
+
+        if post_event_grace_expired && accepted_jsonl_event {
+            event_loop.reconcile_iteration_success();
+        }
 
         if let Some(human_interact_context) = processed_events
             .as_ref()
@@ -4285,6 +4316,7 @@ async fn execute_acp(
     Ok(ExecutionOutcome {
         output,
         success: pty_result.success,
+        post_event_grace_expired: false,
         termination: None,
         total_cost_usd: pty_result.total_cost_usd,
         input_tokens: pty_result.input_tokens,
@@ -4441,6 +4473,7 @@ async fn execute_pty(
             Ok(ExecutionOutcome {
                 output: output_for_parsing,
                 success: pty_result.success,
+                post_event_grace_expired: false,
                 termination,
                 total_cost_usd: pty_result.total_cost_usd,
                 input_tokens: pty_result.input_tokens,

--- a/crates/ralph-cli/tests/integration_run.rs
+++ b/crates/ralph-cli/tests/integration_run.rs
@@ -577,3 +577,169 @@ fn test_run_continue_requires_scratchpad() {
         "stderr: {stderr}"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn test_run_post_event_handoff_does_not_count_as_consecutive_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let temp_path = temp_dir.path();
+    let backend_script = temp_path.join("post-event-handoff.sh");
+    let counter_path = temp_path.join("handoff-count");
+
+    std::fs::write(
+        &backend_script,
+        format!(
+            "#!/bin/sh\nset -eu\ncat >/dev/null\ncounter_file=\"{}\"\ncount=0\nif [ -f \"$counter_file\" ]; then\n  count=$(cat \"$counter_file\")\nfi\ncount=$((count + 1))\nprintf '%s\\n' \"$count\" > \"$counter_file\"\ncase \"$count\" in\n  1)\n    \"{}\" emit \"handoff.$count\" \"step-$count\"\n    sleep 30\n    ;;\n  *)\n    printf 'LOOP_COMPLETE\\n'\n    ;;\nesac\n",
+            counter_path.display(),
+            env!("CARGO_BIN_EXE_ralph")
+        ),
+    )
+    .expect("write backend script");
+
+    let mut permissions = std::fs::metadata(&backend_script)
+        .expect("metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&backend_script, permissions).expect("set executable permissions");
+
+    std::fs::write(
+        temp_path.join("ralph.yml"),
+        r#"
+cli:
+  backend: custom
+  command: "./post-event-handoff.sh"
+  prompt_mode: stdin
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 3
+  max_runtime_seconds: 60
+  max_consecutive_failures: 1
+adapters:
+  custom:
+    timeout: 30
+"#,
+    )
+    .expect("write config");
+
+    let output = run_ralph(
+        temp_path,
+        &[
+            "run",
+            "--autonomous",
+            "--skip-preflight",
+            "--prompt",
+            "exercise a post-event handoff",
+        ],
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let handoff_count = std::fs::read_to_string(&counter_path).expect("read handoff counter");
+
+    assert_eq!(
+        handoff_count.trim(),
+        "2",
+        "a valid post-event handoff must not trip the consecutive-failure circuit breaker.\n\
+         stdout:\n{stdout}\n\
+         stderr:\n{stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "loop should complete successfully after the handoff.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_run_post_event_text_without_jsonl_still_counts_as_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let temp_path = temp_dir.path();
+    let backend_script = temp_path.join("fake-post-event-handoff.sh");
+    let counter_path = temp_path.join("fake-handoff-count");
+
+    std::fs::write(
+        &backend_script,
+        format!(
+            "#!/bin/sh\n\
+             set -eu\n\
+             cat >/dev/null\n\
+             counter_file=\"{}\"\n\
+             count=0\n\
+             if [ -f \"$counter_file\" ]; then\n\
+               count=$(cat \"$counter_file\")\n\
+             fi\n\
+             count=$((count + 1))\n\
+             printf '%s\n' \"$count\" > \"$counter_file\"\n\
+             case \"$count\" in\n\
+               1)\n\
+                 printf 'Event emitted: fake.%s\n' \"$count\"\n\
+                 sleep 30\n\
+                 ;;\n\
+               *)\n\
+                 printf 'LOOP_COMPLETE\n'\n\
+                 ;;\n\
+             esac\n",
+            counter_path.display(),
+        ),
+    )
+    .expect("write backend script");
+
+    let mut permissions = std::fs::metadata(&backend_script)
+        .expect("metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&backend_script, permissions).expect("set executable permissions");
+
+    std::fs::write(
+        temp_path.join("ralph.yml"),
+        r#"
+cli:
+  backend: custom
+  command: "./fake-post-event-handoff.sh"
+  prompt_mode: stdin
+event_loop:
+  completion_promise: "LOOP_COMPLETE"
+  max_iterations: 3
+  max_runtime_seconds: 60
+  max_consecutive_failures: 1
+adapters:
+  custom:
+    timeout: 30
+"#,
+    )
+    .expect("write config");
+
+    let output = run_ralph(
+        temp_path,
+        &[
+            "run",
+            "--autonomous",
+            "--skip-preflight",
+            "--prompt",
+            "exercise fake post-event handoffs",
+        ],
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let handoff_count = std::fs::read_to_string(&counter_path).expect("read handoff counter");
+
+    assert_eq!(
+        handoff_count.trim(),
+        "1",
+        "text that merely claims an event was emitted must not bypass failure accounting.\n\
+         stdout:\n{stdout}\n\
+         stderr:\n{stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a fake post-event handoff should still trip consecutive_failures.\n\
+         stdout:\n{stdout}\n\
+         stderr:\n{stderr}"
+    );
+}

--- a/crates/ralph-core/src/event_loop/mod.rs
+++ b/crates/ralph-core/src/event_loop/mod.rs
@@ -482,6 +482,15 @@ impl EventLoop {
         &self.state
     }
 
+    /// Reclassifies the current iteration as successful when durable success
+    /// evidence becomes available after `process_output`.
+    ///
+    /// Some executors can only determine transport-level failure before the
+    /// caller has had a chance to validate events written to JSONL.
+    pub fn reconcile_iteration_success(&mut self) {
+        self.state.consecutive_failures = 0;
+    }
+
     /// Record this iteration's context-token usage for `hat`.
     ///
     /// Passthrough to `LoopState::record_iteration_tokens` — preserves the


### PR DESCRIPTION
## Summary

Text CLI backends can emit a valid Ralph event and remain alive long enough to
be terminated by the post-event grace deadline.

That termination was still reported as a failed iteration, so
`consecutive_failures` could increase even though the handoff had already been
written successfully to Ralph's JSONL event stream. Repeated healthy handoffs
could eventually trip the failure circuit breaker.

This PR tracks post-event grace termination separately and reconciles the
iteration as successful only after Ralph validates a durable JSONL event.
Printing `Event emitted:` without a valid JSONL event is still treated as a
failure.

## Changes

- Track whether `CliExecutor` was terminated by the post-event grace deadline
  rather than the normal inactivity timeout.
- Defer `ConsecutiveFailures` termination for that case until JSONL processing
  completes.
- Reconcile failure accounting only when an accepted JSONL event is found.
- Accept valid wave events through the existing wave validation path.
- Leave normal inactivity timeouts and other termination reasons unchanged.

## Test Plan

Integration coverage exercises both sides of the behavior:

- A backend performs a real `ralph emit`, remains alive, and is terminated by
  the post-event grace deadline. With `max_consecutive_failures: 1`, Ralph
  continues to the next iteration and completes successfully.
- A backend only prints `Event emitted:` without writing a JSONL event. With
  `max_consecutive_failures: 1`, Ralph stops after the first failed iteration.

Executor coverage also verifies normal inactivity timeouts, post-event grace
classification, timeout precedence, and that continued output does not extend
the fixed post-event deadline.

Local verification:

```text
cargo fmt --all -- --check

cargo clippy --locked \
    -p ralph-core \
    -p ralph-adapters \
    -p ralph-cli \
    --all-targets \
    --no-deps \
    -- -D warnings

cargo test --locked \
    -p ralph-core \
    -p ralph-adapters \
    -p ralph-cli

cargo test \
    -p ralph-core \
    --features recording \
    --test smoke_runner

./scripts/ci-rust-gate.sh \
    --skip-clippy \
    --skip-embedded-files

cargo package \
    -p ralph-cli \
    --allow-dirty \
    --list
```

Results:

- affected-crate tests: pass
- affected-crate Clippy with warnings denied: pass
- smoke replay tests: 59/59 pass
- Hooks BDD: 18/18 pass
- available mock E2E scenarios: 15/15 pass
- package check: pass

## Known upstream baseline failures

Two repository-wide checks currently fail on `main` independently of this
change:

- `./scripts/sync-embedded-files.sh check` reports the OpenCode preset copies
  as out of sync around existing OrcaRouter documentation.
- Full-workspace Clippy on current stable Rust reports
  `clippy::manual-is-variant-and` in
  `crates/ralph-api/src/stream_domain/mod.rs`.

This PR does not modify either affected area.